### PR TITLE
Rollback plugin log redir commit

### DIFF
--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -10,8 +10,6 @@ import (
 	"log"
 	"os/exec"
 	"time"
-
-	"github.com/intelsdilabs/pulse/pkg/logger"
 )
 
 const (
@@ -46,31 +44,7 @@ type waitSignalValue struct {
 
 // Starts the plugin and returns error if one occurred. This is non blocking.
 func (e *ExecutablePlugin) Start() error {
-	e.connectStdErrToLogs()
 	return e.cmd.Start()
-}
-
-// connectStdErrToLogs connects plugin stderr
-// and sends them to logs
-// it's not required to stop this goroutine explicilty because it stops when cmd stops
-// on the plugin side you should redirect all logs (warnings, errors) to stderr - panic goes there by default
-func (e *ExecutablePlugin) connectStdErrToLogs() {
-
-	// ignore the error because we
-	stderr, err := e.cmd.StderrPipe()
-	if err != nil {
-		logger.Errorf("execution.stderr - error when connecting to executablePlugin %s: %s", e.cmd.Path, err)
-	}
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		// this automaticly ends when EOR received eg. process is killed/stoped
-		for scanner.Scan() {
-			logger.Debug("execution.stderr", scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			logger.Debug("execution.stderr", "got error when reading:", err.Error())
-		}
-	}()
 }
 
 // Kills the plugin and returns error if one occurred. This is blocking.


### PR DESCRIPTION
This commit adding some logging redirection that was not part of the design for Pulse plugin logging. Rolling it back because this is just spamming false debug messages and not providing value.

Revert "copy stderr from executablePlugin to the standard Pulse logger"

This reverts commit 0c49d30606c4042aaf094c9a3d5577fb5db61efd.
