### PR TITLE
Added log messages for pulsed flag values for #258

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -115,7 +115,7 @@ func (a *availablePlugin) Stop(r string) error {
 		"_module": "control-aplugin",
 		"block":   "stop",
 		"aplugin": a,
-	}).Info("stoppping available plugin")
+	}).Info("stopping available plugin")
 	return a.Client.Kill(r)
 }
 

--- a/pulse.go
+++ b/pulse.go
@@ -88,6 +88,33 @@ func action(ctx *cli.Context) {
 	apiPort := ctx.Int("api-port")
 	autodiscoverPath := ctx.String("auto-discover")
 
+	var l = map[int]string{
+		1: "debug",
+		2: "info",
+		3: "warning",
+		4: "error",
+		5: "fatal",
+	}
+	log.Info("setting log level to: ", l[logLevel])
+	if logPath == "" {
+		log.Info("setting log path to: stdout")
+	} else {
+		log.Info("setting log path to: ", logPath)
+	}
+	log.Info("setting max procs to: ", maxProcs, " core(s)")
+	if disableApi == false {
+		log.Info("api is enabled")
+		log.Info("setting api port to: ", apiPort)
+	} else {
+		log.Info("api is disabled")
+	}
+	if autodiscoverPath == "" {
+		log.Info("auto discover path is disabled")
+	} else {
+		log.Info("auto discover path is enabled")
+		log.Info("autoloading plugins from: ", autodiscoverPath)
+	}
+
 	if logLevel < 1 || logLevel > 5 {
 		log.WithFields(
 			log.Fields{


### PR DESCRIPTION
Fix for #258 
I have it printing out even if you don't change the values from the default because 1. it can be useful for someone just running it without having to check the help. 2. With the default logging only warnings, a LOG message won't show. 

Let me know if you'd like this done differently.
