### PR TITLE
golang version 1.4.2 and drop support for 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.3.1
-- 1.4
+- 1.4.2
 before_install:
 - cp .netrc ~
 - chmod 600 .netrc


### PR DESCRIPTION
support for 1.3 doubles work/time spent on travis without apparent value
