### PR TITLE
Feature: Add ability to cut Pulse release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,5 @@ pulse:
 install:
 	cp build/bin/pulsed /usr/local/bin/
 	cp build/bin/pulsectl /usr/local/bin/
+release:
+	bash -c "./scripts/release.sh $(TAG) $(RELEASE)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Update path in order for Godeps to function
+export PATH=$PATH:$GOPATH/bin
+
+REPO="intelsdi-x/pulse"
+
+# Collect release data before tagging repository if tag specified
+LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+COMPARISON="$LATEST_TAG..HEAD"
+CHANGELOG=`git log $COMPARISON --oneline --no-merges --reverse`
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+# Set GITVERSION that will be used in release. If tag specified during make release call,
+# then use that version and tag the repo so pulse version corresponds to tag.
+if [ -n "$1" ]; then
+	GITVERSION=$1
+	git tag -a $GITVERSION -m $GITVERSION
+else
+	GITVERSION=`git describe --always`
+fi
+
+if [ -n "$2" ];  then 
+	RELEASE=$2
+fi
+
+# Build Pulse for each OS and arch specified.
+# Currently support:
+#   - Darwin (Mac OS X) 64bit
+#   - Linux 64bit
+for GOOS in darwin linux; do
+	GOARCH=amd64
+	echo "Building Pulse ($GITVERSION) for $GOOS-$GOARCH"
+        export GOOS=$GOOS
+        export GOARCH=$GOARCH
+
+        make
+
+	echo "Preparing Pulse release $GITVERSION-$GOOS-$GOARCH"
+	ARCH_DIR=build/release/$GOOS-$GOARCH
+        RELEASE_DIR=$ARCH_DIR/pulse-$GITVERSION
+	DIST_DIR=build/release/dist/$GITVERSION
+        mkdir -p $RELEASE_DIR/{bin,plugin}
+	mkdir -p $DIST_DIR
+	cp build/bin/* $RELEASE_DIR/bin
+        cp build/plugin/* $RELEASE_DIR/plugin
+	tar czf $DIST_DIR/pulse-$GITVERSION-$GOOS-$GOARCH.tar.gz -C $ARCH_DIR pulse-$GITVERSION/bin/
+	tar czf $DIST_DIR/pulse-plugins-$GITVERSION-$GOOS-$GOARCH.tar.gz -C $ARCH_DIR pulse-$GITVERSION/plugin/
+done
+
+echo "Pushing Pulse release $GITVERSION"
+github-release $REPO $GITVERSION $BRANCH "**CHANGELOG**<br/>$CHANGELOG" "$DIST_DIR/*" $RELEASE 


### PR DESCRIPTION
This PR adds the ability for anyone on the team to push a release of Pulse to intelsdi-x/pulse. By running "make release", make will attempt to build Pulse on your machine for both Mac OS X (64bit) and Linux (64 bit). Thanks to golang compilers cross compilation feature, adding new targets will be trivial.

Is it simple? YES!

It's this simple: make release (TAG="tag for release") (RELEASE=prerelease)
e.g. To tag a release as version 0.2.0 and also set it as a prerelease, you would run the following.

```
make release TAG=0.2.0 RELEASE=prerelease
```

or to set the version to 1.0.0 and mark it as a release.

```
make release TAG=1.0.0
```

Both TAG and RELEASE are optional. If TAG is not set, the tag will be set to the output of git describe which is the last tag plus number of commits since tag plus last commit hash. If RELEASE is left off, then the release pushed to Github will be labeled as the latest release and not a prerelease.

How does it work?

When running the script, a new directory will be added under build titled "release". When a release is finished being built, you will see a direction structure as such

```
.
├── darwin-amd64
│   └── pulse-0.2.0-rc5
│       ├── bin
│       │   ├── pulsectl
│       │   └── pulsed
│       └── plugin
│           ├── pulse-collector-dummy1
│           ├── pulse-collector-dummy2
│           ├── pulse-collector-facter
│           ├── pulse-collector-pcm
│           ├── pulse-collector-psutil
│           ├── pulse-processor-movingaverage
│           ├── pulse-processor-passthru
│           ├── pulse-publisher-file
│           ├── pulse-publisher-influxdb
│           ├── pulse-publisher-kafka
│           ├── pulse-publisher-rabbitmq
│           └── pulse-publisher-riemann
├── dist
│   └── 0.2.0-rc5
│       ├── pulse-0.2.0-rc5-darwin-amd64.tar.gz
│       ├── pulse-0.2.0-rc5-linux-amd64.tar.gz
│       ├── pulse-plugins-0.2.0-rc5-darwin-amd64.tar.gz
│       └── pulse-plugins-0.2.0-rc5-linux-amd64.tar.gz
└── linux-amd64
    └── pulse-0.2.0-rc5
        ├── bin
        │   ├── pulsectl
        │   └── pulsed
        └── plugin
            ├── pulse-collector-dummy1
            ├── pulse-collector-dummy2
            ├── pulse-collector-facter
            ├── pulse-collector-pcm
            ├── pulse-collector-psutil
            ├── pulse-processor-movingaverage
            ├── pulse-processor-passthru
            ├── pulse-publisher-file
            ├── pulse-publisher-influxdb
            ├── pulse-publisher-kafka
            ├── pulse-publisher-rabbitmq
            └── pulse-publisher-riemann
```

After the build is completed, tar archives are created and compressed for both the Pulse binaries (pulsed, pulsectl) and the Pulse plugins. These binaries are uploaded to the releases page on Github for easy consumption. When it creates the github release, it will set the description to the current range of commits from last tag to tag we are just creating. See https://github.com/geauxvirtual/pulse/releases/tag/0.2.0-rc1 for example.

Requirements:

So how do you get this to work on your laptop (currently only tested from Mac OS X)?
1. brew install go --with-cc-all   (This will install go with cross compilation support on your laptop)
2. go get github.com/intelsdi-x/github-release (cd to this directory and run make install)
3. Configure an OAUTH token for your Github account (https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
4. Save your OAUTH token to whatever you use for passwords (I figured I should just point this out)
5. Create three ENV variables
    - GITHUB_TOKEN="OAUTH Token"
    - GITHUB_USER="your github user account"
    - GITHUB_REPO=pulse
6. Be on HEAD of master branch for pulse
7. You have current tags for pulse (git fetch --tags)

TODO (during BETA, not this PR):
- Support building rpm, deb, etc files
- Windows support (did I just type that?)
- Add more CYA to the release script
- Support naming releases so we can be like the cool kids.

ASSUMPTIONS: (huge right here)

First, I'm assuming you've read this far.
Second, THIS TOOL CURRENTLY ASSUMES YOU ARE ON THE MASTER BRANCH OF PULSE WHEN YOU RUN "make release TAG=x.y.z", AND THAT YOU HAVE PULLED DOWN ALL THE CURRENT TAGS. 

Thankfully, Github provides an easy way to delete a release should we not do it correctly (https://help.github.com/articles/editing-and-deleting-releases/#deleting-a-release).

If you're still reading, all this should probably go in a Wiki page.
