### PR TITLE
Fixing issue 392 Issuing start on a running task and stop a stopped task

### DIFF
--- a/cmd/pulsectl/task.go
+++ b/cmd/pulsectl/task.go
@@ -370,6 +370,11 @@ func startTask(ctx *cli.Context) {
 	id := ctx.Args().First()
 	r := pClient.StartTask(id)
 	if r.Err != nil {
+		if strings.Contains(r.Err.Error(), "Task is already running.") {
+			fmt.Println("Task is already running")
+			fmt.Printf("ID: %s\n", id)
+			os.Exit(0)
+		}
 		fmt.Printf("Error starting task:\n%v\n", r.Err)
 		os.Exit(1)
 	}
@@ -387,6 +392,11 @@ func stopTask(ctx *cli.Context) {
 	id := ctx.Args().First()
 	r := pClient.StopTask(id)
 	if r.Err != nil {
+		if strings.Contains(r.Err.Error(), "Task is already stopped.") {
+			fmt.Println("Task is already stopped")
+			fmt.Printf("ID: %s\n", id)
+			os.Exit(0)
+		}
 		fmt.Printf("Error stopping task:\n%v\n", r.Err)
 		os.Exit(1)
 	}

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -450,10 +450,13 @@ func TestPulseClient(t *testing.T) {
 				c.LoadPlugin(FILE_PLUGIN_PATH)
 
 				p1 := c.CreateTask(&Schedule{Type: "simple", Interval: "1s"}, getWMFromSample("1.json"), "baron", false)
-
 				p2 := c.StartTask(p1.ID)
 				So(p2.Err, ShouldBeNil)
 				So(p2.ID, ShouldEqual, p1.ID)
+
+				p3 := c.CreateTask(&Schedule{Type: "simple", Interval: "1s"}, getWMFromSample("1.json"), "baron", true)
+				p4 := c.StartTask(p3.ID)
+				So(p4.Err.Error(), ShouldEqual, "error 0: Task is already running. ")
 			})
 			Convey("do returns err!=nil", func() {
 				port := -1
@@ -486,8 +489,12 @@ func TestPulseClient(t *testing.T) {
 
 				p1 := c.CreateTask(&Schedule{Type: "simple", Interval: "1s"}, getWMFromSample("1.json"), "baron", false)
 				p2 := c.StopTask(p1.ID)
-				So(p2.Err, ShouldBeNil)
-				So(p2.ID, ShouldEqual, p1.ID)
+				So(p2.Err.Error(), ShouldEqual, "error 0: Task is already stopped. ")
+
+				p3 := c.CreateTask(&Schedule{Type: "simple", Interval: "1s"}, getWMFromSample("1.json"), "baron", true)
+				p4 := c.StopTask(p3.ID)
+				So(p3.Err, ShouldBeNil)
+				So(p4.ID, ShouldEqual, p3.ID)
 
 				b := make([]byte, 5)
 				rsp, err := c.do("PUT", fmt.Sprintf("/tasks/%v/stop", p1.ID), ContentTypeJSON, b)

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -258,7 +258,6 @@ func TestScheduler(t *testing.T) {
 
 		// 		// TODO NICK
 		Convey("create a task", func() {
-
 			tsk, err := s.CreateTask(schedule.NewSimpleSchedule(time.Second*5), w, false)
 			So(len(err.Errors()), ShouldEqual, 0)
 			So(tsk, ShouldNotBeNil)
@@ -278,6 +277,11 @@ func TestScheduler(t *testing.T) {
 				t, err := s.GetTask("1234")
 				So(err, ShouldNotBeNil)
 				So(t, ShouldBeNil)
+			})
+			Convey("stop a stopped task", func() {
+				err := s.StopTask(tsk.ID())
+				So(len(err), ShouldEqual, 1)
+				So(err[0].Error(), ShouldEqual, "Task is already stopped.")
 			})
 		})
 


### PR DESCRIPTION
#392

Stopping a running task before:

```
go run cmd/pulsectl/*go task create -t examples/tasks/dummy-file.json                   ✹ ✭
Using task manifest to create task
Task created
ID: 32b80023-c9c7-4019-9932-6a64f4d78811
Name: Task-32b80023-c9c7-4019-9932-6a64f4d78811
State: Running
```

```
go run cmd/pulsectl/*go task start 32b80023-c9c7-4019-9932-6a64f4d78811                   ✹ ✭
Task started:
ID: 32b80023-c9c7-4019-9932-6a64f4d78811
```

```
INFO[0027] API request                                   _module=_mgmt-rest index=5 method=PUT url=/v1/tasks/b60ea936-c45c-47de-b85d-6f970c5ce464/start
INFO[0027] finding latest plugin                         _module=control-plugin-mgr
INFO[0027] task started                                  _block=start-task _module=scheduler task-id=b60ea936-c45c-47de-b85d-6f970c5ce464 task-state=Running
INFO[0027] API response                                  _module=_mgmt-rest index=5 method=PUT status=OK status-code=200 url=/v1/tasks/b60ea936-c45c-47de-b85d-6f970c5ce464/start
DEBU[0027] event received                                _block=handle-events _module=scheduler-events event-namespace=Scheduler.TaskStarted task-id=b60ea936-c45c-47de-b85d-6f970c5ce464
DEBU[0027] handling plugin subscription event            _block=subscribe-pool _module=control-runner event=Control.PluginSubscribed plugin-name=passthru plugin-type=1 plugin-version=1
DEBU[0027] found pool: version 1                         _block=handle-subscription _module=control-runner plugin-name=passthru plugin-type=processor plugin-version=1
DEBU[0027] checking is pool is eligible to grow.         _block=handle-subscription _module=control-runner pool-count=1 pool-eligibility=false pool-max=3 pool-subscription-count=1
```

PR change:

```
go run cmd/pulsectl/*go task create -t examples/tasks/dummy-file.json  ✭
Using task manifest to create task
Task created
ID: 9fda58c8-6797-4836-af8b-d1a9c2d600d8
Name: Task-9fda58c8-6797-4836-af8b-d1a9c2d600d8
State: Running
```

```
go run cmd/pulsectl/*go task start 9fda58c8-6797-4836-af8b-d1a9c2d600d8
Task is already running
ID: 9fda58c8-6797-4836-af8b-d1a9c2d600d8
```

```
INFO[0054] API request                                   _module=_mgmt-rest index=7 method=PUT url=/v1/tasks/643d1b34-b8a1-48e5-845b-66e292eafbb9/start
INFO[0054] API response                                  _module=_mgmt-rest index=7 method=PUT status=Not Found status-code=404 url=/v1/tasks/643d1b34-b8a1-48e5-845b-66e292eafbb9/start
DEBU[0055] starting collector job                        _module=scheduler-job block=run job-type=collector metric-count=2
DEBU[0055] plugin selected                               _module=control-routing block=select hitcount=13 index=collector:dummy1:v1:id1 pool size=1 strategy=round-robin
```
