### PR TITLE
get rid of "unkeyed composite literal" warning from newer version of go vet tool

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -318,7 +318,7 @@ func TestSubscribeMetric(t *testing.T) {
 	c.metricCatalog = mtrc
 	cd := cdata.NewNode()
 	Convey("does not return errors when metricCatalog.Subscribe() does not return an error", t, func() {
-		cd.AddItem("key", &ctypes.ConfigValueStr{"value"})
+		cd.AddItem("key", &ctypes.ConfigValueStr{Value: "value"})
 		mtrc.e = 1
 		_, err := c.SubscribeMetric([]string{""}, -1, cd)
 		So(err, ShouldBeNil)
@@ -331,7 +331,7 @@ func TestSubscribeMetric(t *testing.T) {
 	})
 	Convey("returns errors when processing fails", t, func() {
 		cd := cdata.NewNode()
-		cd.AddItem("fail", &ctypes.ConfigValueStr{"value"})
+		cd.AddItem("fail", &ctypes.ConfigValueStr{Value: "value"})
 		mtrc.e = 1
 		_, errs := c.SubscribeMetric([]string{""}, -1, cd)
 		So(len(errs.Errors()), ShouldEqual, 1)


### PR DESCRIPTION
my vet tool (newer) distributed with source version of golang runtime 1.4, warns about wrong way of using composite literals in `control/control_test.go:321`

``` bash
~/work/go/src/github.com/intelsdilabs/pulse (master)$ go vet ./...
control/control_test.go:321: github.com/intelsdilabs/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
control/control_test.go:334: github.com/intelsdilabs/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
```

In CI environment, we using old go vet (installed manualy from travis.yml), which ignores this kinds of expression and we can't just use vet distributed with go1.3 because it is buggy 

running vet from 1.3, ends with:

```
go vet
?       github.com/ppalucki/pulse   [no test files]
?       github.com/ppalucki/pulse/cli   [no test files]
E
Errors:
  * /home/travis/gopath/src/github.com/ppalucki/pulse/control/available_plugin_test.go 
  Line 39: - runtime error: invalid memory address or nil pointer dereference 
  goroutine 21 [running]:
  runtime.panic(0x7ccd00, 0xa46a93)
...
```

Full log: https://magnum.travis-ci.com/ppalucki/pulse/jobs/14451942

So this change satisfies both: me (working with new go vet) and CI environment. I couldn't find a way, how to configure travis, to use external vet tool for go 1.3 and internal for 1.4 - which is I think the right way to do.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intelsdilabs/pulse/59)

<!-- Reviewable:end -->
