### PR TITLE
Refactoring: docstrings & cleaning & code duplication removal

### DIFF
--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -107,7 +107,11 @@ func NewPluginMeta(name string, version int, pluginType PluginType) *PluginMeta 
 	}
 }
 
-// Start starts a plugin
+// Start starts a plugin where:
+// PluginMeta - base information about plugin
+// Plugin - either CollectorPlugin or PublisherPlugin
+// requestString - plugins arguments (marshaled json of control/plugin Arg struct)
+// returns an error and exitCode (exitCode from SessionState initilization or plugin termination code)
 func Start(m *PluginMeta, c Plugin, requestString string) (error, int) {
 	sessionState, sErr, retCode := NewSessionState(requestString)
 	if sErr != nil {


### PR DESCRIPTION
Just a minor refactoring that:
- add docs strings for plugin.Start (I've again read the source code to start my plugin)
- removes duplication of logger initialization (exact the same code, with difference of oppening flags)
