### PR TITLE
Adds a panic handler to all RPC methods in proxy.go files

### DIFF
--- a/control/plugin/collector_proxy.go
+++ b/control/plugin/collector_proxy.go
@@ -38,6 +38,8 @@ type collectorPluginProxy struct {
 }
 
 func (c *collectorPluginProxy) GetMetricTypes(args GetMetricTypesArgs, reply *GetMetricTypesReply) error {
+	defer catchPluginPanic(c.Session.Logger())
+
 	c.Session.Logger().Println("GetMetricTypes called")
 	// Reset heartbeat
 	c.Session.ResetHeartbeat()
@@ -50,6 +52,8 @@ func (c *collectorPluginProxy) GetMetricTypes(args GetMetricTypesArgs, reply *Ge
 }
 
 func (c *collectorPluginProxy) CollectMetrics(args CollectMetricsArgs, reply *CollectMetricsReply) error {
+	defer catchPluginPanic(c.Session.Logger())
+
 	c.Session.Logger().Println("CollectMetrics called")
 	// Reset heartbeat
 	c.Session.ResetHeartbeat()
@@ -62,6 +66,8 @@ func (c *collectorPluginProxy) CollectMetrics(args CollectMetricsArgs, reply *Co
 }
 
 func (c *collectorPluginProxy) GetConfigPolicyTree(args GetConfigPolicyTreeArgs, reply *GetConfigPolicyTreeReply) error {
+	defer catchPluginPanic(c.Session.Logger())
+
 	c.Session.Logger().Println("GetConfigPolicyTree called")
 	policy, err := c.Plugin.GetConfigPolicyTree()
 

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -4,7 +4,9 @@ package plugin
 import (
 	"crypto/rsa"
 	"fmt" // Don't use "fmt.Print*"
+	"log"
 	"regexp"
+	"runtime"
 	"time"
 )
 
@@ -179,4 +181,14 @@ func Start(m *PluginMeta, c Plugin, requestString string) (error, int) {
 	}
 
 	return nil, retCode
+}
+
+func catchPluginPanic(l *log.Logger) {
+	if err := recover(); err != nil {
+		trace := make([]byte, 4096)
+		count := runtime.Stack(trace, true)
+		l.Printf("Recover from panic: %s\n", err)
+		l.Printf("Stack of %d bytes: %s\n", count, trace)
+		panic(err)
+	}
 }

--- a/control/plugin/processor_proxy.go
+++ b/control/plugin/processor_proxy.go
@@ -25,6 +25,8 @@ type processorPluginProxy struct {
 }
 
 func (p *processorPluginProxy) GetConfigPolicyNode(args GetConfigPolicyNodeArgs, reply *GetConfigPolicyNodeReply) error {
+	defer catchPluginPanic(p.Session.Logger())
+
 	p.Session.Logger().Println("GetConfigPolicyNode called")
 	p.Session.ResetHeartbeat()
 
@@ -34,6 +36,8 @@ func (p *processorPluginProxy) GetConfigPolicyNode(args GetConfigPolicyNodeArgs,
 }
 
 func (p *processorPluginProxy) Process(args ProcessorArgs, reply *ProcessorReply) error {
+	defer catchPluginPanic(p.Session.Logger())
+
 	p.Session.Logger().Println("Processor called")
 	p.Session.ResetHeartbeat()
 

--- a/control/plugin/publisher_proxy.go
+++ b/control/plugin/publisher_proxy.go
@@ -30,6 +30,8 @@ type GetConfigPolicyNodeReply struct {
 }
 
 func (p *publisherPluginProxy) GetConfigPolicyNode(args GetConfigPolicyNodeArgs, reply *GetConfigPolicyNodeReply) error {
+	defer catchPluginPanic(p.Session.Logger())
+
 	p.Session.Logger().Println("GetConfigPolicyNode called")
 	p.Session.ResetHeartbeat()
 
@@ -39,6 +41,8 @@ func (p *publisherPluginProxy) GetConfigPolicyNode(args GetConfigPolicyNodeArgs,
 }
 
 func (p *publisherPluginProxy) Publish(args PublishArgs, reply *PublishReply) error {
+	defer catchPluginPanic(p.Session.Logger())
+
 	p.Session.Logger().Println("Publish called")
 	p.Session.ResetHeartbeat()
 


### PR DESCRIPTION
- Outputs the panic error string
- Outputs 4096 bytes of the runtime stack trace
