### PR TITLE
Revert "Added control.go test coverage"

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -303,9 +303,6 @@ type mc struct {
 }
 
 func (m *mc) Fetch(ns []string) ([]*metricType, error) {
-	if m.e == 2 {
-		return nil, errors.New("test")
-	}
 	return nil, nil
 }
 
@@ -383,16 +380,12 @@ func TestSubscribeMetric(t *testing.T) {
 		mt := MockMetricType{namespace: []string{"intel", "dummy", "foo"}}
 		_, err := c.SubscribeMetricType(mt, cd)
 		So(err, ShouldBeNil)
-		me := c.MetricExists([]string{"intel", "dummy", "foo"}, 0)
-		So(me, ShouldBeTrue)
 	})
 	Convey("returns errors when metricCatalog.Subscribe() returns an error", t, func() {
 		cd := cdata.NewNode()
-		_, err0 := c.SubscribeMetricType(MockMetricType{}, cd) //Test .Get err!=nil
-		So(err0, ShouldNotBeNil)
 		mt := MockMetricType{namespace: []string{"intel", "dummy", "foo"}}
 		_, err := c.SubscribeMetricType(mt, cd)
-		So(err, ShouldNotBeEmpty) //Todo
+		So(err, ShouldNotBeEmpty)
 	})
 }
 
@@ -437,7 +430,7 @@ func TestUnsubscribeMetric(t *testing.T) {
 // }
 
 func TestExportedMetricCatalog(t *testing.T) {
-	Convey("MetricCatalog()", t, func() {
+	Convey(".MetricCatalog()", t, func() {
 		c := New()
 		lp := &loadedPlugin{}
 		mt := newMetricType([]string{"foo", "bar"}, time.Now(), lp)
@@ -448,12 +441,6 @@ func TestExportedMetricCatalog(t *testing.T) {
 			So(len(t), ShouldEqual, 1)
 			So(t[0].Namespace(), ShouldResemble, "/foo/bar")
 		})
-		Convey("If metric catalog fetch fails", func() {
-			c.metricCatalog = &mc{e: 2}
-			mts, err := c.MetricCatalog()
-			So(mts, ShouldBeEmpty)
-			So(err, ShouldNotBeNil)
-		})
 	})
 }
 
@@ -461,8 +448,9 @@ func TestMetricExists(t *testing.T) {
 	Convey("MetricExists()", t, func() {
 		c := New()
 		c.metricCatalog = &mc{}
-		me := c.MetricExists([]string{"hi"}, -1)
-		So(me, ShouldBeFalse)
+		So(c.MetricExists([]string{"hi"}, -1), ShouldEqual, false)
+		// c.metricCatalog.Next()
+		// So(c.MetricExists([]string{"hi"}, -1), ShouldEqual, true)
 	})
 }
 
@@ -529,21 +517,6 @@ func TestCollectMetrics(t *testing.T) {
 			// fmt.Printf(" *  Collect Response: %+v\n", cr)
 		}
 		time.Sleep(time.Millisecond * 500)
-		ap := c.AvailablePlugins()
-		So(ap, ShouldNotBeEmpty)
-	})
-
-	Convey("Pool", t, func() {
-		// adjust HB timeouts for test
-		plugin.PingTimeoutLimit = 1
-		plugin.PingTimeoutDurationDefault = time.Second * 1
-		// Create controller
-		c := New()
-		c.pluginRunner.(*runner).monitor.duration = time.Millisecond * 100
-		c.Start()
-		c.Load(PluginPath)
-		m := []core.Metric{}
-		c.CollectMetrics(m, time.Now().Add(time.Second*60))
 	})
 }
 
@@ -571,11 +544,6 @@ func TestPublishMetrics(t *testing.T) {
 		c.pluginRunner.(*runner).monitor.duration = time.Millisecond * 100
 		c.Start()
 
-		//Test lp==nil
-		config := map[string]ctypes.ConfigValue{}
-		errs := c.SubscribePublisher("file", 1, config)
-		So(errs, ShouldNotBeNil)
-
 		// Load plugin
 		_, err := c.Load(path.Join(PulsePath, "plugin", "publisher", "pulse-publisher-file"))
 		So(err, ShouldBeNil)
@@ -584,13 +552,6 @@ func TestPublishMetrics(t *testing.T) {
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "file")
 		So(lp.ConfigPolicyTree, ShouldNotBeNil)
-
-		Convey("Subscribe to file publisher with no config", func() {
-			config := map[string]ctypes.ConfigValue{}
-			errs := c.SubscribePublisher("file", 1, config)
-			So(errs, ShouldNotBeNil)
-			So(errs, ShouldNotBeEmpty)
-		})
 
 		Convey("Subscribe to file publisher with bad config", func() {
 			config := map[string]ctypes.ConfigValue{
@@ -620,92 +581,7 @@ func TestPublishMetrics(t *testing.T) {
 				contentType := plugin.PulseGOBContentType
 				errs := c.PublishMetrics(contentType, buf.Bytes(), "file", 1, config)
 				So(errs, ShouldBeNil)
-				ap := c.AvailablePlugins()
-				So(ap, ShouldNotBeEmpty)
 			})
-		})
-
-	})
-}
-func TestProcessMetrics(t *testing.T) {
-	Convey("Given an available file processor plugin", t, func() {
-		// adjust HB timeouts for test
-		plugin.PingTimeoutLimit = 1
-		plugin.PingTimeoutDurationDefault = time.Second * 1
-
-		// Create controller
-		c := New()
-		c.pluginRunner.(*runner).monitor.duration = time.Millisecond * 100
-		c.Start()
-
-		config := map[string]ctypes.ConfigValue{}
-		errs := c.SubscribeProcessor("file", 1, config)
-		So(errs, ShouldNotBeNil)
-
-		// Load plugin
-		err := c.Load(path.Join(PulsePath, "plugin", "processor", "pulse-processor-passthru"))
-		So(err, ShouldBeNil)
-		So(len(c.pluginManager.LoadedPlugins().Table()), ShouldEqual, 1)
-		lp, err := c.pluginManager.LoadedPlugins().Get(0)
-		So(err, ShouldBeNil)
-		So(lp.Name(), ShouldResemble, "passthru")
-		So(lp.ConfigPolicyTree, ShouldNotBeNil)
-
-		Convey("Subscribe to file processor with bad config", func() {
-			config := map[string]ctypes.ConfigValue{
-				"foo": ctypes.ConfigValueStr{Value: "bar"},
-			}
-			errs := c.SubscribeProcessor("passthru", 1, config)
-			So(errs, ShouldBeNil)
-			So(errs, ShouldBeEmpty)
-
-		})
-
-		Convey("Subscribe to file processor with good config", func() {
-			config := map[string]ctypes.ConfigValue{
-				"file": ctypes.ConfigValueStr{Value: "/tmp/pulse-TestProcessorMetrics.out"},
-			}
-			errs := c.SubscribeProcessor("passthru", 1, config)
-			So(errs, ShouldBeNil)
-			time.Sleep(1 * time.Second)
-
-			Convey("Publish to file", func() {
-				metrics := []plugin.PluginMetricType{
-					*plugin.NewPluginMetricType([]string{"foo"}, 1),
-				}
-				var buf bytes.Buffer
-				enc := gob.NewEncoder(&buf)
-				enc.Encode(metrics)
-				contentType := plugin.PulseGOBContentType
-				cnt, ct, errs := c.ProcessMetrics(contentType, buf.Bytes(), "passthru", 1, config)
-				fmt.Printf("%v %v", cnt, ct)
-				So(errs, ShouldBeNil)
-			})
-		})
-
-		Convey("Process Metrics", func() {
-			config := map[string]ctypes.ConfigValue{}
-			errs := c.SubscribeProcessor("passthru", 1, config)
-
-			So(errs, ShouldBeNil)
-			time.Sleep(1 * time.Second)
-
-			Convey("Publish to file", func() {
-				var buf bytes.Buffer
-				contentType := plugin.PulseGOBContentType
-				cnt, ct, errs := c.ProcessMetrics(contentType, buf.Bytes(), "passthru", 1, config)
-				fmt.Printf("%v %v", cnt, ct) //TODO
-				So(errs, ShouldBeNil)
-				ap := c.AvailablePlugins()
-				So(ap, ShouldNotBeEmpty)
-			})
-		})
-
-		Convey("Count()", func() {
-			pmt := &pluginMetricTypes{}
-			count := pmt.Count()
-			So(count, ShouldResemble, 0)
-
 		})
 
 	})


### PR DESCRIPTION
Reverts intelsdi-x/pulse#198

This was broken. Need to be fixed.
