### PR TITLE
facter tests conditional build - only on linux

### DIFF
--- a/plugin/collector/pulse-collector-facter/facter/cmd_test.go
+++ b/plugin/collector/pulse-collector-facter/facter/cmd_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 // Tests for communication with external cmd facter (executable)
 
 package facter

--- a/plugin/collector/pulse-collector-facter/facter/facter_test.go
+++ b/plugin/collector/pulse-collector-facter/facter/facter_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 # testing
 go test -v github.com/intelsdilabs/pulse/plugin/collector/pulse-collector-facter/facter


### PR DESCRIPTION
because facter actually takes time on osx based linux, we can just ignore running this tests on osx and left it to travis
