### PR TITLE
FIX: Add back code to actually set GOMAXPROCS

### DIFF
--- a/pulse.go
+++ b/pulse.go
@@ -287,6 +287,7 @@ func setMaxProcs(maxProcs int) {
 	}
 
 	log.Info("setting GOMAXPROCS to: ", _maxProcs, " core(s)")
+	runtime.GOMAXPROCS(_maxProcs)
 	//Verify setting worked
 	actualNumProcs := runtime.GOMAXPROCS(0)
 	if actualNumProcs != _maxProcs {


### PR DESCRIPTION
Some how between testing and merging code, I removed the line that actually set GOMAXPROCS and was missed in previous PR that supposedly fixed setting GOMAXPROCS.
