### PR TITLE
Autoloading a plugin that fails to load will no longer quit daemon

### DIFF
--- a/pulse.go
+++ b/pulse.go
@@ -195,7 +195,7 @@ func action(ctx *cli.Context) {
 						"_module": "pulsed",
 						"logpath": path,
 						"plugin":  file,
-					}).Fatal(err)
+					}).Error(err)
 				} else {
 					log.WithFields(log.Fields{
 						"_block":         "main",


### PR DESCRIPTION
- fixes #289
