### PR TITLE
Adds support for selecting metrics by version

### DIFF
--- a/cmd/pulsectl/commands.go
+++ b/cmd/pulsectl/commands.go
@@ -97,6 +97,10 @@ var (
 					Name:   "list",
 					Usage:  "list",
 					Action: listMetrics,
+					Flags: []cli.Flag{
+						flMetricVersion,
+						flMetricNamespace,
+					},
 				},
 			},
 		},

--- a/cmd/pulsectl/flags.go
+++ b/cmd/pulsectl/flags.go
@@ -72,4 +72,14 @@ var (
 		Name:  "--no-start",
 		Usage: "Do not start task on creation [normally started on creation]",
 	}
+
+	// metric
+	flMetricVersion = cli.IntFlag{
+		Name:  "metric-version, v",
+		Usage: "The metric version",
+	}
+	flMetricNamespace = cli.StringFlag{
+		Name:  "metric-namespace, m",
+		Usage: "A metric namespace",
+	}
 )

--- a/cmd/pulsectl/metric.go
+++ b/cmd/pulsectl/metric.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -10,9 +12,23 @@ import (
 )
 
 func listMetrics(ctx *cli.Context) {
-	mts := pClient.GetMetricCatalog()
+	ns := ctx.String("metric-namespace")
+	ver := ctx.Int("metric-version")
+	if ns != "" {
+		//if the user doesn't provide '/*' we fix it
+		if ns[len(ns)-2:] != "/*" {
+			if ns[len(ns)-1:] == "/" {
+				ns = ns + "*"
+			} else {
+				ns = ns + "/*"
+			}
+		}
+	} else {
+		ns = "/*"
+	}
+	mts := pClient.FetchMetrics(ns, ver)
 	if mts.Err != nil {
-		fmt.Printf("Error getting metric catalog: %v", mts.Err)
+		fmt.Printf("Error getting metrics: %v\n", mts.Err)
 		os.Exit(1)
 	}
 
@@ -28,7 +44,24 @@ func listMetrics(ctx *cli.Context) {
 		for k, _ := range mt.Versions {
 			v = append(v, k)
 		}
-		printFields(w, false, 0, mt.Namespace, strings.Join(v, ","))
+		printFields(w, false, 0, mt.Namespace, strings.Join(sortVersions(v), ","))
 	}
 	w.Flush()
+}
+
+func sortVersions(vers []string) []string {
+	ivers := make([]int, len(vers))
+	svers := make([]string, len(vers))
+	var err error
+	for i, v := range vers {
+		if ivers[i], err = strconv.Atoi(v); err != nil {
+			fmt.Printf("Error metric version err: %v", err)
+			os.Exit(1)
+		}
+	}
+	sort.Ints(ivers)
+	for i, v := range ivers {
+		svers[i] = fmt.Sprintf("%d", v)
+	}
+	return svers
 }

--- a/control/control.go
+++ b/control/control.go
@@ -604,10 +604,10 @@ func (p *pluginControl) AvailablePlugins() []core.AvailablePlugin {
 }
 
 func (p *pluginControl) MetricCatalog() ([]core.CatalogedMetric, error) {
-	return p.FetchMetrics([]string{})
+	return p.FetchMetrics([]string{}, 0)
 }
 
-func (p *pluginControl) FetchMetrics(ns []string) ([]core.CatalogedMetric, error) {
+func (p *pluginControl) FetchMetrics(ns []string, version int) ([]core.CatalogedMetric, error) {
 	cat := make([]*metricCatalogItem, 0)
 
 	mts, err := p.metricCatalog.Fetch(ns)
@@ -617,6 +617,9 @@ func (p *pluginControl) FetchMetrics(ns []string) ([]core.CatalogedMetric, error
 
 	// probably can be serious optimized later
 	for _, mt := range mts {
+		if version > 0 && mt.Version() != version {
+			continue
+		}
 		f := false
 		for _, mci := range cat {
 			if mci.namespace == mt.NamespaceAsString() {

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -260,6 +260,43 @@ func TestPulseClient(t *testing.T) {
 				So(len(p.Catalog[1].Versions), ShouldEqual, 2)
 			})
 		})
+		Convey("FetchMetrics", func() {
+			Convey("leaf metric all versions", func() {
+				port := getPort()
+				uri := startAPI(port)
+				c := New(uri, "v1")
+
+				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
+				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
+				p := c.FetchMetrics("/intel/dummy/bar/*", 0)
+				So(p.Catalog[0].Namespace, ShouldEqual, "/intel/dummy/bar")
+				So(len(p.Catalog[0].Versions), ShouldEqual, 2)
+				So(len(p.Catalog), ShouldEqual, 1)
+			})
+			Convey("version 2 leaf metric", func() {
+				port := getPort()
+				uri := startAPI(port)
+				c := New(uri, "v1")
+
+				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
+				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
+				p := c.FetchMetrics("/intel/dummy/bar/*", 2)
+				So(p.Catalog[0].Namespace, ShouldEqual, "/intel/dummy/bar")
+				So(len(p.Catalog[0].Versions), ShouldEqual, 1)
+				So(len(p.Catalog), ShouldEqual, 1)
+			})
+			Convey("version 2 non-leaf metrics", func() {
+				port := getPort()
+				uri := startAPI(port)
+				c := New(uri, "v1")
+
+				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
+				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
+				p := c.FetchMetrics("/intel/dummy/*", 2)
+				So(len(p.Catalog[0].Versions), ShouldEqual, 1)
+				So(len(p.Catalog), ShouldEqual, 2)
+			})
+		})
 		Convey("CreateTask", func() {
 			Convey("invalid task (missing metric)", func() {
 				port := getPort()

--- a/mgmt/rest/metric.go
+++ b/mgmt/rest/metric.go
@@ -24,16 +24,6 @@ func (s *Server) getMetrics(w http.ResponseWriter, r *http.Request, _ httprouter
 func (s *Server) getMetricsFromTree(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	ns := parseNamespace(params.ByName("namespace"))
 
-	if ns[len(ns)-1] == "*" {
-		mets, err := s.mm.FetchMetrics(ns[:len(ns)-1])
-		if err != nil {
-			respond(404, rbody.FromError(err), w)
-			return
-		}
-		respondWithMetrics(mets, w)
-		return
-	}
-
 	var (
 		ver int
 		err error
@@ -49,6 +39,17 @@ func (s *Server) getMetricsFromTree(w http.ResponseWriter, r *http.Request, para
 			return
 		}
 	}
+
+	if ns[len(ns)-1] == "*" {
+		mets, err := s.mm.FetchMetrics(ns[:len(ns)-1], ver)
+		if err != nil {
+			respond(404, rbody.FromError(err), w)
+			return
+		}
+		respondWithMetrics(mets, w)
+		return
+	}
+
 	mt, err := s.mm.GetMetric(ns, ver)
 	if err != nil {
 		respond(404, rbody.FromError(err), w)

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -67,7 +67,7 @@ type APIResponseMeta struct {
 
 type managesMetrics interface {
 	MetricCatalog() ([]core.CatalogedMetric, error)
-	FetchMetrics([]string) ([]core.CatalogedMetric, error)
+	FetchMetrics([]string, int) ([]core.CatalogedMetric, error)
 	GetMetric([]string, int) (core.Metric, error)
 	Load(string) (core.CatalogedPlugin, perror.PulseError)
 	Unload(core.Plugin) (core.CatalogedPlugin, perror.PulseError)


### PR DESCRIPTION
closes #210

```
▶ go run cmd/pulsectl/*.go metric list -m /intel/dummy
NAMESPACE        VERSION
/intel/dummy/bar     1,2
/intel/dummy/foo     1,2

▶ go run cmd/pulsectl/*.go metric list -m /intel/dummy -v 1
NAMESPACE        VERSION
/intel/dummy/bar     1
/intel/dummy/foo     1
```
