### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: go
 go:
 - 1.3.1
+- 1.4
 - tip
 before_install:
 - cp .netrc ~


### PR DESCRIPTION
Update travis.yml to use container based architecture and go 1.4 along with tip and go 1.3.1.

*\* There seems to be an issue with go 1.3.3 running go get against golang.org, possible due to a certificate checking issue with this release.
