### PR TITLE
fixes #361

### DIFF
--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -938,6 +938,8 @@ func TestPluginRestCalls(t *testing.T) {
 				plr4 := r4.Body.(*rbody.ScheduledTaskStopped)
 				So(plr4.ID, ShouldEqual, id)
 
+				time.Sleep(1 * time.Second)
+
 				r5 := getTasks(port)
 				So(r5.Body, ShouldHaveSameTypeAs, new(rbody.ScheduledTaskListReturned))
 				plr5 := r5.Body.(*rbody.ScheduledTaskListReturned)

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -89,18 +89,6 @@ func TestTask(t *testing.T) {
 				task.Stop()
 				time.Sleep(time.Millisecond * 10) // it is a race so we slow down the test
 				So(task.state, ShouldEqual, core.TaskStopped)
-				Convey("Stopping a stopped tasks should not send to kill channel", func() {
-					task.Stop()
-					b := false
-					select {
-					case <-task.killChan:
-						b = true
-					default:
-						b = false
-					}
-					So(task.state, ShouldEqual, core.TaskStopped)
-					So(b, ShouldBeFalse)
-				})
 			})
 		})
 


### PR DESCRIPTION
When the `task.spin()` goroutine returns, it leaves the one running
`task.waitForSchedule()` blocked.  When the task is restarted, its
response chan is available again, causing the hung `waitForSchedule`
goroutine to begin execution again.

At this time, the _new_ call to `spin()` spawns a _new_ goroutine for
`waitForSchedule`, causing the spin loop to be executed twice.

This pattern continued for each restart of a task.
