### PR TITLE
Fixes bad debug read

### DIFF
--- a/mgmt/rest/log_handler.go
+++ b/mgmt/rest/log_handler.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"io/ioutil"
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
@@ -20,29 +19,12 @@ func NewLogger() *Logger {
 
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	l.counter++
-	// For debug level we output more fields and request details including body
-	if log.GetLevel() == log.DebugLevel {
-		b, _ := ioutil.ReadAll(r.Body)
-		f := log.Fields{
-			"module": "mgmt-rest",
-			"index":  l.counter,
-			"method": r.Method,
-			"url":    r.URL.Path,
-			"body":   string(b),
-		}
-		for k, v := range r.Header {
-			f[k] = v
-		}
-		log.WithFields(f).Debug("API request")
-	} else {
-		log.WithFields(log.Fields{
-			"module": "mgmt-rest",
-			"index":  l.counter,
-			"method": r.Method,
-			"url":    r.URL.Path,
-		}).Info("API request")
-	}
-
+	log.WithFields(log.Fields{
+		"module": "mgmt-rest",
+		"index":  l.counter,
+		"method": r.Method,
+		"url":    r.URL.Path,
+	}).Info("API request")
 	next(rw, r)
 	res := rw.(negroni.ResponseWriter)
 	log.WithFields(log.Fields{


### PR DESCRIPTION
- I was reading the body of the http request this would mean it is empty later for the right hook.
- This removes the debug function period. Since we own the body conversion later after the read of the body, we should just debug log there instead.
