### PR TITLE
Change rest functional test port range from 8000 to 40000

### DIFF
--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -37,7 +37,7 @@ var (
 	PSUTIL_PLUGIN_PATH  = PULSE_PATH + "/plugin/pulse-collector-psutil"
 	RIEMANN_PLUGIN_PATH = PULSE_PATH + "/plugin/pulse-publisher-riemann"
 
-	NextPort         = 8000
+	NextPort         = 40000
 	CompressedUpload = true
 	TotalUploadSize  = 0
 	UploadCount      = 0


### PR DESCRIPTION
Updating rest functional test port range from 8000 to 40000 to avoid conflicts with any other applications that could be running in 8000 range that could cause tests to fail.
