### PR TITLE
Update InfluxDB client code to version 0.9.0

### DIFF
--- a/plugin/publisher/pulse-publisher-influxdb/Godeps/Godeps.json
+++ b/plugin/publisher/pulse-publisher-influxdb/Godeps/Godeps.json
@@ -4,13 +4,13 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/influxdb/influxdb/client",
-			"Comment": "v0.9.0-rc28-61-g5bd53e5",
-			"Rev": "5bd53e54509f3caebc558125dd0f6802a85827c2"
+			"Comment": "v0.9.0",
+			"Rev": "471117ce5b308e59f8f247d8a88a52ead553b602"
 		},
 		{
 			"ImportPath": "github.com/influxdb/influxdb/influxql",
-			"Comment": "v0.9.0-rc28-61-g5bd53e5",
-			"Rev": "5bd53e54509f3caebc558125dd0f6802a85827c2"
+			"Comment": "v0.9.0",
+			"Rev": "471117ce5b308e59f8f247d8a88a52ead553b602"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/gomit",

--- a/plugin/publisher/pulse-publisher-influxdb/influx/influx.go
+++ b/plugin/publisher/pulse-publisher-influxdb/influx/influx.go
@@ -110,7 +110,7 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 	pts := make([]client.Point, len(metrics))
 	for i, m := range metrics {
 		pts[i] = client.Point{
-			Name: strings.Join(m.Namespace(), "/"),
+			Measurement: strings.Join(m.Namespace(), "/"),
 			Fields: map[string]interface{}{
 				"value": m.Data(),
 			},
@@ -118,7 +118,7 @@ func (f *influxPublisher) Publish(contentType string, content []byte, config map
 	}
 
 	bps := client.BatchPoints{
-		Timestamp:       time.Now(),
+		Time:            time.Now(),
 		Precision:       "s",
 		Points:          pts,
 		Database:        config["database"].(ctypes.ConfigValueStr).Value,


### PR DESCRIPTION
Update InfluxDB client code to version 0.9.0 from rc28 and update 'name' to 'measurement' and 'timestamp' to 'time' for changes between rc28 and official release.

https://github.com/influxdb/influxdb/issues/2108 
https://github.com/influxdb/influxdb/issues/2564
