### PR TITLE
true vendoring:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,20 @@
 sudo: false
 language: go
 go:
-- 1.3.1
-- 1.4
+- 1.4.2
 before_install:
-- cp .netrc ~
-- chmod 600 .netrc
-- go get github.com/tools/godep
-- go get github.com/axw/gocov/gocov
-- go get github.com/mattn/goveralls
-- go get -u github.com/golang/lint/golint
-- go get golang.org/x/tools/cmd/vet
-- go get golang.org/x/tools/cmd/goimports
-- go get github.com/smartystreets/goconvey/convey
-- if [ ! -d $PULSE_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $PULSE_SOURCE; fi # CI for forks not from intelsdi-x
-- if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+- cp .netrc ~ && chmod 600 .netrc # have an access to private repo
+- if [ ! -d $PULSE_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $PULSE_SOURCE; fi # CI works for forks 
+- make deps # only testing requirements (like coverage, vet, linters etc...)
 env:
   global:
     - PULSE_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/pulse
     - PULSE_PATH=/home/travis/gopath/src/github.com/intelsdi-x/pulse/build    
 install:
 - gem install facter
-- cd $PULSE_SOURCE # change dir into source
-- ./scripts/deps.sh # load deps for pulse and plugins
-- go get -d -v ./... && go build -v ./... # get and build source
-- make
 script:
-- ./scripts/test.sh 2>&1 # Run test suite
+- cd $PULSE_SOURCE 
+- make test
 notifications:
   slack:
     secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,46 @@
-default: build-pulse
+.PHONY: build test
+
+# `make test` first builds agent and all plugins using vendored packages using help ./scripts/build.sh
+# then calls helper scripts ./scripts/tests.sh that actually goes recursively through all src folders (including plugin) call `go test` in each.
+# Additionally the flag PULSE_BUILD_HELPER_NO_REBUILD is set to not prevent rebuild each plugin binarry before test.
+
+default: build
+
+# It should reassemble process that happens with CI env
+# 1. we should have empty GOPATH with only src/github.com/intelsdi-pulse cloned inside
+# 2. then we are install all build & testing dependencies like (goling/gocov/cover/imports/vet/convey)
+# 3. we build all plugins one by one using their Godeps/_workspace/src as GOPATH
+# 4. we build pulse itself with Godeps/_workspace appended to GOPATH
+# 5. then tests
+# assumptions because we are vendoring, we are not "go getting" any depedencies other that required strictly for building
+
+clean:
+	rm -rf build/
 
 deps:
-	go get -u github.com/smartystreets/goconvey
-	go get -u github.com/smartystreets/assertions
-	go get -u golang.org/x/tools/cmd/cover
-	go get -u github.com/streadway/amqp
-	go get -u github.com/docker/libcontainer
-	cd ../../docker/libcontainer; git checkout tags/v1.4.0; cd -
+	echo "installing build & testing dependecies"
+	echo "in GOPATH=${GOPATH}"
+	#cd ../../docker/libcontainer; git checkout tags/v1.4.0; cd - going to Godeps
+	#go get github.com/docker/libcontainer
+	go get github.com/golang/lint/golint
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get github.com/smartystreets/assertions
+	go get github.com/smartystreets/goconvey
+	go get github.com/smartystreets/goconvey/convey
+	go get github.com/streadway/amqp
+	go get github.com/tools/godep
+	# cover will be in standard lib from 1.5 for 1.4 we have to live with such kind of hack
+	# this hack probably  was required for 1.3
+	#if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+	go get golang.org/x/tools/cmd/cover
+	go get golang.org/x/tools/cmd/goimports
+	go get golang.org/x/tools/cmd/vet
 
-test: 
-	export PULSE_PATH=`pwd`/build; bash -c "./scripts/test.sh"
+test: build
+	# make use of alread build all plugins a moment ago
+	export PULSE_BUILD_HELPER_NO_REBUILD=no
+	./scripts/test.sh
 
-build-pulse:
-	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"
+build:
+	./scripts/build.sh

--- a/README.md
+++ b/README.md
@@ -66,11 +66,34 @@ make
 * [Please read our development guidelines](https://github.com/intelsdilabs/pulse/wiki/Development-guidelines)
 * [ ] TODO - CLA
 
+## Building
+
+```
+make build
+```
+creates all required binaries into build folder
+with a given structure:
+
+```
+build
+├── bin
+│   └── pulse-agent
+└── plugin
+    ├── collector
+    │   └── pulse-collector-PLUGINNAME
+    └── publisher
+        └── pulse-publisher-PLUGINNAME
+```
+
 ## Testing
 
 ```
 make test
 ```
+
+Builds agent & plugins and then calls all tests.
+
+
 
 ## Releases
 

--- a/plugin/helper/helper.go
+++ b/plugin/helper/helper.go
@@ -3,6 +3,7 @@ package helper
 
 import (
 	// "fmt"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -14,7 +15,13 @@ var (
 )
 
 // Attempts to make the plugins before each test.
+// unless PULSE_BUILD_HELPER_NO_REBUILD is set
 func BuildPlugin(pluginType, pluginName string) error {
+
+	if os.Getenv("PULSE_BUILD_HELPER_NO_REBUILD") != "" {
+		fmt.Println("skiping build because PULSE_BUILD_HELPER_NO_REBUILD is set")
+		return nil
+	}
 	wd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -23,10 +30,12 @@ func BuildPlugin(pluginType, pluginName string) error {
 	bPath := strings.Replace(wd, path.Join("/", "plugin", pluginType, pluginName), buildScript, 1)
 	sPath := strings.Replace(wd, path.Join("/", "plugin", pluginType, pluginName), "", 1)
 
-	// fmt.Println(bPath, sPath, pluginType, pluginName)
+	fmt.Println(bPath, sPath, pluginType, pluginName)
 	c := exec.Command(bPath, sPath, pluginType, pluginName)
 
 	_, e := c.Output()
-	// fmt.Println(string(o))
+	if err != nil {
+		panic(err)
+	}
 	return e
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 echo "****  Pulse Build  ****"
-echo
 
-SOURCEDIR=$1
+SOURCEDIR=${1:-`pwd`}
+# aka pluginType when called from BuildHelper
 SPLUGINFOLDER=$2
+# aka pluginName
 SPLUGIN=$3
 BUILDDIR=$SOURCEDIR/build
 PLUGINDIR=plugin
 BINDIR=$BUILDDIR/bin
+AGENT=$BUILDDIR/bin/pulse-agent
 COLLECTORDIR=$BUILDDIR/$PLUGINDIR/collector
 PUBLISHERDIR=$BUILDDIR/$PLUGINDIR/publisher
 
-# Clean build bin dir
-rm -rf $BINDIR/*
 
 # Make dir
 mkdir -p $BINDIR
@@ -22,49 +22,70 @@ mkdir -p $PUBLISHERDIR
 
 # Binaries
 #
-echo "Source Dir = $SOURCEDIR"
-echo "$SPLUGIN"
-echo "$SPLUGINFOLDER"
-echo " Building Pulse Agent"	
-go build -ldflags "-X main.gitversion `git describe --always`" -o $BINDIR/pulse-agent . || exit 1
+echo
+echo "Source dir = $SOURCEDIR"
+echo "Plugin = $SPLUGIN"
+echo "Plugin dir = $SPLUGINFOLDER"
+echo "base GOPATH = $GOPATH"
+echo 
+
+PULSE_GOPATH=$GOPATH
+function mangleGoPath {
+  export GOPATH=`godep path`:$PULSE_GOPATH
+}
+
 
 if [ "$SPLUGIN" ] && [ -n "$SPLUGINFOLDER" ]
 then
 	echo " Building Plugin: $SPLUGIN"
 	# Built-in single plugin building
-	cd $SOURCEDIR/plugin/$SPLUGINFOLDER/
-	target=./$SPLUGIN/
+	cd $SOURCEDIR/plugin/$SPLUGINFOLDER/$SPLUGIN
 	destination=$BUILDDIR/$PLUGINDIR/$SPLUGINFOLDER/$SPLUGIN
 	echo "    $SPLUGIN => $destination"	
-	go build -o $destination $target || exit 2
+  mangleGoPath
+	go build -o $destination . || exit 2
 	cd $SOURCEDIR
 else
-	# Clean build
-	rm -rf $COLLECTORDIR/*
+  # Clean build bin dir and plugin outputs
+  echo " Building Pulse Agent"	
+  echo "    . => $AGENT"
+  rm -f $AGENT
+  mangleGoPath
+  go build -ldflags "-X main.gitversion `git describe --always`" -o $BINDIR/pulse-agent . || exit 1
+
 	echo " Building Collector Plugin(s)"
 	# Built-in Collector Plugin building
 	cd $SOURCEDIR/$PLUGINDIR/collector
 	for d in *; do
 		if [[ -d $d ]]; then
+      cd $d
 			echo "    $d => $COLLECTORDIR/$d"		
-			go build -o $COLLECTORDIR/$d ./$d/ || exit 2
+      destination=$COLLECTORDIR/$d
+      rm -f $destination
+      mangleGoPath
+			go build -o $destination  . || exit 2
 			# chmod -x ../../$COLLECTORDIR/$d / for testing non-executable builds
+      cd $SOURCEDIR/$PLUGINDIR/collector
 		fi
 	done
 	
 	# Publisher build
-	rm -rf $PUBLISHERDIR/*
 	echo " Building Publisher Plugin(s)"
 	# Built-in Collector Plugin building
 	cd $SOURCEDIR/$PLUGINDIR/publisher
 	for d in *; do
 		if [[ -d $d ]]; then
+      cd $d
 			echo "    $d => $PUBLISHERDIR/$d"		
-			go build -o $PUBLISHERDIR/$d ./$d/ || exit 2
+      destination=$PUBLISHERDIR/$d
+      rm -f $destination
+      mangleGoPath
+			go build -o $destination . || exit 2
 			# chmod -x ../../$PUBLISHERDIR/$d / for testing non-executable builds
+      cd $SOURCEDIR/$PLUGINDIR/publisher
 		fi
 	done
-	
+
 	cd $SOURCEDIR
 
 	# Built-in Publisher Plugin building
@@ -73,4 +94,4 @@ fi
 
 
 echo
-echo "*******************"
+echo "***********************"


### PR DESCRIPTION
WIP: trying to make it my fork visible to travis - somehow it doesn't sync it with my ppalucki github account

changes & improvements:
- when calling scripts/test.sh or scripts/build.sh we always use
  vendored code instead of GOPATH (but GOPATH is not replaced but appended at
  the end, so if some package wasn't saved with `go save` it would cause a
  problem in CI, but allows to work with single GOPATH in developer
  environment)
- when using Makefile `make test` will actually use the fact, that all
  was build a moment ago, and wont tries to rebuild all plugin each time
- when using script/test.sh directly, BuildHelper will rebuild our
  plugin binary every time (to be consisted with go test that builds a new
  code)
- there should not be a problem, that some packages (other that build
  tools like coverrage would be unavailable) (speedup for gratis)
