### PR TITLE
Add convenience method to publish without content type

### DIFF
--- a/control/plugin/publisher.go
+++ b/control/plugin/publisher.go
@@ -14,7 +14,11 @@ import (
 // Publisher plugin
 type PublisherPlugin interface {
 	Plugin
-	Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error
+	// Convenience method to publish without a content type
+	Publish(content []byte, config map[string]ctypes.ConfigValue) error
+	// Publishes data
+	PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error
+	// Gets config policy with required info that must be set
 	GetConfigPolicyNode() cpolicy.ConfigPolicyNode
 }
 

--- a/control/plugin/publisher_proxy.go
+++ b/control/plugin/publisher_proxy.go
@@ -43,7 +43,7 @@ func (p *publisherPluginProxy) GetConfigPolicyNode(args GetConfigPolicyNodeArgs,
 func (p *publisherPluginProxy) Publish(args PublishArgs, reply *PublishReply) error {
 	defer catchPluginPanic(p.Session.Logger())
 	p.Session.ResetHeartbeat()
-	err := p.Plugin.Publish(args.ContentType, args.Content, args.Config)
+	err := p.Plugin.PublishType(args.ContentType, args.Content, args.Config)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Publish call error: %v", err.Error()))
 	}

--- a/control/plugin/publisher_test.go
+++ b/control/plugin/publisher_test.go
@@ -17,7 +17,11 @@ type MockPublisher struct {
 	Meta PluginMeta
 }
 
-func (f *MockPublisher) Publish(_ string, _ []byte, _ map[string]ctypes.ConfigValue) error {
+func (m *MockPublisher) Publish(_ []byte, _ map[string]ctypes.ConfigValue) error {
+	return nil
+}
+
+func (f *MockPublisher) PublishType(_ string, _ []byte, _ map[string]ctypes.ConfigValue) error {
 	return nil
 }
 

--- a/plugin/publisher/pulse-publisher-file/file/file.go
+++ b/plugin/publisher/pulse-publisher-file/file/file.go
@@ -32,7 +32,13 @@ func NewFilePublisher() *filePublisher {
 	return &filePublisher{}
 }
 
-func (f *filePublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
+// Convenience method to publish without a content type
+func (f *filePublisher) Publish(content []byte, config map[string]ctypes.ConfigValue) error {
+	return f.PublishType("", content, config)
+}
+
+// Publish sends data to a file
+func (f *filePublisher) PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	logger := log.New()
 	logger.Println("Publishing started")
 	var metrics []plugin.PluginMetricType

--- a/plugin/publisher/pulse-publisher-file/file/file_test.go
+++ b/plugin/publisher/pulse-publisher-file/file/file_test.go
@@ -26,9 +26,9 @@ func TestFilePublish(t *testing.T) {
 		config["file"] = ctypes.ConfigValueStr{Value: "/tmp/pub.out"}
 		fp := NewFilePublisher()
 		So(fp, ShouldNotBeNil)
-		err := fp.Publish("", buf.Bytes(), config)
+		err := fp.Publish(buf.Bytes(), config)
 		So(err, ShouldResemble, errors.New("Unknown content type ''"))
-		err = fp.Publish(plugin.PulseGOBContentType, buf.Bytes(), config)
+		err = fp.PublishType(plugin.PulseGOBContentType, buf.Bytes(), config)
 		So(err, ShouldBeNil)
 		_, err = os.Stat(config["file"].(ctypes.ConfigValueStr).Value)
 		So(err, ShouldBeNil)

--- a/plugin/publisher/pulse-publisher-influxdb/influx/influx.go
+++ b/plugin/publisher/pulse-publisher-influxdb/influx/influx.go
@@ -36,7 +36,7 @@ func NewInfluxPublisher() *influxPublisher {
 type influxPublisher struct {
 }
 
-func (f *influxPublisher) GetConfigPolicyNode() cpolicy.ConfigPolicyNode {
+func (i *influxPublisher) GetConfigPolicyNode() cpolicy.ConfigPolicyNode {
 	config := cpolicy.NewPolicyNode()
 
 	r1, err := cpolicy.NewStringRule("host", true)
@@ -67,9 +67,14 @@ func (f *influxPublisher) GetConfigPolicyNode() cpolicy.ConfigPolicyNode {
 	return *config
 }
 
+// Convenience method to publish without a content type
+func (i *influxPublisher) Publish(content []byte, config map[string]ctypes.ConfigValue) error {
+	return i.PublishType("", content, config)
+}
+
 // Publish publishes metric data to influxdb
 // currently only 0.9 version of influxdb are supported
-func (f *influxPublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
+func (i *influxPublisher) PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	logger := log.New()
 	var metrics []plugin.PluginMetricType
 

--- a/plugin/publisher/pulse-publisher-influxdb/influx/influx_integration_test.go
+++ b/plugin/publisher/pulse-publisher-influxdb/influx/influx_integration_test.go
@@ -45,7 +45,7 @@ func TestInfluxPublish(t *testing.T) {
 			enc := gob.NewEncoder(&buf)
 			enc.Encode(metrics)
 			Convey("int", func() {
-				err := ip.Publish(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
+				err := ip.PublishType(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
 				So(err, ShouldBeNil)
 			})
 
@@ -56,7 +56,7 @@ func TestInfluxPublish(t *testing.T) {
 				buf.Reset()
 				enc = gob.NewEncoder(&buf)
 				enc.Encode(metrics)
-				err := ip.Publish(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
+				err := ip.PublishType(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
 				So(err, ShouldBeNil)
 			})
 
@@ -67,7 +67,7 @@ func TestInfluxPublish(t *testing.T) {
 				buf.Reset()
 				enc = gob.NewEncoder(&buf)
 				enc.Encode(metrics)
-				err := ip.Publish(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
+				err := ip.PublishType(plugin.ContentTypes[plugin.PulseGobContentType], buf.Bytes(), *cfg, log.New(os.Stdout, "influx_test", log.LstdFlags))
 				So(err, ShouldNotBeNil)
 				So(err, ShouldResemble, errors.New("Unsupported data type 'string'"))
 

--- a/plugin/publisher/pulse-publisher-kafka/kafka/kafka.go
+++ b/plugin/publisher/pulse-publisher-kafka/kafka/kafka.go
@@ -27,8 +27,13 @@ func NewKafkaPublisher() *Kafka {
 	return k
 }
 
+// Convenience method to publish without a content type
+func (k *Kafka) Publish(content []byte, config map[string]ctypes.ConfigValue) error {
+	return k.PublishType("", content, config)
+}
+
 // Publish sends data to a Kafka server
-func (k *Kafka) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
+func (k *Kafka) PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	topic := config["topic"].(ctypes.ConfigValueStr).Value
 	brokers := parseBrokerString(config["brokers"].(ctypes.ConfigValueStr).Value)
 	//

--- a/plugin/publisher/pulse-publisher-kafka/kafka/kafka_integration_test.go
+++ b/plugin/publisher/pulse-publisher-kafka/kafka/kafka_integration_test.go
@@ -48,9 +48,9 @@ func TestPublish(t *testing.T) {
 
 			// Send data to create topic. There is a weird bug where first message won't be consumed
 			// ref: http://mail-archives.apache.org/mod_mbox/kafka-users/201411.mbox/%3CCAHwHRrVmwyJg-1eyULkzwCUOXALuRA6BqcDV-ffSjEQ+tmT7dw@mail.gmail.com%3E
-			k.Publish("", []byte(t), *f)
+			k.Publish([]byte(t), *f)
 			// Send the same message. This will be consumed.
-			k.Publish("", []byte(t), *f)
+			k.Publish([]byte(t), *f)
 
 			// start timer and wait
 			m, mErr := consumer(topic, brokers)

--- a/plugin/publisher/pulse-publisher-rabbitmq/rmq/rmq.go
+++ b/plugin/publisher/pulse-publisher-rabbitmq/rmq/rmq.go
@@ -32,7 +32,13 @@ const (
 	pluginType = plugin.PublisherPluginType
 )
 
-func (rmq *rmqPublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
+// Convenience method to publish without a content type
+func (rmq *rmqPublisher) Publish(content []byte, config map[string]ctypes.ConfigValue) error {
+	return rmq.PublishType("", content, config)
+}
+
+// Publish sends data to a RabbitMQ server
+func (rmq *rmqPublisher) PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	logger := log.New()
 	var metrics []plugin.PluginMetricType
 	switch contentType {

--- a/plugin/publisher/pulse-publisher-rabbitmq/rmq/rmq_test.go
+++ b/plugin/publisher/pulse-publisher-rabbitmq/rmq/rmq_test.go
@@ -36,7 +36,7 @@ func TestPublish(t *testing.T) {
 			"exchange_type": ctypes.ConfigValueStr{Value: "fanout"},
 		}
 		logger := log.New(os.Stdout, "", log.LstdFlags)
-		err = rmqPub.Publish(plugin.PulseGOBContentType, data, config, logger)
+		err = rmqPub.PublishType(plugin.PulseGOBContentType, data, config, logger)
 		So(err, ShouldBeNil)
 		Convey("We can receive posted message", func() {
 			cKill := make(chan struct{})

--- a/plugin/publisher/pulse-publisher-riemann/riemann/riemann.go
+++ b/plugin/publisher/pulse-publisher-riemann/riemann/riemann.go
@@ -51,8 +51,13 @@ func (r *Riemann) GetConfigPolicyNode() cpolicy.ConfigPolicyNode {
 	return *config
 }
 
+// Convenience method to publish without a content type
+func (r *Riemann) Publish(content []byte, config map[string]ctypes.ConfigValue) error {
+	return r.PublishType("", content, config)
+}
+
 // Publish serializes the data and calls publish to send events to Riemann
-func (r *Riemann) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
+func (r *Riemann) PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	logger := log.New()
 	//err := r.publish(event, broker)
 	//return err

--- a/plugin/publisher/pulse-publisher-riemann/riemann/riemann_integration_test.go
+++ b/plugin/publisher/pulse-publisher-riemann/riemann/riemann_integration_test.go
@@ -41,7 +41,7 @@ func TestPublish(t *testing.T) {
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
 			enc.Encode(metrics)
-			err := r.Publish(plugin.PulseGOBContentType, buf.Bytes(), *f)
+			err := r.PublishType(plugin.PulseGOBContentType, buf.Bytes(), *f)
 			So(err, ShouldBeNil)
 
 			c, _ := raidman.Dial("tcp", broker)


### PR DESCRIPTION
This basically changes methods in publisher classes from
`Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue)` to `PublishType(contentType string, content []byte, config map[string]ctypes.ConfigValue)`.

It then adds a convenience method that uses an empty string as contentType:
`Publish(content []byte, config map[string]ctypes.ConfigValue)`

All files that use Publish have been updated by doing one of the following:
- adding the new method
- changing the interface declarations
- removing the empty string from all calls to Publish
- changing calls to Publish with a content type to PublishType

Running 'go test ./...' passes while in the directory $PULSE_PATH/../
