### PR TITLE
Merges core.MetricType into core.Metric

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -67,7 +67,7 @@ type managesPlugins interface {
 type catalogsMetrics interface {
 	Get([]string, int) (*metricType, error)
 	Add(*metricType)
-	AddLoadedMetricType(*loadedPlugin, core.MetricType)
+	AddLoadedMetricType(*loadedPlugin, core.Metric)
 	Fetch([]string) ([]*metricType, error)
 	Item() (string, []*metricType)
 	Next() bool
@@ -186,7 +186,7 @@ func (p *pluginControl) SwapPlugins(inPath string, out CatalogedPlugin) error {
 // SubscribeMetricType validates the given config data, and if valid
 // returns a MetricType with a config.  On error a collection of errors is returned
 // either from config data processing, or the inability to find the metric.
-func (p *pluginControl) SubscribeMetricType(mt core.MetricType, cd *cdata.ConfigDataNode) (core.MetricType, []error) {
+func (p *pluginControl) SubscribeMetricType(mt core.Metric, cd *cdata.ConfigDataNode) (core.Metric, []error) {
 	logger.Info("control.subscribe", fmt.Sprintf("subscription called with: %s", mt.Namespace()))
 	var subErrs []error
 
@@ -257,7 +257,7 @@ func (p *pluginControl) SubscribePublisher(name string, ver int, config map[stri
 
 // UnsubscribeMetricType unsubscribes a MetricType
 // If subscriptions fall below zero we will panic.
-func (p *pluginControl) UnsubscribeMetricType(mt core.MetricType) {
+func (p *pluginControl) UnsubscribeMetricType(mt core.Metric) {
 	logger.Info("control.subscribe", fmt.Sprintf("unsubscription called with: %s", mt.Namespace()))
 	err := p.metricCatalog.Unsubscribe(mt.Namespace(), mt.Version())
 	if err != nil {
@@ -300,8 +300,8 @@ func (p *pluginControl) PluginCatalog() PluginCatalog {
 	return pc
 }
 
-func (p *pluginControl) MetricCatalog() ([]core.MetricType, error) {
-	var c []core.MetricType
+func (p *pluginControl) MetricCatalog() ([]core.Metric, error) {
+	var c []core.Metric
 	mts, err := p.metricCatalog.Fetch([]string{})
 	if err != nil {
 		return nil, err
@@ -325,7 +325,7 @@ func (p *pluginControl) MetricExists(mns []string, ver int) bool {
 // of metrics and errors.  If an error is encountered no metrics will be
 // returned.
 func (p *pluginControl) CollectMetrics(
-	metricTypes []core.MetricType,
+	metricTypes []core.Metric,
 	deadline time.Time,
 ) (metrics []core.Metric, errs []error) {
 
@@ -367,7 +367,7 @@ func (p *pluginControl) CollectMetrics(
 		wg.Add(1)
 
 		// get a metrics
-		go func(mt []core.MetricType) {
+		go func(mt []core.Metric) {
 			metrics, err = cli.CollectMetrics(mt)
 			if err != nil {
 				cError <- err
@@ -437,7 +437,7 @@ func (p *pluginControl) PublishMetrics(contentType string, content []byte, plugi
 // just a tuple of loadedPlugin and metricType slice
 type pluginMetricTypes struct {
 	plugin      *loadedPlugin
-	metricTypes []core.MetricType
+	metricTypes []core.Metric
 }
 
 func (p *pluginMetricTypes) Count() int {
@@ -445,7 +445,7 @@ func (p *pluginMetricTypes) Count() int {
 }
 
 // groupMetricTypesByPlugin groups metricTypes by a plugin.Key() and returns appropriate structure
-func groupMetricTypesByPlugin(cat catalogsMetrics, metricTypes []core.MetricType) (map[string]pluginMetricTypes, error) {
+func groupMetricTypesByPlugin(cat catalogsMetrics, metricTypes []core.Metric) (map[string]pluginMetricTypes, error) {
 	pmts := make(map[string]pluginMetricTypes)
 	// For each plugin type select a matching available plugin to call
 	for _, mt := range metricTypes {

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -305,7 +305,7 @@ func (m *mc) Next() bool {
 	return false
 }
 
-func (m *mc) AddLoadedMetricType(*loadedPlugin, core.MetricType) {
+func (m *mc) AddLoadedMetricType(*loadedPlugin, core.Metric) {
 
 }
 
@@ -427,6 +427,10 @@ func (m MockMetricType) Config() *cdata.ConfigDataNode {
 	return m.cfg
 }
 
+func (m MockMetricType) Data() interface{} {
+	return nil
+}
+
 func TestCollectMetrics(t *testing.T) {
 
 	Convey("given a new router", t, func() {
@@ -441,7 +445,7 @@ func TestCollectMetrics(t *testing.T) {
 		// Load plugin
 		c.Load(PluginPath)
 
-		m := []core.MetricType{}
+		m := []core.Metric{}
 		m1 := MockMetricType{namespace: []string{"intel", "dummy", "foo"}}
 		m2 := MockMetricType{namespace: []string{"intel", "dummy", "bar"}}
 
@@ -521,8 +525,8 @@ func TestPublishMetrics(t *testing.T) {
 			time.Sleep(1 * time.Second)
 
 			Convey("Publish to file", func() {
-				metrics := []plugin.PluginMetric{
-					*plugin.NewPluginMetric([]string{"foo"}, 1),
+				metrics := []plugin.PluginMetricType{
+					*plugin.NewPluginMetricType([]string{"foo"}, 1),
 				}
 				var buf bytes.Buffer
 				enc := gob.NewEncoder(&buf)

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -74,6 +74,10 @@ func (m *metricType) Config() *cdata.ConfigDataNode {
 	return m.config
 }
 
+func (m *metricType) Data() interface{} {
+	return nil
+}
+
 type metricCatalog struct {
 	tree        *MTTrie
 	mutex       *sync.Mutex
@@ -91,7 +95,7 @@ func newMetricCatalog() *metricCatalog {
 	}
 }
 
-func (m *metricCatalog) AddLoadedMetricType(lp *loadedPlugin, mt core.MetricType) {
+func (m *metricCatalog) AddLoadedMetricType(lp *loadedPlugin, mt core.Metric) {
 	if lp.ConfigPolicyTree == nil {
 		panic("NO")
 	}

--- a/control/plugin/client/client.go
+++ b/control/plugin/client/client.go
@@ -16,8 +16,8 @@ type PluginClient interface {
 // PluginCollectorClient A client providing collector specific plugin method calls.
 type PluginCollectorClient interface {
 	PluginClient
-	CollectMetrics([]core.MetricType) ([]core.Metric, error)
-	GetMetricTypes() ([]core.MetricType, error)
+	CollectMetrics([]core.Metric) ([]core.Metric, error)
+	GetMetricTypes() ([]core.Metric, error)
 	GetConfigPolicyTree() (cpolicy.ConfigPolicyTree, error)
 }
 

--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -64,7 +64,7 @@ func (p *PluginNativeClient) Publish(contentType string, content []byte, config 
 	return err
 }
 
-func (p *PluginNativeClient) CollectMetrics(coreMetricTypes []core.MetricType) ([]core.Metric, error) {
+func (p *PluginNativeClient) CollectMetrics(coreMetricTypes []core.Metric) ([]core.Metric, error) {
 	// Convert core.MetricType slice into plugin.PluginMetricType slice as we have
 	// to send structs over RPC
 	pluginMetricTypes := make([]plugin.PluginMetricType, len(coreMetricTypes))
@@ -93,13 +93,13 @@ func (p *PluginNativeClient) CollectMetrics(coreMetricTypes []core.MetricType) (
 	return retMetrics, err
 }
 
-func (p *PluginNativeClient) GetMetricTypes() ([]core.MetricType, error) {
+func (p *PluginNativeClient) GetMetricTypes() ([]core.Metric, error) {
 	args := plugin.GetMetricTypesArgs{}
 	reply := plugin.GetMetricTypesReply{}
 
 	err := p.connection.Call("Collector.GetMetricTypes", args, &reply)
 
-	retMetricTypes := make([]core.MetricType, len(reply.PluginMetricTypes))
+	retMetricTypes := make([]core.Metric, len(reply.PluginMetricTypes))
 	for i, _ := range reply.PluginMetricTypes {
 		retMetricTypes[i] = reply.PluginMetricTypes[i]
 	}

--- a/control/plugin/collector.go
+++ b/control/plugin/collector.go
@@ -17,7 +17,7 @@ import (
 // Collector plugin
 type CollectorPlugin interface {
 	Plugin
-	CollectMetrics([]PluginMetricType) ([]PluginMetric, error)
+	CollectMetrics([]PluginMetricType) ([]PluginMetricType, error)
 	GetMetricTypes() ([]PluginMetricType, error)
 	GetConfigPolicyTree() (cpolicy.ConfigPolicyTree, error)
 }

--- a/control/plugin/collector_proxy.go
+++ b/control/plugin/collector_proxy.go
@@ -14,7 +14,7 @@ type CollectMetricsArgs struct {
 
 // Reply assigned by a Collector implementation using CollectMetrics()
 type CollectMetricsReply struct {
-	PluginMetrics []PluginMetric
+	PluginMetrics []PluginMetricType
 }
 
 // GetMetricTypesArgs args passed to GetMetricTypes

--- a/control/plugin/collector_test.go
+++ b/control/plugin/collector_test.go
@@ -79,8 +79,8 @@ func (f *MockPlugin) GetConfigPolicyTree() (cpolicy.ConfigPolicyTree, error) {
 	return cpolicy.ConfigPolicyTree{}, nil
 }
 
-func (f *MockPlugin) CollectMetrics(_ []PluginMetricType) ([]PluginMetric, error) {
-	return []PluginMetric{}, nil
+func (f *MockPlugin) CollectMetrics(_ []PluginMetricType) ([]PluginMetricType, error) {
+	return []PluginMetricType{}, nil
 }
 
 func (c *MockPlugin) GetMetricTypes() ([]PluginMetricType, error) {

--- a/control/plugin/metric.go
+++ b/control/plugin/metric.go
@@ -6,31 +6,6 @@ import (
 	"github.com/intelsdilabs/pulse/core/cdata"
 )
 
-// Represents a collected metric. Only used within plugins and across plugin calls.
-// Converted to core.Metric before being used within modules.
-type PluginMetric struct {
-	Namespace_ []string
-	Data_      interface{}
-}
-
-// PluginMetric Constructor
-func NewPluginMetric(namespace []string, data interface{}) *PluginMetric {
-	return &PluginMetric{
-		Namespace_: namespace,
-		Data_:      data,
-	}
-}
-
-// getter for namespace
-func (p PluginMetric) Namespace() []string {
-	return p.Namespace_
-}
-
-// getter for Data
-func (p PluginMetric) Data() interface{} {
-	return p.Data_
-}
-
 // Represents a metric type. Only used within plugins and across plugin calls.
 // Converted to core.MetricType before being used within modules.
 type PluginMetricType struct {
@@ -38,6 +13,15 @@ type PluginMetricType struct {
 	LastAdvertisedTime_ time.Time
 	Version_            int
 	Config_             *cdata.ConfigDataNode //map[string]ctypes.ConfigValue
+	Data_               interface{}
+}
+
+// // PluginMetricType Constructor
+func NewPluginMetricType(namespace []string, data interface{}) *PluginMetricType {
+	return &PluginMetricType{
+		Namespace_: namespace,
+		Data_:      data,
+	}
 }
 
 // Returns the namespace.
@@ -58,6 +42,14 @@ func (p PluginMetricType) Version() int {
 // Config returns the map of config data for this metric
 func (p PluginMetricType) Config() *cdata.ConfigDataNode {
 	return p.Config_
+}
+
+func (p PluginMetricType) Data() interface{} {
+	return p.Data_
+}
+
+func (p *PluginMetricType) AddData(data interface{}) {
+	p.Data_ = data
 }
 
 /*

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -6,6 +6,14 @@ import (
 	"time"
 )
 
+const (
+	// Builtin Content Types
+	PulseWildcardContentType = "pulse.*"
+	PulseGob                 = "pulse.gob"
+	// PulseJSON = "pulse.json" - disabled until it exists
+	// PulsePB = "pulse.pb" - disabled until it exists
+)
+
 var (
 	// Timeout settings
 	// How much time must elapse before a lack of Ping results in a timeout

--- a/core/metric.go
+++ b/core/metric.go
@@ -6,14 +6,10 @@ import (
 	"github.com/intelsdilabs/pulse/core/cdata"
 )
 
-type MetricType interface {
+type Metric interface {
 	Version() int
 	Namespace() []string
 	LastAdvertisedTime() time.Time
 	Config() *cdata.ConfigDataNode
-}
-
-type Metric interface {
-	Namespace() []string
 	Data() interface{}
 }

--- a/mgmt/rest/metric.go
+++ b/mgmt/rest/metric.go
@@ -19,6 +19,10 @@ func (m *metricType) Namespace() []string {
 	return parseNamespace(m.Ns)
 }
 
+func (m *metricType) Data() interface{} {
+	return nil
+}
+
 func (m *metricType) Version() int                  { return m.Ver }
 func (m *metricType) LastAdvertisedTime() time.Time { return time.Unix(m.LAT, 0) }
 func (m *metricType) Config() *cdata.ConfigDataNode { return nil }

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -16,12 +16,12 @@ import (
 )
 
 type managesMetrics interface {
-	MetricCatalog() ([]core.MetricType, error)
+	MetricCatalog() ([]core.Metric, error)
 	Load(string) error
 }
 
 type managesTasks interface {
-	CreateTask([]core.MetricType, core.Schedule, *cdata.ConfigDataTree, core.Workflow, ...core.TaskOption) (core.Task, core.TaskErrors)
+	CreateTask([]core.Metric, core.Schedule, *cdata.ConfigDataTree, core.Workflow, ...core.TaskOption) (core.Task, core.TaskErrors)
 }
 
 type Server struct {

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -96,7 +96,7 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 		return
 	}
 
-	mts := make([]core.MetricType, len(tr.Workflow.Collect.MetricTypes))
+	mts := make([]core.Metric, len(tr.Workflow.Collect.MetricTypes))
 	for i, m := range tr.Workflow.Collect.MetricTypes {
 		mts[i] = m
 	}

--- a/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
+++ b/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
@@ -21,11 +21,11 @@ type Dummy struct {
 }
 
 // CollectMetrics collects metrics for testing
-func (f *Dummy) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetric, error) {
-	metrics := make([]plugin.PluginMetric, len(mts))
+func (f *Dummy) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	metrics := make([]plugin.PluginMetricType, len(mts))
 	for i, p := range mts {
 		data := fmt.Sprintf("The dummy collected data! config data: user=%s password=%s", p.Config().Table()["name"], p.Config().Table()["name"])
-		metrics[i] = plugin.PluginMetric{
+		metrics[i] = plugin.PluginMetricType{
 			Namespace_: p.Namespace(),
 			Data_:      data,
 		}

--- a/plugin/collector/pulse-collector-dummy2/dummy/dummy.go
+++ b/plugin/collector/pulse-collector-dummy2/dummy/dummy.go
@@ -21,12 +21,12 @@ type Dummy struct {
 }
 
 // CollectMetrics collects metrics for testing
-func (f *Dummy) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetric, error) {
+func (f *Dummy) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
 	for _, p := range mts {
 		log.Println("collecting", p)
 	}
-	m := plugin.PluginMetric{Namespace_: []string{"intel", "dummy", "foo"}, Data_: 1}
-	ms := []plugin.PluginMetric{m}
+	m := plugin.PluginMetricType{Namespace_: []string{"intel", "dummy", "foo"}, Data_: 1}
+	ms := []plugin.PluginMetricType{m}
 	return ms, nil
 }
 

--- a/plugin/collector/pulse-collector-facter/facter/facter.go
+++ b/plugin/collector/pulse-collector-facter/facter/facter.go
@@ -112,7 +112,7 @@ func (f *Facter) GetMetricTypes() ([]plugin.PluginMetricType, error) {
 // Collect collects metrics from external binary a returns them in form
 // acceptable by Pulse, only returns collects that were asked for and return nothing when asked for none
 // the order of requested and received metrics isn't guaranted
-func (f *Facter) CollectMetrics(metricTypes []plugin.PluginMetricType) ([]plugin.PluginMetric, error) {
+func (f *Facter) CollectMetrics(metricTypes []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
 
 	// parse and check requested names of metrics
 	names := []string{}
@@ -147,10 +147,10 @@ func (f *Facter) CollectMetrics(metricTypes []plugin.PluginMetricType) ([]plugin
 	}
 
 	// convert facts into PluginMetrics
-	metrics := make([]plugin.PluginMetric, 0, len(facts))
+	metrics := make([]plugin.PluginMetricType, 0, len(facts))
 	for name, value := range facts {
 		namespace := createNamespace(name)
-		metric := *plugin.NewPluginMetric(namespace, value)
+		metric := *plugin.NewPluginMetricType(namespace, value)
 		metrics = append(metrics, metric)
 	}
 	return metrics, nil

--- a/plugin/publisher/pulse-publisher-file/file/file.go
+++ b/plugin/publisher/pulse-publisher-file/file/file.go
@@ -33,7 +33,7 @@ func NewFilePublisher() *filePublisher {
 
 func (f *filePublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue, logger *log.Logger) error {
 	logger.Println("Publishing started")
-	var metrics []plugin.PluginMetric
+	var metrics []plugin.PluginMetricType
 
 	switch contentType {
 	case plugin.ContentTypes[plugin.PulseGobContentType]:

--- a/plugin/publisher/pulse-publisher-file/file/file_test.go
+++ b/plugin/publisher/pulse-publisher-file/file/file_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestFilePublish(t *testing.T) {
 	var buf bytes.Buffer
-	metrics := []plugin.PluginMetric{
-		*plugin.NewPluginMetric([]string{"foo"}, 99),
+	metrics := []plugin.PluginMetricType{
+		*plugin.NewPluginMetricType([]string{"foo"}, 99),
 	}
 	config := make(map[string]ctypes.ConfigValue)
 	enc := gob.NewEncoder(&buf)

--- a/scheduler/job.go
+++ b/scheduler/job.go
@@ -76,11 +76,11 @@ func (c *coreJob) Errors() []error {
 type collectorJob struct {
 	*coreJob
 	collector   collectsMetrics
-	metricTypes []core.MetricType
+	metricTypes []core.Metric
 	metrics     []core.Metric
 }
 
-func newCollectorJob(metricTypes []core.MetricType, deadlineDuration time.Duration, collector collectsMetrics) *collectorJob {
+func newCollectorJob(metricTypes []core.Metric, deadlineDuration time.Duration, collector collectsMetrics) *collectorJob {
 	return &collectorJob{
 		collector:   collector,
 		metricTypes: metricTypes,
@@ -149,9 +149,9 @@ func (p *publisherJob) Run() {
 	case collectJobType:
 		switch p.contentType {
 		case plugin.ContentTypes[plugin.PulseGobContentType]:
-			metrics := make([]plugin.PluginMetric, len(p.parentJob.(*collectorJob).metrics))
+			metrics := make([]plugin.PluginMetricType, len(p.parentJob.(*collectorJob).metrics))
 			for i, m := range p.parentJob.(*collectorJob).metrics {
-				metrics[i] = *plugin.NewPluginMetric(m.Namespace(), m.Data())
+				metrics[i] = *plugin.NewPluginMetricType(m.Namespace(), m.Data())
 			}
 			enc.Encode(metrics)
 		default:

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -11,38 +11,38 @@ import (
 
 type mockCollector struct{}
 
-func (m *mockCollector) CollectMetrics([]core.MetricType, time.Time) ([]core.Metric, []error) {
+func (m *mockCollector) CollectMetrics([]core.Metric, time.Time) ([]core.Metric, []error) {
 	return nil, nil
 }
 
 func TestCollectorJob(t *testing.T) {
 	Convey("newCollectorJob()", t, func() {
 		Convey("it returns an init-ed collectorJob", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj, ShouldHaveSameTypeAs, &collectorJob{})
 		})
 	})
 	Convey("StartTime()", t, func() {
 		Convey("it should return the job starttime", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj.StartTime(), ShouldHaveSameTypeAs, time.Now())
 		})
 	})
 	Convey("Deadline()", t, func() {
 		Convey("it should return the job daedline", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj.Deadline(), ShouldResemble, cj.deadline)
 		})
 	})
 	Convey("Type()", t, func() {
 		Convey("it should return the job type", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj.Type(), ShouldEqual, collectJobType)
 		})
 	})
 	Convey("ReplChan()", t, func() {
 		Convey("it should return the reply channel", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj.ReplChan(), ShouldHaveSameTypeAs, make(chan struct{}))
 		})
 	})
@@ -54,13 +54,13 @@ func TestCollectorJob(t *testing.T) {
 	// })
 	Convey("Errors()", t, func() {
 		Convey("it should return the errors from the job", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			So(cj.Errors(), ShouldResemble, []error{})
 		})
 	})
 	Convey("Run()", t, func() {
 		Convey("it should reply on the reply chan", func() {
-			cj := newCollectorJob([]core.MetricType{}, defaultDeadline, &mockCollector{})
+			cj := newCollectorJob([]core.Metric{}, defaultDeadline, &mockCollector{})
 			go cj.Run()
 			<-cj.replchan
 			So(cj.Errors(), ShouldResemble, []error{})

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -26,14 +26,14 @@ const (
 // On startup a scheduler will be created and passed a reference to control
 //JC todo refacto this to be managesMetrics
 type managesMetric interface {
-	SubscribeMetricType(mt core.MetricType, cd *cdata.ConfigDataNode) (core.MetricType, []error)
-	UnsubscribeMetricType(mt core.MetricType)
-	CollectMetrics([]core.MetricType, time.Time) ([]core.Metric, []error)
+	SubscribeMetricType(mt core.Metric, cd *cdata.ConfigDataNode) (core.Metric, []error)
+	UnsubscribeMetricType(mt core.Metric)
+	CollectMetrics([]core.Metric, time.Time) ([]core.Metric, []error)
 	PublishMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue) []error
 }
 
 type collectsMetrics interface {
-	CollectMetrics([]core.MetricType, time.Time) ([]core.Metric, []error)
+	CollectMetrics([]core.Metric, time.Time) ([]core.Metric, []error)
 }
 
 type publishesMetrics interface {
@@ -76,7 +76,7 @@ func (t *taskErrors) Errors() []error {
 }
 
 // CreateTask creates and returns task
-func (s *scheduler) CreateTask(mts []core.MetricType, sch core.Schedule, cdt *cdata.ConfigDataTree, wf core.Workflow, opts ...core.TaskOption) (core.Task, core.TaskErrors) {
+func (s *scheduler) CreateTask(mts []core.Metric, sch core.Schedule, cdt *cdata.ConfigDataTree, wf core.Workflow, opts ...core.TaskOption) (core.Task, core.TaskErrors) {
 	te := &taskErrors{
 		errs: make([]error, 0),
 	}
@@ -94,7 +94,7 @@ func (s *scheduler) CreateTask(mts []core.MetricType, sch core.Schedule, cdt *cd
 
 	//subscribe to MT
 	//if we encounter an error we will unwind successful subscriptions
-	subscriptions := make([]core.MetricType, 0)
+	subscriptions := make([]core.Metric, 0)
 	for _, m := range mts {
 		cd := cdt.Get(m.Namespace())
 		mt, err := s.metricManager.SubscribeMetricType(m, cd)

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -18,7 +18,7 @@ type mockMetricManager struct {
 	failuredSoFar              int
 }
 
-func (m *mockMetricManager) SubscribeMetricType(mt core.MetricType, cd *cdata.ConfigDataNode) (core.MetricType, []error) {
+func (m *mockMetricManager) SubscribeMetricType(mt core.Metric, cd *cdata.ConfigDataNode) (core.Metric, []error) {
 	if m.failValidatingMetrics {
 		if m.failValidatingMetricsAfter > m.failuredSoFar {
 			m.failuredSoFar++
@@ -31,11 +31,11 @@ func (m *mockMetricManager) SubscribeMetricType(mt core.MetricType, cd *cdata.Co
 	return nil, nil
 }
 
-func (m *mockMetricManager) UnsubscribeMetricType(mt core.MetricType) {
+func (m *mockMetricManager) UnsubscribeMetricType(mt core.Metric) {
 
 }
 
-func (m *mockMetricManager) CollectMetrics([]core.MetricType, time.Time) ([]core.Metric, []error) {
+func (m *mockMetricManager) CollectMetrics([]core.Metric, time.Time) ([]core.Metric, []error) {
 	return nil, nil
 }
 
@@ -68,6 +68,10 @@ func (m mockMetricType) LastAdvertisedTime() time.Time {
 
 func (m mockMetricType) Config() *cdata.ConfigDataNode {
 	return m.config
+}
+
+func (m mockMetricType) Data() interface{} {
+	return nil
 }
 
 type mockWorkflow struct {
@@ -110,7 +114,7 @@ func TestScheduler(t *testing.T) {
 	Convey("new", t, func() {
 		c := new(mockMetricManager)
 		sch := core.NewSimpleSchedule(time.Millisecond * 5)
-		mt := []core.MetricType{
+		mt := []core.Metric{
 			&mockMetricType{
 				namespace:          []string{"foo", "bar"},
 				version:            1,

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -22,7 +22,7 @@ type task struct {
 	killChan         chan struct{}
 	schedule         schedule
 	workflow         workflow
-	metricTypes      []core.MetricType
+	metricTypes      []core.Metric
 	state            core.TaskState
 	creationTime     time.Time
 	lastFireTime     time.Time
@@ -47,7 +47,7 @@ func TaskDeadlineDuration(v time.Duration) option {
 }
 
 //NewTask creates a Task
-func newTask(s schedule, mtc []core.MetricType, wf workflow, m *workManager, mm managesMetric, opts ...core.TaskOption) *task {
+func newTask(s schedule, mtc []core.Metric, wf workflow, m *workManager, mm managesMetric, opts ...core.TaskOption) *task {
 	task := &task{
 		id:               id(),
 		schResponseChan:  make(chan scheduleResponse),

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -13,7 +13,7 @@ func TestTask(t *testing.T) {
 	Convey("Task", t, func() {
 		Convey("task + simple schedule", func() {
 			sch := newSimpleSchedule(core.NewSimpleSchedule(time.Millisecond * 100))
-			task := newTask(sch, []core.MetricType{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
+			task := newTask(sch, []core.Metric{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
 			task.Spin()
 			time.Sleep(time.Millisecond * 10) // it is a race so we slow down the test
 			So(task.state, ShouldEqual, core.TaskSpinning)
@@ -22,7 +22,7 @@ func TestTask(t *testing.T) {
 
 		Convey("Task is created and starts to spin", func() {
 			sch := newSimpleSchedule(core.NewSimpleSchedule(time.Second * 5))
-			task := newTask(sch, []core.MetricType{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
+			task := newTask(sch, []core.Metric{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
 			task.Spin()
 			So(task.state, ShouldEqual, core.TaskSpinning)
 			Convey("Task is Stopped", func() {
@@ -46,7 +46,7 @@ func TestTask(t *testing.T) {
 
 		Convey("task fires", func() {
 			sch := newSimpleSchedule(core.NewSimpleSchedule(time.Millisecond * 10))
-			task := newTask(sch, []core.MetricType{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
+			task := newTask(sch, []core.Metric{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
 			task.Spin()
 			time.Sleep(time.Millisecond * 100)
 			So(task.hitCount, ShouldBeGreaterThan, 2)
@@ -58,7 +58,7 @@ func TestTask(t *testing.T) {
 	Convey("Create task collection", t, func() {
 
 		sch := newSimpleSchedule(core.NewSimpleSchedule(time.Millisecond * 10))
-		task := newTask(sch, []core.MetricType{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
+		task := newTask(sch, []core.Metric{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
 		So(task.id, ShouldNotBeEmpty)
 		So(task.id, ShouldNotBeNil)
 		taskCollection := newTaskCollection()
@@ -92,7 +92,7 @@ func TestTask(t *testing.T) {
 			})
 
 			Convey("Create another task and compare the id", func() {
-				task2 := newTask(sch, []core.MetricType{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
+				task2 := newTask(sch, []core.Metric{}, &mockWorkflow{}, newWorkManager(), &mockMetricManager{})
 				So(task2.id, ShouldEqual, task.id+1)
 			})
 

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -135,6 +135,6 @@ type collectStep struct {
 	step
 }
 
-func (c *collectStep) createJob(metricTypes []core.MetricType, deadlineDuration time.Duration, collector collectsMetrics) job {
+func (c *collectStep) createJob(metricTypes []core.Metric, deadlineDuration time.Duration, collector collectsMetrics) job {
 	return newCollectorJob(metricTypes, deadlineDuration, collector)
 }

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -40,6 +40,10 @@ func (m MockMetricType) Config() *cdata.ConfigDataNode {
 	return nil
 }
 
+func (m MockMetricType) Data() interface{} {
+	return nil
+}
+
 func TestCollectPublishWorkflow(t *testing.T) {
 	Convey("Given a started plugin control", t, func() {
 		logger.SetLevel(logger.DebugLevel)
@@ -77,7 +81,7 @@ func TestCollectPublishWorkflow(t *testing.T) {
 					Convey("Start", func() {
 						workerKillChan = make(chan struct{})
 						manager := newWorkManager()
-						task := newTask(sch, []core.MetricType{smt}, wf, manager, c)
+						task := newTask(sch, []core.Metric{smt}, wf, manager, c)
 						task.Spin()
 						time.Sleep(4 * time.Second)
 					})


### PR DESCRIPTION
Since Metric only represented Data inside a metric this PR merges does to one interface. A metric is not collected unless provided so the order of operations never has a metric with out a namespace.
