### PR TITLE
adds https ability to go rest client and pulsectl

### DIFF
--- a/cmd/pulsectl/flags.go
+++ b/cmd/pulsectl/flags.go
@@ -11,6 +11,15 @@ var (
 		EnvVar: "PULSE_URL",
 		Value:  "http://localhost:8181",
 	}
+	flAPIVer = cli.StringFlag{
+		Name:  "api-version, a",
+		Usage: "The Pulse API version",
+		Value: "v1",
+	}
+	flSecure = cli.BoolFlag{
+		Name:  "insecure",
+		Usage: "Ignore certificate errors when Pulse's API is running HTTPS",
+	}
 	flRunning = cli.BoolFlag{
 		Name:  "running",
 		Usage: "Shows running plugins",

--- a/cmd/pulsectl/main.go
+++ b/cmd/pulsectl/main.go
@@ -20,12 +20,12 @@ func main() {
 	app.Name = "pulsectl"
 	app.Version = gitversion
 	app.Usage = "A powerful telemetry agent framework"
-	app.Flags = []cli.Flag{flURL}
+	app.Flags = []cli.Flag{flURL, flSecure, flAPIVer}
 	app.Commands = commands
 
 	app.Before = func(c *cli.Context) error {
 		if pClient == nil {
-			pClient = client.New(c.GlobalString("url"), "")
+			pClient = client.New(c.GlobalString("url"), c.GlobalString("api-version"), c.GlobalBool("insecure"))
 		}
 		return nil
 	}

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -80,13 +80,13 @@ func TestPulseClient(t *testing.T) {
 			Convey("empty version", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "")
+				c := New(uri, "", true)
 				So(c.Version, ShouldEqual, "v1")
 			})
 			Convey("empty list", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				p := c.GetPlugins(false)
 				p2 := c.GetPlugins(true)
 
@@ -103,7 +103,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("single item", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				p := c.GetPlugins(false)
@@ -115,7 +115,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("multiple items", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -128,7 +128,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("empty list, err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p := c.GetPlugins(false)
 				p2 := c.GetPlugins(true)
@@ -148,7 +148,7 @@ func TestPulseClient(t *testing.T) {
 				CompressUpload = true
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p := c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				So(p.Err, ShouldBeNil)
@@ -161,7 +161,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("multiple load", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p1 := c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				So(p1.Err, ShouldBeNil)
@@ -181,7 +181,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("already loaded", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p1 := c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				So(p1.Err, ShouldBeNil)
@@ -198,7 +198,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("directory error", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p1 := c.LoadPlugin(DIRECTORY_PATH)
 				So(p1.Err, ShouldNotBeNil)
@@ -210,7 +210,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unload unknown plugin", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p := c.UnloadPlugin("not a type", "foo", 3)
 				So(p.Err, ShouldNotBeNil)
@@ -220,7 +220,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unload only one there is", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				p := c.UnloadPlugin("collector", "dummy1", 1)
@@ -233,7 +233,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unload one of multiple", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -253,7 +253,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("empty catalog", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p := c.GetMetricCatalog()
 				So(p.Err, ShouldBeNil)
@@ -262,7 +262,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("items in catalog", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -283,7 +283,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("leaf metric all versions", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -296,7 +296,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("version 2 leaf metric", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -309,7 +309,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("version 2 non-leaf metrics", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
@@ -326,7 +326,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("invalid task (missing metric)", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				wf := getWMFromSample("1.json")
 				sch := &Schedule{Type: "simple", Interval: "1s"}
@@ -338,7 +338,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("invalid task (missing publisher)", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 
@@ -352,7 +352,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("valid task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -377,7 +377,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("valid task started on creation", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -402,7 +402,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("do returns err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				wf := getWMFromSample("1.json")
 				sch := &Schedule{Type: "simple", Interval: "1s"}
@@ -416,7 +416,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unknown task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.StartTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -425,7 +425,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("existing task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -439,7 +439,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("do returns err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.StartTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -450,7 +450,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unknown task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.StopTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -459,7 +459,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("existing task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -477,7 +477,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("do returns err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.StopTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -488,7 +488,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("unknown task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.RemoveTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -497,7 +497,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("existing task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -516,7 +516,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("do returns err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 				uuid := uuid.New()
 				p := c.RemoveTask(uuid)
 				So(p.Err, ShouldNotBeNil)
@@ -528,7 +528,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("valid task", func() {
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH1)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -553,7 +553,7 @@ func TestPulseClient(t *testing.T) {
 			Convey("do returns err!=nil", func() {
 				port := -1
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				p := c.GetTask(uuid.New())
 				p2 := c.GetTasks()
@@ -568,7 +568,7 @@ func TestPulseClient(t *testing.T) {
 				rest.StreamingBufferWindow = 0.01
 				port := getPort()
 				uri := startAPI(port)
-				c := New(uri, "v1")
+				c := New(uri, "v1", true)
 
 				c.LoadPlugin(DUMMY_PLUGIN_PATH2)
 				c.LoadPlugin(FILE_PLUGIN_PATH)
@@ -616,7 +616,7 @@ func TestPulseClient(t *testing.T) {
 		Convey("Passing a bad task manifest", func() {
 			port := getPort()
 			uri := startAPI(port)
-			c := New(uri, "v1")
+			c := New(uri, "v1", true)
 
 			c.LoadPlugin(DUMMY_PLUGIN_PATH2)
 			c.LoadPlugin(FILE_PLUGIN_PATH)

--- a/mgmt/rest/client/plugin.go
+++ b/mgmt/rest/client/plugin.go
@@ -13,7 +13,7 @@ func (c *Client) LoadPlugin(p []string) *LoadPluginResult {
 	r := new(LoadPluginResult)
 	resp, err := c.pluginUploadRequest(p)
 	if err != nil {
-		r.Err = err
+		r.Err = perror.New(err)
 		return r
 	}
 

--- a/mgmt/tribe/agreement/agreement.go
+++ b/mgmt/tribe/agreement/agreement.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	RestAPIPort = "rest_api_port"
+	RestPort               = "rest_api_port"
+	RestProtocol           = "rest_proto"
+	RestInsecureSkipVerify = "rest_insecure"
 )
 
 var logger = log.WithFields(log.Fields{
@@ -74,8 +76,19 @@ func NewMember(node *memberlist.Node) *Member {
 	}
 }
 
-func (m *Member) GetRESTAPIPort() string {
-	return m.Tags[RestAPIPort]
+func (m *Member) GetRestPort() string {
+	return m.Tags[RestPort]
+}
+
+func (m *Member) GetRestProto() string {
+	return m.Tags[RestProtocol]
+}
+
+func (m *Member) GetRestInsecureSkipVerify() bool {
+	if m.Tags[RestInsecureSkipVerify] == "true" {
+		return true
+	}
+	return false
 }
 
 func (m *Member) GetName() string {

--- a/mgmt/tribe/worker/worker.go
+++ b/mgmt/tribe/worker/worker.go
@@ -65,7 +65,9 @@ type getsMembers interface {
 
 type Member interface {
 	GetAddr() net.IP
-	GetRESTAPIPort() string
+	GetRestPort() string
+	GetRestProto() string
+	GetRestInsecureSkipVerify() bool
 	GetName() string
 }
 
@@ -142,9 +144,9 @@ func (w worker) start() {
 								continue
 							}
 							for _, member := range shuffle(members) {
-								uri := fmt.Sprintf("http://%s:%s", member.GetAddr(), member.GetRESTAPIPort())
+								uri := fmt.Sprintf("%s://%s:%s", member.GetRestProto(), member.GetAddr(), member.GetRestPort())
 								wLogger.Debugf("getting task %v from %v", work.Task.ID, uri)
-								c := client.New(uri, "v1")
+								c := client.New(uri, "v1", member.GetRestInsecureSkipVerify())
 								taskResult := c.GetTask(work.Task.ID)
 								if taskResult.Err != nil {
 									wLogger.WithField("err", taskResult.Err.Error()).Debug("error getting task")
@@ -217,7 +219,7 @@ func (w worker) start() {
 						continue
 					}
 					for _, member := range shuffle(members) {
-						url := fmt.Sprintf("http://%s:%s/v1/plugins/%s/%s/%d?download=true", member.GetAddr(), member.GetRESTAPIPort(), work.Plugin.TypeName(), work.Plugin.Name(), work.Plugin.Version())
+						url := fmt.Sprintf("%s://%s:%s/v1/plugins/%s/%s/%d?download=true", member.GetRestProto(), member.GetAddr(), member.GetRestPort(), work.Plugin.TypeName(), work.Plugin.Name(), work.Plugin.Version())
 						resp, err := http.Get(url)
 						if err != nil {
 							wLogger.Error(err)


### PR DESCRIPTION
HTTPS is available in two modes on the REST API: with a given certificate
/ key pair, or it can generate unsigned ones at start up.  The client
 needs the ability to bypass cert signing errors when communicating
with the API.  In this commit a param is added when constructing a
client instance called `insecure`.  If this flag is given, the
certificating signing errors are bypassed.

When pulsectl constructs a client instance, it passes in the value of a
new `--insecure` flag which provides pulsectl the same functionality
described above.
