### PR TITLE
Pass single eventManager instance from control to all availablePlugins

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -36,23 +36,23 @@ type availablePlugin struct {
 	id                 int
 	hitCount           int
 	lastHitTime        time.Time
-	eventManager       *gomit.EventController
+	emitter            gomit.Emitter
 	failedHealthChecks int
 	healthChan         chan error
 }
 
 // newAvailablePlugin returns an availablePlugin with information from a
 // plugin.Response
-func newAvailablePlugin(resp *plugin.Response, id int) (*availablePlugin, error) {
+func newAvailablePlugin(resp *plugin.Response, id int, emitter gomit.Emitter) (*availablePlugin, error) {
 	ap := &availablePlugin{
 		Name:    resp.Meta.Name,
 		Version: resp.Meta.Version,
 		Type:    resp.Type,
 
-		eventManager: new(gomit.EventController),
-		healthChan:   make(chan error, 1),
-		lastHitTime:  time.Now(),
-		id:           id,
+		emitter:     emitter,
+		healthChan:  make(chan error, 1),
+		lastHitTime: time.Now(),
+		id:          id,
 	}
 
 	// Create RPC Client
@@ -118,14 +118,14 @@ func (ap *availablePlugin) healthCheckFailed() {
 			Key:     ap.Key,
 			Index:   ap.Index,
 		}
-		defer ap.eventManager.Emit(pde)
+		defer ap.emitter.Emit(pde)
 	}
 	hcfe := &control_event.HealthCheckFailedEvent{
 		Name:    ap.Name,
 		Version: ap.Version,
 		Type:    int(ap.Type),
 	}
-	defer ap.eventManager.Emit(hcfe)
+	defer ap.emitter.Emit(hcfe)
 }
 
 func (a *availablePlugin) HitCount() int {

--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -22,7 +22,7 @@ func TestAvailablePlugin(t *testing.T) {
 				Type:          plugin.CollectorPluginType,
 				ListenAddress: "127.0.0.1:4000",
 			}
-			ap, err := newAvailablePlugin(resp, -1)
+			ap, err := newAvailablePlugin(resp, -1, nil)
 			So(ap, ShouldHaveSameTypeAs, new(availablePlugin))
 			So(err, ShouldBeNil)
 		})
@@ -233,7 +233,7 @@ func TestAvailablePlugins(t *testing.T) {
 				Type:          plugin.CollectorPluginType,
 				ListenAddress: "localhost:",
 			}
-			ap, err := newAvailablePlugin(resp, -1)
+			ap, err := newAvailablePlugin(resp, -1, nil)
 			So(ap, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
@@ -246,7 +246,7 @@ func TestAvailablePlugins(t *testing.T) {
 				Type:          plugin.ProcessorPluginType,
 				ListenAddress: "localhost:9999",
 			}
-			ap, err := newAvailablePlugin(resp, -1)
+			ap, err := newAvailablePlugin(resp, -1, nil)
 			So(ap, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/intelsdilabs/gomit"
 	"github.com/intelsdilabs/pulse/control/plugin"
 	"github.com/intelsdilabs/pulse/control/plugin/cpolicy"
 	"github.com/intelsdilabs/pulse/core"
@@ -33,29 +34,14 @@ type MockPluginManagerBadSwap struct {
 	ExistingPlugin CatalogedPlugin
 }
 
-func (m *MockPluginManagerBadSwap) LoadPlugin(string) (*loadedPlugin, error) {
+func (m *MockPluginManagerBadSwap) LoadPlugin(string, gomit.Emitter) (*loadedPlugin, error) {
 	return new(loadedPlugin), nil
 }
-
-func (m *MockPluginManagerBadSwap) UnloadPlugin(c CatalogedPlugin) error {
-	return errors.New("fake")
-}
-
-func (m *MockPluginManagerBadSwap) LoadedPlugins() *loadedPlugins {
-	return nil
-}
-
-func (m *MockPluginManagerBadSwap) SetMetricCatalog(catalogsMetrics) {
-
-}
-
-func (m *MockPluginManagerBadSwap) GenerateArgs() plugin.Arg {
-	return plugin.Arg{}
-}
-
-func TestControlNew(t *testing.T) {
-
-}
+func (m *MockPluginManagerBadSwap) UnloadPlugin(c CatalogedPlugin) error { return errors.New("fake") }
+func (m *MockPluginManagerBadSwap) LoadedPlugins() *loadedPlugins        { return nil }
+func (m *MockPluginManagerBadSwap) SetMetricCatalog(catalogsMetrics)     {}
+func (m *MockPluginManagerBadSwap) SetEmitter(gomit.Emitter)             {}
+func (m *MockPluginManagerBadSwap) GenerateArgs() plugin.Arg             { return plugin.Arg{} }
 
 func TestPluginControlGenerateArgs(t *testing.T) {
 	Convey("pluginControl.Start", t, func() {

--- a/control/monitor_test.go
+++ b/control/monitor_test.go
@@ -31,8 +31,7 @@ func TestMonitor(t *testing.T) {
 			Name:       "test",
 			Client:     new(MockUnhealthyPluginCollectorClient),
 			healthChan: make(chan error, 1),
-
-			eventManager: gomit.NewEventController(),
+			emitter:    gomit.NewEventController(),
 		}
 		ap1.makeKey()
 		aps.Insert(ap1)
@@ -42,8 +41,7 @@ func TestMonitor(t *testing.T) {
 			Version: 1,
 			Name:    "test",
 			Client:  &mockPluginClient{},
-
-			eventManager: &gomit.EventController{},
+			emitter: &gomit.EventController{},
 		}
 		ap2.makeKey()
 		aps.Insert(ap2)
@@ -53,8 +51,7 @@ func TestMonitor(t *testing.T) {
 			Version: 1,
 			Name:    "test",
 			Client:  &mockPluginClient{},
-
-			eventManager: &gomit.EventController{},
+			emitter: &gomit.EventController{},
 		}
 		ap3.makeKey()
 		aps.Insert(ap3)

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/intelsdilabs/gomit"
 	"github.com/intelsdilabs/pulse/control/plugin"
 	"github.com/intelsdilabs/pulse/control/plugin/client"
 	"github.com/intelsdilabs/pulse/control/plugin/cpolicy"
@@ -203,7 +204,7 @@ func (p *pluginManager) LoadedPlugins() *loadedPlugins {
 
 // Load is the method for loading a plugin and
 // saving plugin into the LoadedPlugins array
-func (p *pluginManager) LoadPlugin(path string) (*loadedPlugin, error) {
+func (p *pluginManager) LoadPlugin(path string, emitter gomit.Emitter) (*loadedPlugin, error) {
 	// log.Printf("Attempting to load: %s\v", path)
 	lPlugin := new(loadedPlugin)
 	lPlugin.Path = path
@@ -233,7 +234,7 @@ func (p *pluginManager) LoadPlugin(path string) (*loadedPlugin, error) {
 	lPlugin.ConfigPolicyTree = &resp.ConfigPolicyTree
 
 	if resp.Type == plugin.CollectorPluginType {
-		ap, err := newAvailablePlugin(resp, -1)
+		ap, err := newAvailablePlugin(resp, -1, emitter)
 		if err != nil {
 			// log.Println(err.Error())
 			return nil, err

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -64,7 +64,7 @@ func TestLoadPlugin(t *testing.T) {
 			Convey("loads plugin successfully", func() {
 				p := newPluginManager()
 				p.SetMetricCatalog(newMetricCatalog())
-				lp, err := p.LoadPlugin(PluginPath)
+				lp, err := p.LoadPlugin(PluginPath, nil)
 
 				So(lp, ShouldHaveSameTypeAs, new(loadedPlugin))
 				So(p.LoadedPlugins(), ShouldNotBeEmpty)
@@ -74,7 +74,7 @@ func TestLoadPlugin(t *testing.T) {
 
 			Convey("error is returned on a bad PluginPath", func() {
 				p := newPluginManager()
-				lp, err := p.LoadPlugin("")
+				lp, err := p.LoadPlugin("", nil)
 
 				So(lp, ShouldBeNil)
 				So(err, ShouldNotBeNil)
@@ -93,7 +93,7 @@ func TestUnloadPlugin(t *testing.T) {
 				Convey("then it is removed from the loadedPlugins", func() {
 					p := newPluginManager()
 					p.SetMetricCatalog(newMetricCatalog())
-					_, err := p.LoadPlugin(PluginPath)
+					_, err := p.LoadPlugin(PluginPath, nil)
 
 					num_plugins_loaded := len(p.LoadedPlugins().Table())
 					lp, _ := p.LoadedPlugins().Get(0)
@@ -108,7 +108,7 @@ func TestUnloadPlugin(t *testing.T) {
 				Convey("then an error is thrown", func() {
 					p := newPluginManager()
 					p.SetMetricCatalog(newMetricCatalog())
-					_, err := p.LoadPlugin(PluginPath)
+					_, err := p.LoadPlugin(PluginPath, nil)
 					lp, _ := p.LoadedPlugins().Get(0)
 					lp.State = DetectedState
 					err = p.UnloadPlugin(lp)
@@ -120,7 +120,7 @@ func TestUnloadPlugin(t *testing.T) {
 				Convey("then an error is thrown", func() {
 					p := newPluginManager()
 					p.SetMetricCatalog(newMetricCatalog())
-					_, err := p.LoadPlugin(PluginPath)
+					_, err := p.LoadPlugin(PluginPath, nil)
 
 					plugin, _ := p.LoadedPlugins().Get(0)
 					err = p.UnloadPlugin(plugin)

--- a/control/runner.go
+++ b/control/runner.go
@@ -49,6 +49,7 @@ func (i *idCounter) Next() int {
 // Handles events pertaining to plugins and control the runnning state accordingly.
 type runner struct {
 	delegates        []gomit.Delegator
+	emitter          gomit.Emitter
 	monitor          *monitor
 	availablePlugins *availablePlugins
 	metricCatalog    catalogsMetrics
@@ -69,6 +70,10 @@ func newRunner() *runner {
 
 func (r *runner) SetMetricCatalog(c catalogsMetrics) {
 	r.metricCatalog = c
+}
+
+func (r *runner) SetEmitter(e gomit.Emitter) {
+	r.emitter = e
 }
 
 func (r *runner) SetPluginManager(m managesPlugins) {
@@ -156,7 +161,7 @@ func (r *runner) startPlugin(p executablePlugin) (*availablePlugin, error) {
 	}
 
 	// build availablePlugin
-	ap, err := newAvailablePlugin(resp, r.apIdCounter.Next())
+	ap, err := newAvailablePlugin(resp, r.apIdCounter.Next(), r.emitter)
 	if err != nil {
 		return nil, err
 	}

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -118,6 +118,10 @@ func (mucc *MockUnhealthyPluginCollectorClient) Kill(string) error {
 	return errors.New("Fail")
 }
 
+type MockEmitter struct{}
+
+func (me *MockEmitter) Emit(gomit.EventBody) (int, error) { return 0, nil }
+
 func TestRunnerState(t *testing.T) {
 	Convey("pulse/control", t, func() {
 
@@ -129,6 +133,7 @@ func TestRunnerState(t *testing.T) {
 					r := newRunner()
 
 					r.AddDelegates(new(MockHandlerDelegate))
+					r.SetEmitter(new(MockEmitter))
 					So(len(r.delegates), ShouldEqual, 1)
 				})
 
@@ -253,6 +258,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 				if PulsePath != "" {
 					Convey("should return an AvailablePlugin", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin.log",
 							// Daemon:        true,
@@ -277,6 +283,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("availablePlugins should include returned availablePlugin", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin.log",
 						}
@@ -298,6 +305,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("healthcheck on healthy plugin does not increment failedHealthChecks", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin.log",
 						}
@@ -316,6 +324,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("healthcheck on unhealthy plugin increments failedHealthChecks", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin.log",
 						}
@@ -334,6 +343,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("successful healthcheck resets failedHealthChecks", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin-foo.log",
 						}
@@ -356,6 +366,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("three consecutive failedHealthChecks disables the plugin", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{
 							PluginLogPath: "/tmp/pulse-test-plugin.log",
 						}
@@ -376,6 +387,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 
 					Convey("should return error for WaitForResponse error", func() {
 						r := newRunner()
+						r.SetEmitter(new(MockEmitter))
 						exPlugin := new(MockExecutablePlugin)
 						exPlugin.Timeout = true // set to not response
 						ap, e := r.startPlugin(exPlugin)


### PR DESCRIPTION
because availablePlugin are started in two ways, this commit:
- pass eventManager (as Emitter) through pluginManager.LoadPlugin()
  function
- sets Emitter in runner - that runner can pass this instance to every
  newly created instance of availablePlugin

ps. this PR allow to emit/listen for events send from availablePlugin in other components
