### PR TITLE
Smart plugin

### DIFF
--- a/plugin/collector/pulse-collector-smart/main.go
+++ b/plugin/collector/pulse-collector-smart/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/plugin/collector/pulse-collector-smart/smart"
+)
+
+func main() {
+
+	smartCollector := &smart.SmartCollector{}
+
+	plugin.Start(plugin.NewPluginMeta(smart.Name, smart.Version, smart.Type, []string{}, []string{plugin.PulseGOBContentType}, plugin.ConcurrencyCount(1)),
+		smartCollector,
+		os.Args[1],
+	)
+}

--- a/plugin/collector/pulse-collector-smart/main_test.go
+++ b/plugin/collector/pulse-collector-smart/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/intelsdi-x/pulse/control"
+	"github.com/intelsdi-x/pulse/plugin/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	PluginName = "pulse-collector-smart"
+	PluginType = "collector"
+	PulsePath  = os.Getenv("PULSE_PATH")
+	PluginPath = path.Join(PulsePath, "plugin", PluginName)
+)
+
+func TestPluginLoads(t *testing.T) {
+	// These tests only work if PULSE_PATH is known.
+	// It is the responsibility of the testing framework to
+	// build the plugins first into the build dir.
+	if PulsePath != "" {
+		// Helper plugin trigger build if possible for this plugin
+		helper.BuildPlugin(PluginType, PluginName)
+		//
+		Convey("ensure plugin loads and responds", t, func() {
+			c := control.New()
+			c.Start()
+			_, err := c.Load(PluginPath)
+
+			So(err, ShouldBeNil)
+		})
+	} else {
+		fmt.Printf("PULSE_PATH not set. Cannot test %s plugin.\n", PluginName)
+	}
+}
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/collector/pulse-collector-smart/smart/plugin.go
+++ b/plugin/collector/pulse-collector-smart/smart/plugin.go
@@ -1,0 +1,122 @@
+package smart
+
+import (
+	"errors"
+	"fmt"
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/control/plugin/cpolicy"
+	"strings"
+)
+
+const (
+	Name    = "pulse-collector-smart"
+	Version = 1
+	Type    = plugin.CollectorPluginType
+)
+
+var sysUtilProvider SysutilProvider = NewSysutilProvider()
+
+var namespace_prefix = []string{"intel", "disk"}
+var namespace_suffix = []string{"smart"}
+
+func makeName(device, metric string) []string {
+	splited := strings.Split(metric, "/")
+
+	name := []string{}
+	name = append(name, namespace_prefix...)
+	name = append(name, device)
+	name = append(name, namespace_suffix...)
+	name = append(name, splited...)
+
+	return name
+}
+
+func parseName(namespace []string) (disk, attribute string) {
+	disk = namespace[len(namespace_prefix)]
+	smart_namespace := namespace[len(namespace_prefix)+len(namespace_suffix)+1:]
+	attribute = strings.Join(smart_namespace, "/")
+	return
+}
+
+func validateName(namespace []string) bool {
+	for i, v := range namespace_prefix {
+		if namespace[i] != v {
+			return false
+		}
+	}
+
+	offset := len(namespace_prefix) + 1
+	for i, v := range namespace_suffix {
+		if namespace[offset+i] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+type SmartCollector struct {
+}
+
+type smartResults map[string]interface{}
+
+// CollectMetrics returns metrics from smart
+func (sc *SmartCollector) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	buffered_results := map[string]smartResults{}
+
+	results := make([]plugin.PluginMetricType, len(mts))
+
+	for i, mt := range mts {
+		if !validateName(mt.Namespace()) {
+			return nil, errors.New(fmt.Sprintf("%v is not valid metric", mt.Namespace()))
+		}
+		disk, attribute_path := parseName(mt.Namespace())
+		buffered, ok := buffered_results[disk]
+		if !ok {
+			values, err := ReadSmartData(disk, sysUtilProvider)
+			if err != nil {
+				return nil, err
+			}
+			buffered = values.GetAttributes()
+			buffered_results[disk] = buffered
+		}
+
+		attribute, ok := buffered[attribute_path]
+
+		if !ok {
+			return nil, errors.New("Unknown attribute " + attribute_path)
+		}
+
+		results[i] = plugin.PluginMetricType{
+			Namespace_: mt.Namespace(),
+			Data_:      attribute,
+		}
+	}
+
+	return results, nil
+}
+
+// GetMetricTypes returns the metric types exposed by smart
+func (sc *SmartCollector) GetMetricTypes() ([]plugin.PluginMetricType, error) {
+	smart_metrics := ListAllKeys()
+	devices, err := sysUtilProvider.ListDevices()
+	if err != nil {
+		return nil, err
+	}
+	mts := make([]plugin.PluginMetricType, 0, len(smart_metrics)*len(devices))
+
+	for _, device := range devices {
+		for _, metric := range smart_metrics {
+			path := makeName(device, metric)
+			mts = append(mts, plugin.PluginMetricType{Namespace_: path})
+		}
+	}
+
+	return mts, nil
+}
+
+//GetConfigPolicy returns a ConfigPolicy
+func (p *SmartCollector) GetConfigPolicy() (cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	return *c, nil
+}

--- a/plugin/collector/pulse-collector-smart/smart/plugin_test.go
+++ b/plugin/collector/pulse-collector-smart/smart/plugin_test.go
@@ -1,0 +1,314 @@
+package smart
+
+import (
+	"errors"
+	"github.com/intelsdi-x/pulse/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"strings"
+	"testing"
+)
+
+type fakeSysutilProvider2 struct {
+	FillBuf []byte
+}
+
+func (s *fakeSysutilProvider2) ListDevices() ([]string, error) {
+	return []string{"DEV_ONE", "DEV_TWO"}, nil
+}
+
+func (s *fakeSysutilProvider2) OpenDevice(device string) (*os.File, error) {
+	return nil, nil
+}
+
+func (s *fakeSysutilProvider2) Ioctl(fd uintptr, cmd uint, buf []byte) error {
+	if cmd == smart_read_values {
+		for i, v := range s.FillBuf {
+			buf[i] = v
+		}
+	}
+	return nil
+}
+
+func sysUtilWithMetrics(metrics []byte) fakeSysutilProvider2 {
+	util := fakeSysutilProvider2{FillBuf: make([]byte, 512)}
+
+	for i, m := range metrics {
+		util.FillBuf[2+i*12] = m
+	}
+
+	return util
+}
+
+func TestGetMetricTypes(t *testing.T) {
+	Convey("When having two devices with known smart attribute", t, func() {
+
+		Convey("And system lets you to list devices", func() {
+			provider := &fakeSysutilProvider2{}
+
+			orgProvider := sysUtilProvider
+			sysUtilProvider = provider
+
+			collector := SmartCollector{}
+
+			Convey("Both devices should be present in metric list", func() {
+
+				dev_one, dev_two := false, false
+				metrics, _ := collector.GetMetricTypes()
+
+				for _, m := range metrics {
+					switch m.Namespace()[2] {
+					case "DEV_ONE":
+						dev_one = true
+					case "DEV_TWO":
+						dev_two = true
+					}
+				}
+
+				So(dev_one, ShouldBeTrue)
+				So(dev_two, ShouldBeTrue)
+
+			})
+
+			Reset(func() {
+				sysUtilProvider = orgProvider
+			})
+
+		})
+
+	})
+
+}
+
+func TestParseName(t *testing.T) {
+	Convey("When given correct namespace refering to single word attribute", t, func() {
+
+		disk, attr := parseName([]string{"intel", "disk", "DEV", "smart", "abc"})
+
+		Convey("Device should be correctly extracted", func() {
+
+			So(disk, ShouldEqual, "DEV")
+
+		})
+
+		Convey("Attribute should be correctly extracted", func() {
+
+			So(attr, ShouldEqual, "abc")
+
+		})
+
+	})
+
+	Convey("When given correct namespace refering to multi level attribute", t, func() {
+
+		disk, attr := parseName([]string{"intel", "disk", "DEV", "smart",
+			"abc", "def"})
+
+		Convey("Device should be correctly extracted", func() {
+
+			So(disk, ShouldEqual, "DEV")
+
+		})
+
+		Convey("Attribute should be correctly extracted", func() {
+
+			So(attr, ShouldEqual, "abc/def")
+
+		})
+
+	})
+
+}
+
+func TestValidateName(t *testing.T) {
+	Convey("When given namespace with invalid prefix", t, func() {
+
+		test := validateName([]string{"intel", "cake", "DEV", "smart",
+			"abc", "def"})
+
+		Convey("Validation should fail", func() {
+
+			So(test, ShouldBeFalse)
+
+		})
+
+	})
+
+	Convey("When given namespace with invalid suffix", t, func() {
+
+		test := validateName([]string{"intel", "disk", "DEV", "dumb",
+			"abc", "def"})
+
+		Convey("Validation should fail", func() {
+
+			So(test, ShouldBeFalse)
+
+		})
+
+	})
+
+	Convey("When given correct namespace refering to single word attribute", t, func() {
+
+		test := validateName([]string{"intel", "disk", "DEV", "smart", "abc"})
+
+		Convey("Validation should pass", func() {
+
+			So(test, ShouldBeTrue)
+
+		})
+
+	})
+
+	Convey("When given correct namespace refering to multi level attribute", t, func() {
+
+		test := validateName([]string{"intel", "disk", "DEV", "smart",
+			"abc", "def"})
+		Convey("Validation should pass", func() {
+
+			So(test, ShouldBeTrue)
+
+		})
+
+	})
+}
+
+func TestCollectMetrics(t *testing.T) {
+	Convey("Using fake system", t, func() {
+
+		orgReader := ReadSmartData
+		orgProvider := sysUtilProvider
+
+		sc := SmartCollector{}
+
+		metric_id, metric_name := firstKnownMetric()
+		metric_ns := strings.Split(metric_name, "/")
+
+		Convey("When asked about metric not in valid namespace", func() {
+
+			_, err := sc.CollectMetrics([]plugin.PluginMetricType{
+				{Namespace_: []string{"cake"}}})
+
+			Convey("Returns error", func() {
+
+				So(err, ShouldNotBeNil)
+
+				Convey("Error is about invalid metric", func() {
+
+					So(err.Error(), ShouldContainSubstring, "not valid")
+
+				})
+
+			})
+
+		})
+
+		Convey("When asked about metric in valid namespace but unknown to reader", func() {
+
+			ReadSmartData = func(device string,
+				sysutilProvider SysutilProvider) (*SmartValues, error) {
+				return &SmartValues{}, nil
+			}
+
+			_, err := sc.CollectMetrics([]plugin.PluginMetricType{
+				{Namespace_: []string{"intel", "disk", "x", "smart", "y"}}})
+
+			Convey("Returns error", func() {
+
+				So(err, ShouldNotBeNil)
+
+				Convey("Error is about unknown metric", func() {
+
+					So(err.Error(), ShouldContainSubstring, "Unknown")
+
+				})
+
+			})
+
+		})
+
+		Convey("When asked about metric in valid namespace but reading fails", func() {
+
+			ReadSmartData = func(device string,
+				sysutilProvider SysutilProvider) (*SmartValues, error) {
+				return nil, errors.New("Something")
+			}
+
+			_, err := sc.CollectMetrics([]plugin.PluginMetricType{
+				{Namespace_: []string{"intel", "disk", "x", "smart", "y"}}})
+
+			Convey("Returns error", func() {
+
+				So(err, ShouldNotBeNil)
+
+			})
+
+		})
+
+		Convey("When asked about metric in valid namespace", func() {
+
+			drive_asked := ""
+
+			ReadSmartData = func(device string,
+				sysutilProvider SysutilProvider) (*SmartValues, error) {
+				drive_asked = device
+
+				result := SmartValues{}
+				result.Values[0].Id = metric_id
+
+				return &result, nil
+			}
+
+			metrics, _ := sc.CollectMetrics([]plugin.PluginMetricType{
+				{Namespace_: append([]string{"intel", "disk", "x", "smart"},
+					metric_ns...)}})
+
+			Convey("Asks reader to read metric from correct drive", func() {
+
+				So(drive_asked, ShouldEqual, "x")
+
+				Convey("Returns value of metric from reader", func() {
+					So(len(metrics), ShouldBeGreaterThan, 0)
+
+					//TODO: Value is correct
+
+				})
+
+			})
+
+		})
+
+		Convey("When asked about metrics in valid namespaces", func() {
+
+			asked := map[string]int{"x": 0, "y": 0}
+
+			ReadSmartData = func(device string,
+				sysutilProvider SysutilProvider) (*SmartValues, error) {
+				asked[device]++
+
+				result := SmartValues{}
+				result.Values[0].Id = metric_id
+
+				return &result, nil
+			}
+			sc.CollectMetrics([]plugin.PluginMetricType{
+				{Namespace_: append([]string{"intel", "disk", "x", "smart"}, metric_ns...)},
+				{Namespace_: append([]string{"intel", "disk", "y", "smart"}, metric_ns...)},
+				{Namespace_: append([]string{"intel", "disk", "y", "smart"}, metric_ns...)},
+				{Namespace_: append([]string{"intel", "disk", "x", "smart"}, metric_ns...)},
+			})
+
+			Convey("Reader is asked once per drive", func() {
+				So(asked["x"], ShouldEqual, 1)
+				So(asked["y"], ShouldEqual, 1)
+
+			})
+
+		})
+
+		Reset(func() {
+			sysUtilProvider = orgProvider
+			ReadSmartData = orgReader
+		})
+
+	})
+}

--- a/plugin/collector/pulse-collector-smart/smart/smart.go
+++ b/plugin/collector/pulse-collector-smart/smart/smart.go
@@ -1,0 +1,272 @@
+package smart
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unicode"
+	"unsafe"
+)
+
+const (
+	hdio_drive_cmd        = 0x031f
+	win_smart             = 0xb0
+	smart_read_values     = 0xd0
+	smart_read_thresholds = 0xd1
+	smart_enable          = 0xd8
+	nr_attributes         = 30
+)
+
+type AttributeFormat int
+
+// Supported formats of attribute's raw data.
+const (
+	FormatDefault AttributeFormat = iota
+	FormatTemperature
+	FormatPLPF
+	FormatFP1024
+	FormatTTS
+)
+
+type Attribute struct {
+	Name   string
+	Format AttributeFormat
+}
+
+// Connects attribute ID with its label and format of raw data.
+var AttributeMap = map[byte]Attribute{
+	0x05: {"reallocatedsectors", FormatDefault},
+	0x09: {"poweronhours", FormatDefault},
+	0x0c: {"powercyclecount", FormatDefault},
+	0xaa: {"availablereservedspace", FormatDefault},
+	0xab: {"programfailcount", FormatDefault},
+	0xac: {"erasefailcount", FormatDefault},
+	0xae: {"unexpectedpowerloss", FormatDefault},
+	0xaf: {"powerlossprotectionfailure", FormatPLPF},
+	0xb7: {"satadownshifts", FormatDefault},
+	0xb8: {"e2eerrors", FormatDefault},
+	0xbb: {"uncorrectableerrors", FormatDefault},
+	0xbe: {"casetemperature", FormatTemperature},
+	0xc0: {"unsafeshutdowns", FormatDefault},
+	0xc2: {"internaltemperature", FormatDefault},
+	0xc5: {"pendingsectors", FormatDefault},
+	0xc7: {"crcerrors", FormatDefault},
+	0xe1: {"hostwrites", FormatDefault},
+	0xe2: {"timedworkload/mediawear", FormatFP1024},
+	0xe3: {"timedworkload/readpercent", FormatDefault},
+	0xe4: {"timedworkload/time", FormatDefault},
+	0xe8: {"reservedblocks", FormatDefault},
+	0xe9: {"wearout", FormatDefault},
+	0xeA: {"thermalthrottle", FormatTTS},
+	0xf1: {"totallba/written", FormatDefault},
+	0xf2: {"totallba/read", FormatDefault},
+}
+
+// Data format for single attribute.
+type SmartValue struct {
+	Id     byte
+	Status int16
+	Data   byte
+	Vendor [8]byte
+}
+
+// Data format for smart binary data.
+type SmartValues struct {
+	Revision          int16
+	Values            [nr_attributes]SmartValue
+	OfflineStatus     byte
+	Vendor1           byte
+	OfflineTimeout    int16
+	Vendor2           byte
+	OfflineCapability byte
+	SmartCapability   int16
+	Reserved          [16]byte
+	Vendor            [125]byte
+	Checksum          byte
+}
+
+// ReadSmartData_ enables SMART on device and retrieves binary data from it.
+// It returns data casted to appropriate Go structure.
+func ReadSmartData_(device string, sysutilProvider SysutilProvider) (*SmartValues, error) {
+	f, err := sysutilProvider.OpenDevice(device)
+	if err != nil {
+		return nil, errors.New(device + ": Can't open device")
+	}
+	defer f.Close()
+
+	if err := enableSmart(f.Fd(), sysutilProvider); err != nil {
+		return nil, errors.New(fmt.Sprintf("%s: %s", device, err))
+	}
+
+	buf := make([]byte, 4+512)
+	buf[0] = win_smart
+	buf[1] = 0
+	buf[2] = smart_read_values
+	buf[3] = 1
+
+	if err := sysutilProvider.Ioctl(f.Fd(), hdio_drive_cmd, buf); err != nil {
+		return nil, errors.New(fmt.Sprintf(
+			"%s: S.M.A.R.T Reading failed, error = %v", device, err))
+	}
+
+	values := SmartValues{}
+	smart_data := bytes.NewBuffer(buf[4:])
+	binary.Read(smart_data, binary.LittleEndian, &values)
+
+	return &values, nil
+}
+
+func enableSmart(fd uintptr, sysutilProvider SysutilProvider) error {
+	buf := make([]byte, 4+512)
+	buf[0] = win_smart
+	buf[1] = 0
+	buf[2] = smart_enable
+	buf[3] = 0
+	e := sysutilProvider.Ioctl(fd, hdio_drive_cmd, buf)
+	if e != nil {
+		return errors.New("Can't enable S.M.A.R.T")
+	}
+	return nil
+}
+
+// Parses 8 bytes of raw data in a way specific to this format.
+// It returns map of values. Main value is accessible using empty string.
+// Additional values are accessible using "/[additonal value]"
+func (a AttributeFormat) ParseRaw(data [8]byte) map[string]interface{} {
+	switch a {
+	case FormatDefault:
+		return map[string]interface{}{"": uint64(data[1]) + uint64(data[2])<<8 +
+			uint64(data[3])<<16 + uint64(data[4])<<24 +
+			uint64(data[5])<<32 + uint64(data[5])<<40}
+	case FormatFP1024:
+		return map[string]interface{}{"": float64(uint64(data[1])+uint64(data[2])<<8+
+			uint64(data[3])<<16+uint64(data[4])<<24+
+			uint64(data[5])<<32+uint64(data[5])<<40) / 1024}
+	case FormatPLPF:
+		return map[string]interface{}{"": uint64(data[1]) + uint64(data[2])<<8,
+			"/sincelast": uint64(data[3]) + uint64(data[4])<<8,
+			"/tests":     uint64(data[5]) + uint64(data[6])<<8}
+	case FormatTemperature:
+		return map[string]interface{}{"": uint64(data[1]) + uint64(data[2])<<8,
+			"/min": uint64(data[3]), "/max": uint64(data[4]),
+			"/overcounter": uint64(data[5]) + uint64(data[6])<<8,
+		}
+	case FormatTTS:
+		return map[string]interface{}{"": uint64(data[1]),
+			"/eventcount": uint64(data[2]) + uint64(data[3])<<8 +
+				uint64(data[4])<<16 + uint64(data[5])<<24,
+		}
+	}
+
+	return nil
+}
+
+// Introduced to make mocking possible. See ReadSmartData_.
+var ReadSmartData = ReadSmartData_
+
+// GetKeys returns list of keys that can be used to access parsed values
+// of particular format.
+func (a AttributeFormat) GetKeys() []string {
+	ret := []string{}
+	switch a {
+	case FormatPLPF:
+		ret = []string{"/sincelast", "/tests"}
+	case FormatTemperature:
+		ret = []string{"/min", "/max", "/overcounter"}
+	case FormatTTS:
+		ret = []string{"/eventcount"}
+	}
+	return append([]string{"", "/normalized"}, ret...)
+}
+
+// GetAttributes transforms smart data structure to map containing attributes'
+// values. Main value is accessed using label.
+// Additional values are accessed using "[label]/[additonal value]".
+func (sv SmartValues) GetAttributes() map[string]interface{} {
+	ret_val := map[string]interface{}{}
+	for i := 0; i < nr_attributes; i++ {
+		a, ok := AttributeMap[sv.Values[i].Id]
+		if ok {
+			ret_val[a.Name+"/normalized"] = sv.Values[i].Data
+			attrib_content := a.Format.ParseRaw(sv.Values[i].Vendor)
+			for k, v := range attrib_content {
+				ret_val[a.Name+k] = v
+			}
+		}
+	}
+	return ret_val
+}
+
+// Returns list of keys that can be used to access all values of all formats.
+// Which is cross product of attributes' label and (sub)value keys.
+func ListAllKeys() []string {
+	keys := []string{}
+	for _, v := range AttributeMap {
+		for _, f := range v.Format.GetKeys() {
+			keys = append(keys, v.Name+f)
+		}
+	}
+
+	return keys
+}
+
+// Represents OS abstraction layer, currently used for mocking.
+type SysutilProvider interface {
+	OpenDevice(device string) (*os.File, error)
+	Ioctl(fd uintptr, cmd uint, buf []byte) error
+	ListDevices() ([]string, error)
+}
+
+type sysutilProviderLinux struct {
+}
+
+func (s *sysutilProviderLinux) OpenDevice(device string) (*os.File, error) {
+	f, err := os.OpenFile("/dev/"+device, os.O_RDWR, 0)
+	return f, err
+}
+
+func (s *sysutilProviderLinux) Ioctl(fd uintptr, cmd uint, buf []byte) error {
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(cmd), ptr)
+
+	if e != 0 {
+		return e
+	}
+
+	return nil
+}
+
+func (s *sysutilProviderLinux) ListDevices() ([]string, error) {
+	result := []string{}
+
+	f, err := os.Open("/proc/partitions")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scan := bufio.NewScanner(f)
+	for scan.Scan() {
+		if len(scan.Text()) < 1 {
+			continue
+		}
+
+		table := strings.Fields(scan.Text())
+		if table[0] == "8" && strings.IndexFunc(table[3], unicode.IsDigit) < 0 {
+			result = append(result, table[3])
+		}
+
+	}
+
+	return result, nil
+
+}
+
+func NewSysutilProvider() SysutilProvider {
+	return &sysutilProviderLinux{}
+}

--- a/plugin/collector/pulse-collector-smart/smart/smart_test.go
+++ b/plugin/collector/pulse-collector-smart/smart/smart_test.go
@@ -1,0 +1,267 @@
+package smart
+
+import (
+	"errors"
+	"fmt"
+	. "github.com/smartystreets/goconvey/convey"
+	"os"
+	"strings"
+	"testing"
+)
+
+type IoctlArgsType struct {
+	fd  uintptr
+	cmd uint
+	buf []byte
+}
+
+type OpenDeviceRetType struct {
+	f *os.File
+	e error
+}
+
+type fakeSysutilProvider struct {
+	OpenDeviceArg []string
+	IoctlArgs     []IoctlArgsType
+
+	OpenDeviceRet OpenDeviceRetType
+	IoctlRets     []error
+
+	FillBuf []byte
+}
+
+func (s *fakeSysutilProvider) ListDevices() ([]string, error) {
+	return []string{"DEV_ONE", "DEV_TWO"}, nil
+}
+
+func (s *fakeSysutilProvider) OpenDevice(device string) (*os.File, error) {
+	s.OpenDeviceArg = append(s.OpenDeviceArg, device)
+
+	return s.OpenDeviceRet.f, s.OpenDeviceRet.e
+}
+
+func (s *fakeSysutilProvider) Ioctl(fd uintptr, cmd uint, buf []byte) error {
+	i := len(s.IoctlArgs)
+	s.IoctlArgs = append(s.IoctlArgs, IoctlArgsType{fd, cmd, buf})
+
+	//if
+
+	return s.IoctlRets[i]
+}
+
+func firstKnownMetric() (byte, string) {
+	for k, v := range AttributeMap {
+		if !strings.Contains(v.Name, "/") {
+			continue
+		}
+		return k, v.Name
+	}
+
+	panic("no attributes")
+}
+
+func TestSmartReader(t *testing.T) {
+
+	Convey("Reading from smart capable device", t, func() {
+
+		provider := &fakeSysutilProvider{OpenDeviceRet: OpenDeviceRetType{nil, nil},
+			IoctlRets: []error{nil, nil}}
+		_, err := ReadSmartData("MYDEV", provider)
+
+		Convey("Should call OpenDevice from abstraction layer", func() {
+
+			So(len(provider.OpenDeviceArg), ShouldEqual, 1)
+
+		})
+
+		Convey("Should call Ioctl twice", func() {
+
+			So(provider.OpenDeviceArg[0], ShouldEqual, "MYDEV")
+
+		})
+
+		Convey("Should return no error", func() {
+
+			So(err, ShouldBeNil)
+
+		})
+
+	})
+
+	Convey("When it fails to open device during reading", t, func() {
+
+		provider := &fakeSysutilProvider{OpenDeviceRet: OpenDeviceRetType{nil,
+			errors.New("Something")},
+			IoctlRets: []error{nil, nil}}
+		_, err := ReadSmartData("MYDEV", provider)
+
+		Convey("Should not call any ioctls", func() {
+
+			So(len(provider.IoctlArgs), ShouldEqual, 0)
+
+		})
+
+		Convey("Should report error", func() {
+
+			So(err, ShouldNotBeNil)
+
+			Convey("Error should be about opening", func() {
+
+				So(err.Error(), ShouldContainSubstring, "open")
+
+			})
+
+		})
+
+	})
+
+	Convey("When smart cannot be enabled during reading", t, func() {
+
+		provider := &fakeSysutilProvider{OpenDeviceRet: OpenDeviceRetType{nil, nil},
+			IoctlRets: []error{errors.New("Something"), nil}}
+		_, err := ReadSmartData("MYDEV", provider)
+
+		Convey("Should call ioctl once", func() {
+
+			So(len(provider.IoctlArgs), ShouldEqual, 1)
+
+		})
+
+		Convey("Should report error", func() {
+
+			So(err, ShouldNotBeNil)
+
+			Convey("Error should be about enabling smart", func() {
+
+				So(err.Error(), ShouldContainSubstring, "enable")
+
+			})
+
+		})
+
+	})
+
+	Convey("When device fails during reading but not during smart enabling phase",
+		t, func() {
+
+			provider := &fakeSysutilProvider{OpenDeviceRet: OpenDeviceRetType{nil, nil},
+				IoctlRets: []error{nil, errors.New("Something else")}}
+			_, err := ReadSmartData("MYDEV", provider)
+
+			Convey("Should call ioctl twice", func() {
+
+				So(len(provider.IoctlArgs), ShouldEqual, 2)
+
+			})
+
+			Convey("Should report error", func() {
+
+				So(err, ShouldNotBeNil)
+
+				Convey("Error should be about reading", func() {
+
+					So(err.Error(), ShouldContainSubstring, "Read")
+
+				})
+
+			})
+
+		})
+
+}
+
+func TestGetAttributes(t *testing.T) {
+	Convey("When there is no known attribute", t, func() {
+
+		sv := SmartValues{}
+		sv.Values[0].Id = 255
+
+		metrics := sv.GetAttributes()
+
+		Convey("List of metrics should be empty", func() {
+
+			So(metrics, ShouldBeEmpty)
+
+		})
+
+	})
+
+	Convey("When known attribute is present", t, func() {
+
+		id, value := firstKnownMetric()
+
+		sv := SmartValues{}
+		sv.Values[0].Id = id
+
+		metrics := sv.GetAttributes()
+
+		Convey("Should be present in list of metrics in raw form", func() {
+
+			_, ok := metrics[value]
+			So(ok, ShouldBeTrue)
+
+		})
+
+		Convey("Should be present in list of metrics in normalized form", func() {
+
+			_, ok := metrics[value+"/normalized"]
+			So(ok, ShouldBeTrue)
+
+		})
+
+	})
+}
+
+func TestAttributeFormat(t *testing.T) {
+
+	format_desc := map[AttributeFormat]string{
+		FormatDefault:     "FormatDefault",
+		FormatFP1024:      "FormatFP1024",
+		FormatPLPF:        "FormatPLPF",
+		FormatTTS:         "FormatTTS",
+		FormatTemperature: "FormatTemperature",
+	}
+
+	for format, label := range format_desc {
+		Convey(fmt.Sprintf("Testing %v", label), t, func() {
+
+			keys := format.GetKeys()
+
+			Convey("Raw value is exposed", func() {
+
+				So(keys, ShouldContain, "")
+
+			})
+
+			Convey("Normalized value is exposed", func() {
+
+				So(keys, ShouldContain, "/normalized")
+
+			})
+
+			Convey("Keys and output of parsing is consistent", func() {
+
+				raw := [8]byte{}
+				parsed := format.ParseRaw(raw)
+				Convey("Parsing returns every reported key", func() {
+					for _, key := range keys {
+						if key == "/normalized" {
+							continue
+						}
+						_, ok := parsed[key]
+						if !ok {
+							Printf("%v is missing", key)
+						}
+						So(ok, ShouldBeTrue)
+					}
+				})
+				Convey("Everything returned by parsing is reported", func() {
+					for key, _ := range parsed {
+						So(keys, ShouldContain, key)
+					}
+				})
+
+			})
+		})
+	}
+}


### PR DESCRIPTION
# S.M.A.R.T Collector plugin

Added plugin for collecting SMART data. Data interpretation is based on Intel SSD 710 Series specification. Current compatibility status with other drives is unknown.
## Metric catalog
- /intel/disk/[DEVICE NAME]/smart/availablereservedspace
- /intel/disk/[DEVICE NAME]/smart/availablereservedspace/normalized
- /intel/disk/[DEVICE NAME]/smart/casetemperature
- /intel/disk/[DEVICE NAME]/smart/casetemperature/max
- /intel/disk/[DEVICE NAME]/smart/casetemperature/min
- /intel/disk/[DEVICE NAME]/smart/casetemperature/normalized
- /intel/disk/[DEVICE NAME]/smart/casetemperature/overcounter
- /intel/disk/[DEVICE NAME]/smart/crcerrors
- /intel/disk/[DEVICE NAME]/smart/crcerrors/normalized
- /intel/disk/[DEVICE NAME]/smart/e2eerrors
- /intel/disk/[DEVICE NAME]/smart/e2eerrors/normalized
- /intel/disk/[DEVICE NAME]/smart/erasefailcount
- /intel/disk/[DEVICE NAME]/smart/erasefailcount/normalized
- /intel/disk/[DEVICE NAME]/smart/hostwrites
- /intel/disk/[DEVICE NAME]/smart/hostwrites/normalized
- /intel/disk/[DEVICE NAME]/smart/internaltemperature
- /intel/disk/[DEVICE NAME]/smart/internaltemperature/normalized
- /intel/disk/[DEVICE NAME]/smart/pendingsectors
- /intel/disk/[DEVICE NAME]/smart/pendingsectors/normalized
- /intel/disk/[DEVICE NAME]/smart/powercyclecount
- /intel/disk/[DEVICE NAME]/smart/powercyclecount/normalized
- /intel/disk/[DEVICE NAME]/smart/powerlossprotectionfailure
- /intel/disk/[DEVICE NAME]/smart/powerlossprotectionfailure/normalized
- /intel/disk/[DEVICE NAME]/smart/powerlossprotectionfailure/sincelast
- /intel/disk/[DEVICE NAME]/smart/powerlossprotectionfailure/tests
- /intel/disk/[DEVICE NAME]/smart/poweronhours
- /intel/disk/[DEVICE NAME]/smart/poweronhours/normalized
- /intel/disk/[DEVICE NAME]/smart/programfailcount
- /intel/disk/[DEVICE NAME]/smart/programfailcount/normalized
- /intel/disk/[DEVICE NAME]/smart/reallocatedsectors
- /intel/disk/[DEVICE NAME]/smart/reallocatedsectors/normalized
- /intel/disk/[DEVICE NAME]/smart/reservedblocks
- /intel/disk/[DEVICE NAME]/smart/reservedblocks/normalized
- /intel/disk/[DEVICE NAME]/smart/satadownshifts
- /intel/disk/[DEVICE NAME]/smart/satadownshifts/normalized
- /intel/disk/[DEVICE NAME]/smart/thermalthrottle
- /intel/disk/[DEVICE NAME]/smart/thermalthrottle/eventcount
- /intel/disk/[DEVICE NAME]/smart/thermalthrottle/normalized
- /intel/disk/[DEVICE NAME]/smart/timedworkload/mediawear
- /intel/disk/[DEVICE NAME]/smart/timedworkload/mediawear/normalized
- /intel/disk/[DEVICE NAME]/smart/timedworkload/readpercent
- /intel/disk/[DEVICE NAME]/smart/timedworkload/readpercent/normalized
- /intel/disk/[DEVICE NAME]/smart/timedworkload/time
- /intel/disk/[DEVICE NAME]/smart/timedworkload/time/normalized
- /intel/disk/[DEVICE NAME]/smart/totallba/read
- /intel/disk/[DEVICE NAME]/smart/totallba/read/normalized
- /intel/disk/[DEVICE NAME]/smart/totallba/written
- /intel/disk/[DEVICE NAME]/smart/totallba/written/normalized
- /intel/disk/[DEVICE NAME]/smart/uncorrectableerrors
- /intel/disk/[DEVICE NAME]/smart/uncorrectableerrors/normalized
- /intel/disk/[DEVICE NAME]/smart/unexpectedpowerloss
- /intel/disk/[DEVICE NAME]/smart/unexpectedpowerloss/normalized
- /intel/disk/[DEVICE NAME]/smart/unsafeshutdowns
- /intel/disk/[DEVICE NAME]/smart/unsafeshutdowns/normalized
- /intel/disk/[DEVICE NAME]/smart/wearout
- /intel/disk/[DEVICE NAME]/smart/wearout/normalized
## Example output

```
Watching Task (2):
NAMESPACE                                                        DATA            TIMESTAMP                       SOURCE
/intel/disk/sda/smart/e2eerrors/normalized                       100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/internaltemperature                        32              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/satadownshifts/normalized                  100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/readpercent                  26              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/availablereservedspace                     0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/casetemperature                            21              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/casetemperature/min                        17              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powerlossprotectionfailure/normalized      100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/poweronhours/normalized                    100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/readpercent/normalized       100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/totallba/read/normalized                   100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/casetemperature/max                        26              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/uncorrectableerrors                        0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/totallba/written/normalized                100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/availablereservedspace/normalized          100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/crcerrors                                  0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powercyclecount                            25              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/poweronhours                               6239            0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/mediawear                    0.5             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/erasefailcount                             0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powercyclecount/normalized                 100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/programfailcount/normalized                100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/casetemperature/overcounter                0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powerlossprotectionfailure/tests           32              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/reallocatedsectors                         0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/mediawear/normalized         100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/internaltemperature/normalized             100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powerlossprotectionfailure/sincelast       3679            0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/unsafeshutdowns/normalized                 100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/e2eerrors                                  0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/hostwrites/normalized                      100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/totallba/read                              26141           0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/pendingsectors/normalized                  100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/unsafeshutdowns                            14              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/thermalthrottle/eventcount                 0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/pendingsectors                             0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/powerlossprotectionfailure                 645             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/totallba/written                           73547           0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/crcerrors/normalized                       100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/satadownshifts                             0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/thermalthrottle/normalized                 100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/time/normalized              100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/wearout/normalized                         100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/programfailcount                           0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/reservedblocks                             0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/uncorrectableerrors/normalized             100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/unexpectedpowerloss                        14              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/casetemperature/normalized                 79              0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/hostwrites                                 73547           0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/erasefailcount/normalized                  100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/reallocatedsectors/normalized              100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/timedworkload/time                         374146          0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/wearout                                    0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/reservedblocks/normalized                  100             0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/thermalthrottle                            0               0001-01-01 00:00:00 +0000 UTC
/intel/disk/sda/smart/unexpectedpowerloss/normalized             100             0001-01-01 00:00:00 +0000 UTC
```
