### PR TITLE
Added details for missing plugins and metrics for task loading for #301 and maybe #214

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -286,10 +286,9 @@ func (p *pluginControl) validatePluginSubscription(pl core.SubscribedPlugin) []p
 		"_block": "validate-plugin-subscription",
 		"plugin": fmt.Sprintf("%s:%d", pl.Name(), pl.Version()),
 	}).Info(fmt.Sprintf("validating dependencies for plugin %s:%d", pl.Name(), pl.Version()))
-
 	lp, err := p.pluginManager.get(fmt.Sprintf("%s:%s:%d", pl.TypeName(), pl.Name(), pl.Version()))
 	if err != nil {
-		pe := perror.New(ErrLoadedPluginNotFound)
+		pe := perror.New(errors.New(fmt.Sprintf("Plugin not found: type(%s) name(%s) version(%d)", pl.TypeName(), pl.Name(), pl.Version())))
 		pe.SetFields(map[string]interface{}{
 			"name":    pl.Name(),
 			"version": pl.Version(),
@@ -803,7 +802,7 @@ func groupMetricTypesByPlugin(cat catalogsMetrics, metricTypes []core.Metric) (m
 		}
 		// if loaded plugin is nil, we have failed.  return error
 		if lp == nil {
-			return nil, errors.New(fmt.Sprintf("Metric missing: %s", strings.Join(mt.Namespace(), "/")))
+			return nil, errors.New(fmt.Sprintf("Metric not found: %s", strings.Join(mt.Namespace(), "/")))
 		}
 
 		key := lp.Key()

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -430,19 +430,19 @@ func (m *mc) Get(ns []string, ver int) (*metricType, error) {
 			policy: &mockCDProc{},
 		}, nil
 	}
-	return nil, errMetricNotFound
+	return nil, errorMetricNotFound(ns)
 }
 
 func (m *mc) Subscribe(ns []string, ver int) error {
 	if ns[0] == "nf" {
-		return errMetricNotFound
+		return errorMetricNotFound(ns)
 	}
 	return nil
 }
 
 func (m *mc) Unsubscribe(ns []string, ver int) error {
 	if ns[0] == "nf" {
-		return errMetricNotFound
+		return errorMetricNotFound(ns)
 	}
 	if ns[0] == "neg" {
 		return errNegativeSubCount

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -18,6 +18,10 @@ var (
 	errNegativeSubCount = errors.New("subscription count cannot be < 0")
 )
 
+func errorMetricNotFound(ns []string) error {
+	return errors.New(fmt.Sprintf("Metric not found: %s", strings.Join(ns, "/")))
+}
+
 type metricCatalogItem struct {
 	namespace string
 	versions  map[int]core.Metric
@@ -251,7 +255,7 @@ func (mc *metricCatalog) get(ns []string, ver int) (*metricType, error) {
 		if ver >= 0 {
 			l, err := getVersion(mts, ver)
 			if err != nil {
-				return nil, err
+				return nil, errorMetricNotFound(ns)
 			}
 			return l, nil
 		}

--- a/control/metrics_test.go
+++ b/control/metrics_test.go
@@ -1,7 +1,6 @@
 package control
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -121,7 +120,7 @@ func TestMetricCatalog(t *testing.T) {
 			m35 := newMetricType([]string{"foo", "bar"}, ts, lp35)
 			mc.Add(m35)
 			_, err := mc.Get([]string{"foo", "bar"}, 7)
-			So(err, ShouldResemble, errMetricNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"foo", "bar"}))
 		})
 
 	})
@@ -144,7 +143,7 @@ func TestMetricCatalog(t *testing.T) {
 			mc.Remove(ns)
 			_mt, err := mc.Get(ns, -1)
 			So(_mt, ShouldBeNil)
-			So(err, ShouldResemble, errors.New("metric not found"))
+			So(err, ShouldResemble, errorMetricNotFound([]string{"test"}))
 		})
 	})
 	Convey("metricCatalog.Next()", t, func() {
@@ -222,7 +221,7 @@ func TestSubscribe(t *testing.T) {
 	Convey("when the metric is not in the table", t, func() {
 		Convey("then it returns an error", func() {
 			err := mc.Subscribe([]string{"test4"}, -1)
-			So(err, ShouldResemble, errMetricNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"test4"}))
 		})
 	})
 	Convey("when the metric is in the table", t, func() {
@@ -267,7 +266,7 @@ func TestUnsubscribe(t *testing.T) {
 	Convey("when the metric is not in the table", t, func() {
 		Convey("then it returns metric not found error", func() {
 			err := mc.Unsubscribe([]string{"test4"}, -1)
-			So(err, ShouldResemble, errMetricNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"test4"}))
 		})
 	})
 	Convey("when the metric's count is already 0", t, func() {

--- a/control/mttrie.go
+++ b/control/mttrie.go
@@ -173,7 +173,7 @@ func (mtt *mttNode) Get(ns []string) ([]*metricType, error) {
 		return nil, err
 	}
 	if node.mts == nil {
-		return nil, ErrNotFound
+		return nil, errorMetricNotFound(ns)
 	}
 	var mts []*metricType
 	for _, mt := range node.mts {
@@ -203,7 +203,7 @@ func (mtt *mttNode) walk(ns []string) (*mttNode, int) {
 func (mtt *mttNode) find(ns []string) (*mttNode, error) {
 	node, index := mtt.walk(ns)
 	if index != len(ns) {
-		return nil, ErrNotFound
+		return nil, errorMetricNotFound(ns)
 	}
 	return node, nil
 }

--- a/control/mttrie_test.go
+++ b/control/mttrie_test.go
@@ -84,7 +84,7 @@ func TestTrie(t *testing.T) {
 		Convey("Fetch with error: not found", func() {
 			_, err := trie.Fetch([]string{"not", "present"})
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, ErrNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"not", "present"}))
 		})
 		Convey("Fetch with error: depth exceeded", func() {
 			lp := new(loadedPlugin)
@@ -93,7 +93,7 @@ func TestTrie(t *testing.T) {
 			trie.Add(mt)
 			_, err := trie.Fetch([]string{"intel", "foo", "bar", "baz"})
 			So(err, ShouldNotBeNil)
-			So(err, ShouldResemble, ErrNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"intel", "foo", "bar", "baz"}))
 		})
 	})
 	Convey("Get", t, func() {
@@ -115,7 +115,7 @@ func TestTrie(t *testing.T) {
 			trie.Add(mt)
 			n, err := trie.Get([]string{"intel"})
 			So(n, ShouldBeNil)
-			So(err, ShouldEqual, ErrNotFound)
+			So(err, ShouldResemble, errorMetricNotFound([]string{"intel"}))
 		})
 	})
 }

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -308,7 +308,7 @@ func TestPulseClient(t *testing.T) {
 
 				p := c.CreateTask(sch, wf, "baron", true)
 				So(p.Err, ShouldNotBeNil)
-				So(p.Err.Error(), ShouldEqual, "metric not found")
+				So(p.Err.Error(), ShouldResemble, "Metric not found: intel/dummy/foo")
 			})
 			Convey("invalid task (missing publisher)", func() {
 				port := getPort()
@@ -322,7 +322,7 @@ func TestPulseClient(t *testing.T) {
 
 				p := c.CreateTask(sch, wf, "baron", false)
 				So(p.Err, ShouldNotBeNil)
-				So(p.Err.Error(), ShouldEqual, "Loaded plugin not found")
+				So(p.Err.Error(), ShouldEqual, "Plugin not found: type(publisher) name(riemann) version(1)")
 			})
 			Convey("valid task", func() {
 				port := getPort()

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -786,7 +786,7 @@ func TestPluginRestCalls(t *testing.T) {
 				r := createTask("1.json", "foo", "1s", true, port)
 				So(r.Body, ShouldHaveSameTypeAs, new(rbody.Error))
 				plr := r.Body.(*rbody.Error)
-				So(plr.ErrorMessage, ShouldEqual, "metric not found")
+				So(plr.ErrorMessage, ShouldEqual, "Metric not found: intel/dummy/foo")
 			})
 
 			Convey("create task works when plugins are loaded", func() {


### PR DESCRIPTION
This addresses PR #301. Not sure if it fully addresses #214 though since I couldn't get the same output.

`pulsectl task create -t cmd/pulsectl/sample/psutil-file.json`                              

```
Using task manifest to create task
Error creating task:
Metric not found: psutil/load/load1
```

`pulsectl plugin load build/plugin/pulse-collector-psutil`

```
Using task manifest to create task
Error creating task:
Plugin not found: type(processor) name(passthru) version(1)
```

`pulsectl plugin load build/plugin/pulse-processor-passthru`

```
Using task manifest to create task
Error creating task:
Plugin not found: type(publisher) name(file) version(1)
```
