### PR TITLE
Fix: proper parsing of flag, env, then default on pulse host connection

### DIFF
--- a/cmd/pulse-ctl/flags.go
+++ b/cmd/pulse-ctl/flags.go
@@ -6,7 +6,8 @@ var (
 	flURL = cli.StringFlag{
 		Name:   "url, u",
 		Usage:  "Sets the URL to use",
-		EnvVar: "PULSE_HOST",
+		EnvVar: "PULSE_URL",
+		Value:  "http://localhost:8181",
 	}
 	flRunning = cli.BoolFlag{
 		Name:  "running",

--- a/cmd/pulse-ctl/main.go
+++ b/cmd/pulse-ctl/main.go
@@ -21,24 +21,14 @@ func main() {
 	app.Version = gitversion
 	app.Usage = "A powerful telemetry agent framework"
 	app.Flags = []cli.Flag{flURL}
-	app.Action = mainFlags
-
-	// Parse main flags first
-	app.Run(os.Args)
-
-	// Add subcommands and reparse
 	app.Commands = commands
-	app.Run(os.Args)
-}
 
-func mainFlags(c *cli.Context) {
-	// Get url main flag
-	url := c.String("url")
-	// Fall back to a default value if flag and env var have not been provided
-	if url == "" {
-		url = "http://localhost:8181"
+	app.Before = func(c *cli.Context) error {
+		if pClient == nil {
+			pClient = client.New(c.GlobalString("url"), "")
+		}
+		return nil
 	}
-	if pClient == nil {
-		pClient = client.New(url, "")
-	}
+
+	app.Run(os.Args)
 }


### PR DESCRIPTION
The previous behavior did not honor the environment variables. It would take a flag or flip back to default.

This update makes the order of selection follow:
1. the `--url` flag
2. the `$PULSE_HOST` environmental flag
3. the default: `http://localhost:8181`

Note:

When subcommands are adding to a the cli app the main flags are not parsed for each subcommand function. This changes the main() to use two loops and package vars to store the client before the subcommand needs it.
