### PR TITLE
Fixes, debugging features, and tests

### DIFF
--- a/pkg/ctree/tree.go
+++ b/pkg/ctree/tree.go
@@ -92,6 +92,8 @@ func (c *ConfigTree) Get(ns []string) Node {
 		c.log(fmt.Sprintf("adding root node (not nil) to nodes to merge (%v)\n", c.root.Node))
 		*retNodes = append(*retNodes, c.root.Node)
 	}
+
+	c.log(fmt.Sprintf("children to get from (%d)\n", len(c.root.nodes)))
 	for _, child := range c.root.nodes {
 		childNodes := child.get(remain)
 		*retNodes = append(*retNodes, *childNodes...)
@@ -101,7 +103,7 @@ func (c *ConfigTree) Get(ns []string) Node {
 	// Call Node.Merge() sequentially on the retNodes
 	rn := (*retNodes)[0]
 	for _, n := range (*retNodes)[1:] {
-		rn.Merge(n)
+		rn = rn.Merge(n)
 	}
 	return rn
 }
@@ -130,7 +132,7 @@ func (c *ConfigTree) Print() {
 }
 
 type Node interface {
-	Merge(Node)
+	Merge(Node) Node
 }
 
 type node struct {
@@ -165,9 +167,8 @@ func (n *node) add(ns []string, inNode Node) {
 			return
 		}
 	}
-	newNode := &node{
-		keys: []string{f},
-	}
+	newNode := new(node)
+	newNode.setKeys([]string{f})
 	newNode.add(remain, inNode)
 	n.nodes = append(n.nodes, newNode)
 }

--- a/pkg/ctree/tree_test.go
+++ b/pkg/ctree/tree_test.go
@@ -11,8 +11,9 @@ type dummyNode struct {
 	data string
 }
 
-func (d *dummyNode) Merge(dn Node) {
+func (d dummyNode) Merge(dn Node) Node {
 	d.data = fmt.Sprintf("%s/%s", d.data, dn.(*dummyNode).data)
+	return d
 }
 
 func newDummyNode() *dummyNode {
@@ -53,7 +54,7 @@ func TestConfigTree(t *testing.T) {
 			c.Print()
 			g := c.Get([]string{"intel", "foo", "sdilabs", "joel", "dan", "nick", "justin", "sarah"})
 			So(g, ShouldNotBeNil)
-			So(g.(*dummyNode).data, ShouldResemble, "b/a")
+			So(g.(dummyNode).data, ShouldResemble, "b/a")
 		})
 
 		Convey("single item ns", func() {
@@ -65,6 +66,21 @@ func TestConfigTree(t *testing.T) {
 			g := c.Get([]string{"1"})
 			So(g, ShouldNotBeNil)
 			So(g.(*dummyNode).data, ShouldResemble, "a")
+		})
+
+		Convey("add 2 nodes that will not change on compression", func() {
+			d1 := newDummyNode()
+			d1.data = "a"
+			d2 := newDummyNode()
+			d2.data = "b"
+			c := New()
+			c.Debug = true
+			c.Add([]string{"1"}, d1)
+			c.Add([]string{"1", "2"}, d2)
+			c.Freeze()
+			g := c.Get([]string{"1", "2"})
+			So(g, ShouldNotBeNil)
+			So(g.(dummyNode).data, ShouldResemble, "a/b")
 		})
 
 		Convey("blank tree return nil", func() {


### PR DESCRIPTION
- Fix: Adding a namespace with a single item did not add the Node into the root and did not generate the keys byte array.
- Change: Moved setting of keys to node.setkeys to make sure keys conversion to the keys byte was common.
- Change: Added a Debug flag to ConfigTree and logging for debugging behavior.
- Fix: The long namespace and short tree test was wrong. The root node should return in the response since it lies in the path of the long namespace.
- Change: Added panic for calling Get() on a non frozen tree. Test added for this case.
- Change: Exported Print() on ConfigTree
- Fix: Fixed deadlock where we should have been using defer with mutex.Unlock() inside Add() @geauxvirtual pointed this out after we merged it.
- Change: Merge() on Node interface to return the modified Node and not use a pointer. This is important as implementations of Node which forced type above cannot use a pointer to an interface.
- Fix: Nodes added that are not compressed during a Compress() would not have keys as byte array set. Changed Add() and add() to use setKeys() to fix. Added test for nodes that don't compress.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intelsdilabs/pulse/49)

<!-- Reviewable:end -->
