### PR TITLE
Update error code in response to comment on #206

### DIFF
--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -422,6 +422,7 @@ func TestPluginRestCalls(t *testing.T) {
 				So(plr.LoadedPlugins[0].LoadedTimestamp, ShouldBeLessThanOrEqualTo, time.Now().Unix())
 
 				r2 := uploadPlugin(DUMMY_PLUGIN_PATH1, port)
+				So(r2.Meta.Code, ShouldEqual, 409)
 				So(r2.Body, ShouldHaveSameTypeAs, new(rbody.Error))
 				plr2 := r2.Body.(*rbody.Error)
 


### PR DESCRIPTION
Respond back with HTTP code 409 if a plugin is already loaded to specify a conflict. Add test to verify 409 is being sent for a duplicate plugin.
