### PR TITLE
Updated README for pulsectl command

### DIFF
--- a/cmd/pulsectl/README.md
+++ b/cmd/pulsectl/README.md
@@ -1,4 +1,4 @@
-# pulsectl 
+# pulsectl
 A powerful telemetry agent framework
 
 ## Usage
@@ -49,7 +49,7 @@ Example Usage
 Start pulse with the REST interface enabled
 
 ```
-$PULSE_PATH/bin/pulsed 
+$PULSE_PATH/bin/pulsed
 ```
 
 1. load a collector plugin
@@ -68,8 +68,7 @@ $PULSE_PATH/bin/pulsectl plugin load $PULSE_PATH/plugin/pulse-processor-passthru
 $PULSE_PATH/bin/pulsectl plugin load $PULSE_PATH/plugin/pulse-publisher-influxdb
 $PULSE_PATH/bin/pulsectl plugin load $PULSE_PATH/plugin/pulse-publisher-file
 $PULSE_PATH/bin/pulsectl plugin list
-$PULSE_PATH/bin/pulsectl task create $PULSE_PATH/../cmd/pulsectl/sample/psutil-influx.json
-$PULSE_PATH/bin/pulsectl task start 1
+$PULSE_PATH/bin/pulsectl task create -t $PULSE_PATH/../cmd/pulsectl/sample/psutil-influx.json
 $PULSE_PATH/bin/pulsectl task list
 $PULSE_PATH/bin/pulsectl plugin unload -n psutil -v 1
 ```


### PR DESCRIPTION
Minor changes.

When creating task, there is obligatory value, that needs to be added '-t' or '-w'.
In case of our example, we have to add '-t' to be able, to load sample task.
Also, there is unnecessary step, to start task, because task is already running.
