### PR TITLE
Update release process to support annotated tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ install:
 	cp build/bin/pulsed /usr/local/bin/
 	cp build/bin/pulsectl /usr/local/bin/
 release:
-	bash -c "./scripts/release.sh $(TAG) $(RELEASE)"
+	bash -c "./scripts/release.sh $(TAG) $(COMMIT)"


### PR DESCRIPTION
Update release process to support annotated tags.
Allows tagging at a commit and not just HEAD of master.
Marks all builds at pre-release currently.
