### PR TITLE
rethinking concurrency count and addition of exclusivity

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -90,8 +90,16 @@ type catalogsMetrics interface {
 	GetPlugin([]string, int) (*loadedPlugin, error)
 }
 
+type controlOpt func(*pluginControl)
+
+func MaxRunningPlugins(m int) controlOpt {
+	return func(c *pluginControl) {
+		maximumRunningPlugins = m
+	}
+}
+
 // New returns a new pluginControl instance
-func New() *pluginControl {
+func New(opts ...controlOpt) *pluginControl {
 
 	c := &pluginControl{}
 	// Initialize components
@@ -135,6 +143,14 @@ func New() *pluginControl {
 	err := c.pluginRunner.Start()
 	if err != nil {
 		panic(err)
+	}
+
+	// apply options
+
+	// it is important that this happens last, as an option may
+	// require that an internal member of c be constructed.
+	for _, opt := range opts {
+		opt(c)
 	}
 
 	return c

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -77,9 +77,11 @@ type PluginMeta struct {
 	// Return content types in priority order
 	// This is only really valid on processors
 	ReturnedContentTypes []string
-	// the max number of running instances this plugin
-	// is capable of running concurrently
+	// the max number of subscriptions this plugin
+	// can handle
 	ConcurrencyCount int
+	// should always only be one instance of this plugin running
+	Exclusive bool
 }
 
 type metaOp func(m *PluginMeta)
@@ -87,6 +89,12 @@ type metaOp func(m *PluginMeta)
 func ConcurrencyCount(cc int) metaOp {
 	return func(m *PluginMeta) {
 		m.ConcurrencyCount = cc
+	}
+}
+
+func Exclusive(e bool) metaOp {
+	return func(m *PluginMeta) {
+		m.Exclusive = e
 	}
 }
 
@@ -122,6 +130,9 @@ func NewPluginMeta(name string, version int, pluginType PluginType, acceptConten
 		Type:                 pluginType,
 		AcceptedContentTypes: acceptContentTypes,
 		ReturnedContentTypes: returnContentTypes,
+
+		//set the default for concurrency count to 1
+		ConcurrencyCount: 1,
 	}
 
 	for _, opt := range opts {

--- a/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
+++ b/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
@@ -54,5 +54,5 @@ func (f *Dummy) GetConfigPolicyTree() (cpolicy.ConfigPolicyTree, error) {
 
 //Meta returns meta data for testing
 func Meta() *plugin.PluginMeta {
-	return plugin.NewPluginMeta(Name, Version, Type, []string{plugin.PulseGOBContentType}, []string{plugin.PulseGOBContentType}, plugin.ConcurrencyCount(1))
+	return plugin.NewPluginMeta(Name, Version, Type, []string{plugin.PulseGOBContentType}, []string{plugin.PulseGOBContentType})
 }


### PR DESCRIPTION
Concurrency count is actually the number of subscriptions an instance of
a plugin can handle.  This commit corrects the previous behavior.  Also
added is plugin exclusivity.  I.e., only one instance of a given loaded
plugin should ever be running.
