### PR TITLE
Fixes scheduler so it doesn't depend on control

### DIFF
--- a/schedule/task.go
+++ b/schedule/task.go
@@ -28,7 +28,7 @@ type Task struct {
 
 type TaskState int
 
-func NewTask(s Schedule, mtc []core.MetricType) *Task {
+func NewTask(s Schedule, mtc []core.MetricType, wf Workflow) *Task {
 	return &Task{
 		schResponseChan: make(chan ScheduleResponse),
 		killChan:        make(chan struct{}),
@@ -36,7 +36,7 @@ func NewTask(s Schedule, mtc []core.MetricType) *Task {
 		schedule:        s,
 		state:           TaskStopped,
 		creationTime:    time.Now(),
-		workflow:        NewWorkflow(),
+		workflow:        wf,
 	}
 }
 
@@ -87,7 +87,7 @@ func (t *Task) fire() {
 	defer t.mu.Unlock()
 
 	t.state = TaskFiring
-	t.workflow.Start(t, WorkManager)
+	t.workflow.Start(t)
 	t.state = TaskSpinning
 }
 

--- a/schedule/task_test.go
+++ b/schedule/task_test.go
@@ -52,17 +52,22 @@ func TestTask(t *testing.T) {
 
 		Convey("task + simple schedule", func() {
 			sch := NewSimpleSchedule(time.Millisecond * 100)
-			task := NewTask(sch, nil)
+			workManager := new(managesWork)
+			wf := NewWorkflow(workManager)
+			task := NewTask(sch, nil, wf)
 			task.Spin()
 			time.Sleep(time.Millisecond * 10) // it is a race so we slow down the test
 			So(task.state, ShouldEqual, TaskSpinning)
+			task.Stop()
 		})
 
 		Convey("Task is created and starts to spin", func() {
 			mockSchedule := &MockSchedule{
 				tick: false,
 			}
-			task := NewTask(mockSchedule, nil)
+			workManager := new(managesWork)
+			wf := NewWorkflow(workManager)
+			task := NewTask(mockSchedule, nil, wf)
 			task.Spin()
 			time.Sleep(time.Millisecond * 10) // it is a race so we slow down the test
 			So(task.state, ShouldEqual, TaskSpinning)

--- a/schedule/work_manager.go
+++ b/schedule/work_manager.go
@@ -64,6 +64,3 @@ func (w *managesWork) Work(j Job) Job {
 	}()
 	return <-respChan
 }
-
-// WorkManager
-var WorkManager *managesWork = new(managesWork)

--- a/schedule/work_manager_test.go
+++ b/schedule/work_manager_test.go
@@ -10,6 +10,7 @@ import (
 func TestWorkerManager(t *testing.T) {
 	Convey("WorkerManager", t, func() {
 		manager := new(managesWork)
+		So(manager, ShouldNotBeNil)
 		Convey("Work", func() {
 			metricTypes := []core.MetricType{
 				&MockMetricType{

--- a/schedule/workflow_test.go
+++ b/schedule/workflow_test.go
@@ -3,12 +3,16 @@ package schedule
 import (
 	"testing"
 
+	"github.com/intelsdilabs/pulse/core"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestWorkflow(t *testing.T) {
 	Convey("Workflow", t, func() {
-		wf := NewWorkflow()
+		workManager := new(managesWork)
+		wf := NewWorkflow(workManager)
+		So(wf.workManager, ShouldNotBeNil)
+		So(wf.state, ShouldNotBeNil)
 		Convey("Add steps", func() {
 			pubStep := new(publishStep)
 			procStep := new(processStep)
@@ -17,9 +21,9 @@ func TestWorkflow(t *testing.T) {
 			So(wf.rootStep.Steps(), ShouldNotBeNil)
 			Convey("Start", func() {
 				schedule := new(MockSchedule)
-				task := NewTask(schedule, nil)
-				manager := new(managesWork)
-				wf.Start(task, manager)
+				mts := make([]core.MetricType, 0)
+				task := NewTask(schedule, mts, wf)
+				wf.Start(task)
 				So(wf.State(), ShouldEqual, WorkflowStarted)
 			})
 		})


### PR DESCRIPTION
Scheduler doesn't require control for init but the MetricManager must be
before the scheduler can be started and the scheduler must be started
before a task can be created.  Lastly, the workflow is now being passed
into CreateTask instead of being created implicitly.
