### PR TITLE
adds source and time to a collected metric

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -555,7 +555,15 @@ func (m MockMetricType) Namespace() []string {
 	return m.namespace
 }
 
+func (m MockMetricType) Source() string {
+	return ""
+}
+
 func (m MockMetricType) LastAdvertisedTime() time.Time {
+	return time.Now()
+}
+
+func (m MockMetricType) Timestamp() time.Time {
 	return time.Now()
 }
 
@@ -701,7 +709,7 @@ func TestPublishMetrics(t *testing.T) {
 
 			Convey("Publish to file", func() {
 				metrics := []plugin.PluginMetricType{
-					*plugin.NewPluginMetricType([]string{"foo"}, 1),
+					*plugin.NewPluginMetricType([]string{"foo"}, time.Now(), "", 1),
 				}
 				var buf bytes.Buffer
 				enc := gob.NewEncoder(&buf)
@@ -753,7 +761,7 @@ func TestProcessMetrics(t *testing.T) {
 
 			Convey("process metrics", func() {
 				metrics := []plugin.PluginMetricType{
-					*plugin.NewPluginMetricType([]string{"foo"}, 1),
+					*plugin.NewPluginMetricType([]string{"foo"}, time.Now(), "", 1),
 				}
 				var buf bytes.Buffer
 				enc := gob.NewEncoder(&buf)

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -44,6 +44,8 @@ type metricType struct {
 	policy             processesConfigData
 	config             *cdata.ConfigDataNode
 	data               interface{}
+	source             string
+	timestamp          time.Time
 }
 
 type processesConfigData interface {
@@ -107,6 +109,14 @@ func (m *metricType) Version() int {
 
 func (m *metricType) Config() *cdata.ConfigDataNode {
 	return m.config
+}
+
+func (m *metricType) Source() string {
+	return m.source
+}
+
+func (m *metricType) Timestamp() time.Time {
+	return m.timestamp
 }
 
 type metricCatalog struct {

--- a/control/plugin/client/httpjsonrpc_test.go
+++ b/control/plugin/client/httpjsonrpc_test.go
@@ -29,7 +29,7 @@ type mockProxy struct {
 func (m *mockProxy) CollectMetrics(args plugin.CollectMetricsArgs, reply *plugin.CollectMetricsReply) error {
 	rand.Seed(time.Now().Unix())
 	for _, i := range args.PluginMetricTypes {
-		p := plugin.NewPluginMetricType(i.Namespace(), rand.Intn(100))
+		p := plugin.NewPluginMetricType(i.Namespace(), time.Now(), "", rand.Intn(100))
 		p.Config_ = i.Config()
 		reply.PluginMetrics = append(reply.PluginMetrics, *p)
 	}
@@ -310,7 +310,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 			})
 
 			Convey("Process metrics", func() {
-				pmt := plugin.NewPluginMetricType([]string{"foo", "bar"}, 1)
+				pmt := plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1)
 				b, _ := json.Marshal([]plugin.PluginMetricType{*pmt})
 				contentType, content, err := p.Process(plugin.PulseJSONContentType, b, nil)
 				So(contentType, ShouldResemble, plugin.PulseJSONContentType)
@@ -355,7 +355,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 			})
 
 			Convey("Publish metrics", func() {
-				pmt := plugin.NewPluginMetricType([]string{"foo", "bar"}, 1)
+				pmt := plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1)
 				b, _ := json.Marshal([]plugin.PluginMetricType{*pmt})
 				err := p.Publish(plugin.PulseJSONContentType, b, nil)
 				So(err, ShouldBeNil)

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -16,8 +16,8 @@ type mockPlugin struct {
 }
 
 var mockPluginMetricType []PluginMetricType = []PluginMetricType{
-	*NewPluginMetricType([]string{"foo", "bar"}, 1),
-	*NewPluginMetricType([]string{"foo", "baz"}, 2),
+	*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+	*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", 2),
 }
 
 func (p *mockPlugin) GetMetricTypes() ([]PluginMetricType, error) {

--- a/control/plugin/metric.go
+++ b/control/plugin/metric.go
@@ -29,18 +29,35 @@ const (
 // Represents a metric type. Only used within plugins and across plugin calls.
 // Converted to core.MetricType before being used within modules.
 type PluginMetricType struct {
-	Namespace_          []string              `json:"namespace"`
-	LastAdvertisedTime_ time.Time             `json:"last_advertised_time"`
-	Version_            int                   `json:"version"`
-	Config_             *cdata.ConfigDataNode `json:"config"`
-	Data_               interface{}           `json:"data"`
+	// Namespace is the identifier for a metric.
+	Namespace_ []string `json:"namespace"`
+
+	// Last advertised time is the last time the Pulse agent was told about
+	// a metric.
+	LastAdvertisedTime_ time.Time `json:"last_advertised_time"`
+
+	// The metric version. It is bound to the Plugin version.
+	Version_ int `json:"version"`
+
+	// The config data needed to collect a metric.
+	Config_ *cdata.ConfigDataNode `json:"config"`
+
+	Data_ interface{} `json:"data"`
+
+	// The source of the metric (host, IP, etc).
+	Source_ string `json:"source"`
+
+	// The timestamp from when the metric was created.
+	Timestamp_ time.Time `json:"timestamp"`
 }
 
 // // PluginMetricType Constructor
-func NewPluginMetricType(namespace []string, data interface{}) *PluginMetricType {
+func NewPluginMetricType(namespace []string, timestamp time.Time, source string, data interface{}) *PluginMetricType {
 	return &PluginMetricType{
 		Namespace_: namespace,
 		Data_:      data,
+		Timestamp_: timestamp,
+		Source_:    source,
 	}
 }
 
@@ -62,6 +79,16 @@ func (p PluginMetricType) Version() int {
 // Config returns the map of config data for this metric
 func (p PluginMetricType) Config() *cdata.ConfigDataNode {
 	return p.Config_
+}
+
+// returns the timestamp of when the metric was collected
+func (p PluginMetricType) Timestamp() time.Time {
+	return p.Timestamp_
+}
+
+// returns the source of the metric
+func (p PluginMetricType) Source() string {
+	return p.Source_
 }
 
 func (p PluginMetricType) Data() interface{} {

--- a/control/plugin/metric_test.go
+++ b/control/plugin/metric_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/intelsdi-x/pulse/core/cdata"
 	"github.com/intelsdi-x/pulse/core/ctypes"
@@ -12,8 +13,8 @@ import (
 func TestMetric(t *testing.T) {
 	Convey("error on invalid pulse content type", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, 2),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", 2),
 		}
 		a, c, e := MarshalPluginMetricTypes("foo", m)
 		m[0].Version_ = 1
@@ -41,8 +42,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using pulse.* default to pulse.gob", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.*", m)
 		So(e, ShouldBeNil)
@@ -63,8 +64,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using pulse.gob", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.gob", m)
 		So(e, ShouldBeNil)
@@ -91,8 +92,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using pulse.json", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.json", m)
 		So(e, ShouldBeNil)
@@ -119,8 +120,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("error on unmarshall using bad content type", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.json", m)
 		So(e, ShouldBeNil)
@@ -136,8 +137,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from pulse.gob to pulse.json", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.gob", m)
 		So(e, ShouldBeNil)
@@ -160,8 +161,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from pulse.json to pulse.*", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.json", m)
 		So(e, ShouldBeNil)
@@ -184,8 +185,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from pulse.json to pulse.gob", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.json", m)
 		So(e, ShouldBeNil)
@@ -208,8 +209,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("error on bad content type to swap", t, func() {
 		m := []PluginMetricType{
-			*NewPluginMetricType([]string{"foo", "bar"}, 1),
-			*NewPluginMetricType([]string{"foo", "baz"}, "2"),
+			*NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", 1),
+			*NewPluginMetricType([]string{"foo", "baz"}, time.Now(), "", "2"),
 		}
 		a, c, e := MarshalPluginMetricTypes("pulse.json", m)
 		So(e, ShouldBeNil)

--- a/core/metric.go
+++ b/core/metric.go
@@ -12,6 +12,8 @@ type Metric interface {
 	LastAdvertisedTime() time.Time
 	Config() *cdata.ConfigDataNode
 	Data() interface{}
+	Source() string
+	Timestamp() time.Time
 }
 
 // RequestedMetric is a metric requested for collection

--- a/mgmt/rest/rbody/task.go
+++ b/mgmt/rest/rbody/task.go
@@ -219,4 +219,6 @@ func (s *StreamedTaskEvent) ToJSON() string {
 type StreamedMetric struct {
 	Namespace string      `json:"namespace"`
 	Data      interface{} `json:"data"`
+	Source    string      `json:"source"`
+	Timestamp time.Time   `json:"timestamp"`
 }

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -322,6 +322,8 @@ func (t *TaskWatchHandler) CatchCollection(m []core.Metric) {
 		sm[i] = rbody.StreamedMetric{
 			Namespace: joinNamespace(m[i].Namespace()),
 			Data:      m[i].Data(),
+			Source:    m[i].Source(),
+			Timestamp: m[i].Timestamp(),
 		}
 	}
 	t.mChan <- rbody.StreamedTaskEvent{

--- a/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
+++ b/plugin/collector/pulse-collector-dummy1/dummy/dummy.go
@@ -2,6 +2,8 @@ package dummy
 
 import (
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/intelsdi-x/pulse/control/plugin"
 	"github.com/intelsdi-x/pulse/control/plugin/cpolicy"
@@ -28,7 +30,9 @@ func (f *Dummy) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMe
 		metrics[i] = plugin.PluginMetricType{
 			Namespace_: p.Namespace(),
 			Data_:      data,
+			Timestamp_: time.Now(),
 		}
+		metrics[i].Source_, _ = os.Hostname()
 	}
 	return metrics, nil
 }

--- a/plugin/collector/pulse-collector-facter/facter/facter.go
+++ b/plugin/collector/pulse-collector-facter/facter/facter.go
@@ -25,6 +25,7 @@ package facter
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -146,11 +147,12 @@ func (f *Facter) CollectMetrics(metricTypes []plugin.PluginMetricType) ([]plugin
 		return nil, errors.New("assertion: getFacts returns more/less than asked!")
 	}
 
+	host, _ := os.Hostname()
 	// convert facts into PluginMetrics
 	metrics := make([]plugin.PluginMetricType, 0, len(facts))
 	for name, value := range facts {
 		namespace := createNamespace(name)
-		metric := *plugin.NewPluginMetricType(namespace, value)
+		metric := *plugin.NewPluginMetricType(namespace, time.Now(), host, value)
 		metrics = append(metrics, metric)
 	}
 	return metrics, nil

--- a/plugin/processor/pulse-processor-movingaverage/movingaverage/movingaverage_test.go
+++ b/plugin/processor/pulse-processor-movingaverage/movingaverage/movingaverage_test.go
@@ -29,7 +29,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 				time.Sleep(3)
 				rand.Seed(time.Now().UTC().UnixNano())
 				data := randInt(65, 90)
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, data)
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", data)
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
@@ -53,7 +53,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 				time.Sleep(3)
 				rand.Seed(time.Now().UTC().UnixNano())
 				data := randInt(65, 90)
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, float32(data))
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", float32(data))
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
@@ -76,7 +76,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 				time.Sleep(3)
 				rand.Seed(time.Now().UTC().UnixNano())
 				data := randInt(65, 90)
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, float64(data))
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", float64(data))
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
@@ -100,7 +100,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 				time.Sleep(3)
 				rand.Seed(time.Now().UTC().UnixNano())
 				data := randInt(65, 90)
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, uint32(data))
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", uint32(data))
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
@@ -123,7 +123,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 				time.Sleep(3)
 				rand.Seed(time.Now().UTC().UnixNano())
 				data := randInt(65, 90)
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, uint64(data))
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", uint64(data))
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)
@@ -145,7 +145,7 @@ func TestMovingAverageProcessorMetrics(t *testing.T) {
 			for i, _ := range metrics {
 
 				data := "I am an unknow data Type"
-				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, data)
+				metrics[i] = *plugin.NewPluginMetricType([]string{"foo", "bar"}, time.Now(), "", data)
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)

--- a/plugin/publisher/pulse-publisher-file/file/file_test.go
+++ b/plugin/publisher/pulse-publisher-file/file/file_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/intelsdi-x/pulse/control/plugin"
 	"github.com/intelsdi-x/pulse/core/ctypes"
@@ -16,7 +17,7 @@ import (
 func TestFilePublish(t *testing.T) {
 	var buf bytes.Buffer
 	metrics := []plugin.PluginMetricType{
-		*plugin.NewPluginMetricType([]string{"foo"}, 99),
+		*plugin.NewPluginMetricType([]string{"foo"}, time.Now(), "", 99),
 	}
 	config := make(map[string]ctypes.ConfigValue)
 	enc := gob.NewEncoder(&buf)

--- a/plugin/publisher/pulse-publisher-mysql/mysql/mysql_test.go
+++ b/plugin/publisher/pulse-publisher-mysql/mysql/mysql_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/intelsdi-x/pulse/control/plugin"
 	"github.com/intelsdi-x/pulse/core/ctypes"
@@ -15,11 +16,11 @@ import (
 func TestMySQLPublish(t *testing.T) {
 	var buf bytes.Buffer
 	metrics := []plugin.PluginMetricType{
-		*plugin.NewPluginMetricType([]string{"test_string"}, "example_string"),
-		*plugin.NewPluginMetricType([]string{"test_int"}, 1),
-		*plugin.NewPluginMetricType([]string{"test_string_slice"}, []string{"str1", "str2"}),
-		*plugin.NewPluginMetricType([]string{"test_string_slice"}, []int{1, 2}),
-		*plugin.NewPluginMetricType([]string{"test_uint8"}, uint8(1)),
+		*plugin.NewPluginMetricType([]string{"test_string"}, time.Now(), "", "example_string"),
+		*plugin.NewPluginMetricType([]string{"test_int"}, time.Now(), "", 1),
+		*plugin.NewPluginMetricType([]string{"test_string_slice"}, time.Now(), "", []string{"str1", "str2"}),
+		*plugin.NewPluginMetricType([]string{"test_string_slice"}, time.Now(), "", []int{1, 2}),
+		*plugin.NewPluginMetricType([]string{"test_uint8"}, time.Now(), "", uint8(1)),
 	}
 	config := make(map[string]ctypes.ConfigValue)
 	enc := gob.NewEncoder(&buf)

--- a/plugin/publisher/pulse-publisher-riemann/riemann/riemann_integration_test.go
+++ b/plugin/publisher/pulse-publisher-riemann/riemann/riemann_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/intelsdi-x/pulse/control/plugin"
 	"github.com/intelsdi-x/pulse/control/plugin/cpolicy"
@@ -36,7 +37,7 @@ func TestPublish(t *testing.T) {
 			So(getProcessErrorStr(cErr), ShouldEqual, "")
 
 			metrics := []plugin.PluginMetricType{
-				*plugin.NewPluginMetricType([]string{"intel", "cpu", "temp"}, 100),
+				*plugin.NewPluginMetricType([]string{"intel", "cpu", "temp"}, time.Now(), "", 100),
 			}
 			var buf bytes.Buffer
 			enc := gob.NewEncoder(&buf)

--- a/scheduler/job.go
+++ b/scheduler/job.go
@@ -114,6 +114,8 @@ func (m *metric) Version() int {
 
 func (m *metric) Data() interface{}             { return nil }
 func (m *metric) LastAdvertisedTime() time.Time { return time.Unix(0, 0) }
+func (m *metric) Source() string                { return "" }
+func (m *metric) Timestamp() time.Time          { return time.Unix(0, 0) }
 
 func (c *collectorJob) Run() {
 	log.WithFields(log.Fields{
@@ -154,7 +156,6 @@ func (c *collectorJob) Run() {
 	c.replchan <- struct{}{}
 }
 
-//todo rename to processJob
 type processJob struct {
 	*coreJob
 	processor     processesMetrics
@@ -200,7 +201,7 @@ func (p *processJob) Run() {
 		case plugin.PulseGOBContentType:
 			metrics := make([]plugin.PluginMetricType, len(p.parentJob.(*collectorJob).metrics))
 			for i, m := range p.parentJob.(*collectorJob).metrics {
-				metrics[i] = *plugin.NewPluginMetricType(m.Namespace(), m.Data())
+				metrics[i] = *plugin.NewPluginMetricType(m.Namespace(), m.Timestamp(), m.Source(), m.Data())
 			}
 			enc.Encode(metrics)
 			_, content, errs := p.processor.ProcessMetrics(p.contentType, buf.Bytes(), p.pluginName, p.pluginVersion, p.config)
@@ -290,7 +291,7 @@ func (p *publisherJob) Run() {
 		case plugin.PulseGOBContentType:
 			metrics := make([]plugin.PluginMetricType, len(p.parentJob.(*collectorJob).metrics))
 			for i, m := range p.parentJob.(*collectorJob).metrics {
-				metrics[i] = *plugin.NewPluginMetricType(m.Namespace(), m.Data())
+				metrics[i] = *plugin.NewPluginMetricType(m.Namespace(), m.Timestamp(), m.Source(), m.Data())
 			}
 			enc.Encode(metrics)
 			errs := p.publisher.PublishMetrics(p.contentType, buf.Bytes(), p.pluginName, p.pluginVersion, p.config)


### PR DESCRIPTION
This commit also contains some clean up on the UI in pulsectl for task
watching.  Now watching will redraw the metrics in place as opposed to
scrolling down in a log-like fashion.
