### PR TITLE
Fix: Change err to errp in PublishMetrics and Process Metrics

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -722,7 +722,7 @@ func (p *pluginControl) PublishMetrics(contentType string, content []byte, plugi
 		}
 
 		errp := cli.Publish(contentType, content, config)
-		if err != nil {
+		if errp != nil {
 			return []error{errp}
 		}
 		ap.hitCount++
@@ -758,7 +758,7 @@ func (p *pluginControl) ProcessMetrics(contentType string, content []byte, plugi
 		}
 
 		ct, c, errp := cli.Process(contentType, content, config)
-		if err != nil {
+		if errp != nil {
 			return "", nil, []error{errp}
 		}
 		ap.hitCount++


### PR DESCRIPTION
Change err to errp so publish or process plugin errors are checked and returned properly in order to increment failure counts.
