### PR TITLE
Consistency on use of Lock() and Unlock() in plugin_manager

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -42,8 +42,8 @@ func newLoadedPlugins() *loadedPlugins {
 // adds a loadedPlugin pointer to the loadedPlugins table
 func (l *loadedPlugins) Append(lp *loadedPlugin) error {
 
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
+	l.Lock()
+	defer l.Unlock()
 
 	// make sure we don't already  have a pointer to this plugin in the table
 	for i, pl := range *l.table {
@@ -105,9 +105,9 @@ func (l *loadedPlugins) NonblockingSplice(index int) {
 // atomic splice
 func (l *loadedPlugins) Splice(index int) {
 
-	l.mutex.Lock()
+	l.Lock()
 	l.splice(index)
-	l.mutex.Unlock()
+	l.Unlock()
 
 }
 


### PR DESCRIPTION
Append() and Splice() were still calling .mutex.Lock() and .mutex.Unlock() directly, while Get() had been updated to use the exported Lock() and Unlock() methods that call .mutex.Lock() and .mutex.Unlock() respectively. This commit brings consistency to plugin_manager.go for all methods to use Lock() and Unlock() accordingly. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intelsdilabs/pulse/46)

<!-- Reviewable:end -->
