### PR TITLE
Perf events plugin. Collect HW metrics per Cgroup.

### DIFF
--- a/plugin/collector/pulse-collector-perfevents/README.md
+++ b/plugin/collector/pulse-collector-perfevents/README.md
@@ -1,0 +1,37 @@
+## Pulse Perf Events Collector Plugin
+
+# Description
+Collect following HW metrics for Cgroups from "perf" - Performance Counters for Linux:
+*  cycles
+*  instructions
+*  cache-references
+*  cache-misses
+*  branch-instructions
+*  branch-misses
+*  stalled-cycles-frontend
+*  stalled-cycles-backend
+*  ref-cycles
+
+ By default metrics are gathered once per second.
+
+# Assumptions
+* "perf" - performance monitoring tool installed.
+* /proc/sys/kernel/perf_event_paranoid set to 0 (echo 0 > /proc/sys/kernel/perf_event_paranoid) 
+* Linux kernel version 2.6.31+
+
+# Tips
+Creating sample cgroup for testing:
+* create sample process
+- dd if=/dev/zero of=/dev/null &
+- pid=$!
+
+* create cgroup and move process into cgroup
+- sudo cgcreate -g perf_event:A -g cpu:A -g cpuset:A -g cpuacct:A
+- sudo cgclassify -g perf_event:A -g cpu:A -g cpuacct:A $pid
+- sudo cgset -r cpuset.cpus=0-7 A
+- sudo cgset -r cpuset.mems=0 A
+- sudo cgclassify -g cpuset:A $pid
+- sudo cgset -r cpu.shares=20 A
+
+* list cgroup
+- lscgroup | grep perf_event

--- a/plugin/collector/pulse-collector-perfevents/main.go
+++ b/plugin/collector/pulse-collector-perfevents/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/plugin/collector/pulse-collector-perfevents/perfevents"
+)
+
+// plugin bootstrap
+func main() {
+	plugin.Start(
+		plugin.NewPluginMeta(perfevents.Name, perfevents.Version, perfevents.Type, []string{}, []string{plugin.PulseGOBContentType}, plugin.ConcurrencyCount(1)),
+		perfevents.NewPerfevents(),
+		os.Args[1],
+	)
+}

--- a/plugin/collector/pulse-collector-perfevents/perfevents/perfevents.go
+++ b/plugin/collector/pulse-collector-perfevents/perfevents/perfevents.go
@@ -1,0 +1,263 @@
+package perfevents
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/control/plugin/cpolicy"
+)
+
+const (
+	// Name of plugin
+	Name = "perfevents"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+	// Namespace definition
+	ns_vendor  = "intel"
+	ns_class   = "linux"
+	ns_type    = "perfevents"
+	ns_subtype = "cgroup"
+)
+
+type event struct {
+	id    string
+	etype string
+	value uint64
+}
+
+type Perfevents struct {
+	cgroup_events []event
+	Init          func() error
+}
+
+var CGROUP_EVENTS = []string{"cycles", "instructions", "cache-references", "cache-misses",
+	"branch-instructions", "branch-misses", "stalled-cycles-frontend",
+	"stalled-cycles-backend", "ref-cycles"}
+
+// CollectMetrics returns HW metrics from perf events subsystem
+// for Cgroups present on the host.
+func (p *Perfevents) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+	if len(mts) == 0 {
+		return nil, nil
+	}
+	events := []string{}
+	cgroups := []string{}
+
+	// Get list of events and cgroups from Namespace
+	// Replace "_" with "/" in cgroup name
+	for _, m := range mts {
+		err := validateNamespace(m.Namespace())
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, m.Namespace()[4])
+		cgroups = append(cgroups, strings.Replace(m.Namespace()[5], "_", "/", -1))
+	}
+
+	// Prepare events (-e) and Cgroups (-G) switches for "perf stat"
+	cgroups_switch := "-G" + strings.Join(cgroups, ",")
+	events_switch := "-e" + strings.Join(events, ",")
+
+	// Prepare "perf stat" command
+	cmd := exec.Command("perf", "stat", "--log-fd", "1", `-x;`, "-a", events_switch, cgroups_switch, "--", "sleep", "1")
+
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating StdoutPipe", err)
+		return nil, err
+	}
+
+	// Parse "perf stat" output
+	p.cgroup_events = make([]event, len(mts))
+	scanner := bufio.NewScanner(cmdReader)
+	go func() {
+		for i := 0; scanner.Scan(); i++ {
+			line := strings.Split(scanner.Text(), ";")
+			value, err := strconv.ParseUint(line[0], 10, 64)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "Invalid metric value", err)
+			}
+			etype := line[2]
+			id := line[3]
+			e := event{id: id, etype: etype, value: value}
+			p.cgroup_events[i] = e
+		}
+	}()
+
+	// Run command and wait (up to 2 secs) for completion
+	err = cmd.Start()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error starting perf stat", err)
+		return nil, err
+	}
+
+	st := time.Now()
+	for {
+		if len(p.cgroup_events) == cap(p.cgroup_events) {
+			break
+		}
+		if time.Since(st) > time.Second*2 {
+			return nil, fmt.Errorf("Timed out waiting for metrics from perf stat")
+		}
+	}
+	err = cmd.Wait()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error waiting for perf stat", err)
+		return nil, err
+	}
+
+	// Populate metrics
+	metrics := make([]plugin.PluginMetricType, len(mts))
+	i := 0
+	for _, m := range mts {
+		metric, err := populate_metric(m.Namespace(), p.cgroup_events[i])
+		if err != nil {
+			return nil, err
+		}
+		metrics[i] = *metric
+		metrics[i].Source_, _ = os.Hostname()
+		i++
+	}
+	return metrics, nil
+}
+
+// GetMetricTypes returns the metric types exposed by perf events subsystem
+func (p *Perfevents) GetMetricTypes() ([]plugin.PluginMetricType, error) {
+	err := p.Init()
+	if err != nil {
+		return nil, err
+	}
+	cgroups, err := list_cgroups()
+	if err != nil {
+		return nil, err
+	}
+	if len(cgroups) == 0 {
+		return nil, nil
+	}
+	mts := []plugin.PluginMetricType{}
+	mts = append(mts, set_supported_metrics(ns_subtype, cgroups, CGROUP_EVENTS)...)
+
+	return mts, nil
+}
+
+// GetConfigPolicy returns a ConfigPolicy
+func (p *Perfevents) GetConfigPolicy() (cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	return *c, nil
+}
+
+// New initializes Perfevents plugin
+func NewPerfevents() *Perfevents {
+	return &Perfevents{Init: initialize}
+}
+
+func initialize() error {
+	file, err := os.Open("/proc/sys/kernel/perf_event_paranoid")
+	if err != nil {
+		if os.IsExist(err) {
+			return errors.New("perf_event_paranoid file exists but couldn't be opened")
+		}
+		return errors.New("perf event system not enabled")
+	}
+
+	scanner := bufio.NewScanner(file)
+	if !scanner.Scan() {
+		return errors.New("cannot read from perf_event_paranoid")
+	}
+
+	i, err := strconv.ParseInt(scanner.Text(), 10, 64)
+	if err != nil {
+		return errors.New("invalid value in perf_event_paranoid file")
+	}
+
+	if i >= 1 {
+		return errors.New("insufficient perf event subsystem capabilities")
+	}
+	return nil
+}
+
+func set_supported_metrics(source string, cgroups []string, events []string) []plugin.PluginMetricType {
+	mts := make([]plugin.PluginMetricType, len(events)*len(cgroups))
+	for _, e := range events {
+		for _, c := range flatten_cg_name(cgroups) {
+			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{ns_vendor, ns_class, ns_type, source, e, c}})
+		}
+	}
+	return mts
+}
+func flatten_cg_name(cg []string) []string {
+	flat_cg := []string{}
+	for _, c := range cg {
+		flat_cg = append(flat_cg, strings.Replace(c, "/", "_", -1))
+	}
+	return flat_cg
+}
+
+func populate_metric(ns []string, e event) (*plugin.PluginMetricType, error) {
+	return &plugin.PluginMetricType{
+		Namespace_: ns,
+		Data_:      e.value,
+		Timestamp_: time.Now(),
+	}, nil
+}
+
+func list_cgroups() ([]string, error) {
+	cgroups := []string{}
+	base_path := "/sys/fs/cgroup/perf_event/"
+	err := filepath.Walk(base_path, func(path string, info os.FileInfo, _ error) error {
+		if info.IsDir() {
+			cgroup_name := strings.TrimPrefix(path, base_path)
+			if len(cgroup_name) > 0 {
+				cgroups = append(cgroups, cgroup_name)
+			}
+		}
+		return nil
+
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cgroups, nil
+}
+
+func validateNamespace(namespace []string) error {
+	if len(namespace) != 6 {
+		return errors.New(fmt.Sprintf("unknown metricType %s (should containt exactly 6 segments)", namespace))
+	}
+	if namespace[0] != ns_vendor {
+		return errors.New(fmt.Sprintf("unknown metricType %s (expected 1st segment %s)", namespace, ns_vendor))
+	}
+
+	if namespace[1] != ns_class {
+		return errors.New(fmt.Sprintf("unknown metricType %s (expected 2nd segment %s)", namespace, ns_class))
+	}
+	if namespace[2] != ns_type {
+		return errors.New(fmt.Sprintf("unknown metricType %s (expected 3rd segment %s)", namespace, ns_type))
+	}
+	if namespace[3] != ns_subtype {
+		return errors.New(fmt.Sprintf("unknown metricType %s (expected 4th segment %s)", namespace, ns_subtype))
+	}
+	if !namespaceContains(namespace[4], CGROUP_EVENTS) {
+		return errors.New(fmt.Sprintf("unknown metricType %s (expected 5th segment %v)", namespace, CGROUP_EVENTS))
+	}
+	return nil
+}
+
+func namespaceContains(element string, slice []string) bool {
+	for _, v := range slice {
+		if v == element {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/collector/pulse-collector-perfevents/perfevents/perfevents_test.go
+++ b/plugin/collector/pulse-collector-perfevents/perfevents/perfevents_test.go
@@ -1,0 +1,130 @@
+package perfevents
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/plugin/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	PluginName    = "pulse-collector-perfevents"
+	PluginType    = "collector"
+	PluginVersion = 1
+	PulsePath     = os.Getenv("PULSE_PATH")
+	PluginPath    = path.Join(PulsePath, "plugin", PluginName)
+)
+
+func TestPluginLoads(t *testing.T) {
+	// These tests only work if PULSE_PATH is known.
+	// It is the responsibility of the testing framework to
+	// build the plugins first into the build dir.
+	if PulsePath != "" {
+		// Helper plugin trigger build if possible for this plugin
+		helper.BuildPlugin(PluginType, PluginName)
+		//
+		Convey("GetMetricTypes functionality", t, func() {
+			p := NewPerfevents()
+			Convey("invalid init", func() {
+				p.Init = func() error { return errors.New("error") }
+				_, err := p.GetMetricTypes()
+				So(err, ShouldNotBeNil)
+			})
+			Convey("set_supported_metrics", func() {
+				cg := []string{"cgroup1", "cgroup2", "cgroup3"}
+				events := []string{"event1", "event2", "event3"}
+				a := set_supported_metrics(ns_subtype, cg, events)
+				So(a[len(a)-1].Namespace_, ShouldResemble, []string{ns_vendor, ns_class, ns_type, ns_subtype, "event3", "cgroup3"})
+			})
+			Convey("flatten cgroup name", func() {
+				cg := []string{"cg_root/cg_sub1/cg_sub2"}
+				events := []string{"event"}
+				a := set_supported_metrics(ns_subtype, cg, events)
+				So(a[len(a)-1].Namespace_, ShouldContain, "cg_root_cg_sub1_cg_sub2")
+			})
+		})
+		Convey("CollectMetrics error cases", t, func() {
+			p := NewPerfevents()
+			Convey("empty list of requested metrics", func() {
+				metricTypes := []plugin.PluginMetricType{}
+				metrics, err := p.CollectMetrics(metricTypes)
+				So(err, ShouldBeNil)
+				So(metrics, ShouldBeEmpty)
+			})
+			Convey("namespace too short", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{"invalid"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "segments")
+			})
+			Convey("namespace wrong vendor", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{"invalid", ns_class, ns_type, ns_subtype, "cycles", "A"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "1st")
+			})
+			Convey("namespace wrong class", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{ns_vendor, "invalid", ns_type, ns_subtype, "cycles", "A"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "2nd")
+			})
+			Convey("namespace wrong type", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{ns_vendor, ns_class, "invalid", ns_subtype, "cycles", "A"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "3rd")
+			})
+			Convey("namespace wrong subtype", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{ns_vendor, ns_class, ns_type, "invalid", "cycles", "A"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "4th")
+			})
+			Convey("namespace wrong event", func() {
+				_, err := p.CollectMetrics(
+					[]plugin.PluginMetricType{
+						plugin.PluginMetricType{
+							Namespace_: []string{ns_vendor, ns_class, ns_type, ns_subtype, "invalid", "A"},
+						},
+					},
+				)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "5th")
+			})
+
+		})
+	} else {
+		fmt.Printf("PULSE_PATH not set. Cannot test %s plugin.\n", PluginName)
+	}
+}


### PR DESCRIPTION
### Perf events plugin

**Metrics catalog:**
- /intel/linux/perfevents/cgroup/cycles/CGROUP_NAME
- /intel/linux/perfevents/cgroup/instructions/CGROUP_NAME
- /intel/linux/perfevents/cgroup/cache-references/CGROUP_NAME
- /intel/linux/perfevents/cgroup/cache-misses/CGROUP_NAME
- /intel/linux/perfevents/cgroup/branch-instructions/CGROUP_NAME
- /intel/linux/perfevents/cgroup/branch-misses/CGROUP_NAME
- /intel/linux/perfevents/cgroup/stalled-cycles-frontend/CGROUP_NAME
- /intel/linux/perfevents/cgroup/stalled-cycles-backend/CGROUP_NAME
- /intel/linux/perfevents/cgroup/ref-cycles/CGROUP_NAME

**Sample output (from "pulsectl task watch"):**

```
NAMESPACE                                                           DATA
/intel/linux/perfevents/cgroup/stalled-cycles-frontend/A            1.182234456e+09
/intel/linux/perfevents/cgroup/cache-misses/A                       991
/intel/linux/perfevents/cgroup/cycles/A                             3.27173986e+09
/intel/linux/perfevents/cgroup/instructions/user_0.user_8.session   240849
/intel/linux/perfevents/cgroup/ref-cycles/A                         2.762895146e+09
/intel/linux/perfevents/cgroup/stalled-cycles-backend/A             3.35373132e+08
/intel/linux/perfevents/cgroup/branch-instructions/A                9.79942219e+08
/intel/linux/perfevents/cgroup/branch-misses/A                      9420
/intel/linux/perfevents/cgroup/cache-references/A                   9731
/intel/linux/perfevents/cgroup/instructions/A                       5.114755105e+09
```
