### PR TITLE
Fixed go vet error: composite literal uses unkeyed fields

### DIFF
--- a/control/config_test.go
+++ b/control/config_test.go
@@ -38,11 +38,11 @@ func TestPluginConfig(t *testing.T) {
 			cfg.Plugins.All.AddItem("gvar", ctypes.ConfigValueBool{Value: true})
 			So(len(cfg.Plugins.All.Table()), ShouldEqual, 1)
 			Convey("with an entry for ALL collector plugins", func() {
-				cfg.Plugins.Collector.All.AddItem("user", ctypes.ConfigValueStr{"jane"})
-				cfg.Plugins.Collector.All.AddItem("password", ctypes.ConfigValueStr{"P@ssw0rd"})
+				cfg.Plugins.Collector.All.AddItem("user", ctypes.ConfigValueStr{Value: "jane"})
+				cfg.Plugins.Collector.All.AddItem("password", ctypes.ConfigValueStr{Value: "P@ssw0rd"})
 				So(len(cfg.Plugins.Collector.All.Table()), ShouldEqual, 2)
 				Convey("an entry for a specific plugin of any version", func() {
-					cfg.Plugins.Collector.Plugins["test"] = newPluginConfigItem(optAddPluginConfigItem("user", ctypes.ConfigValueStr{"john"}))
+					cfg.Plugins.Collector.Plugins["test"] = newPluginConfigItem(optAddPluginConfigItem("user", ctypes.ConfigValueStr{Value: "john"}))
 					So(len(cfg.Plugins.Collector.Plugins["test"].Table()), ShouldEqual, 1)
 					Convey("and an entry for a specific plugin of a specific version", func() {
 						cfg.Plugins.Collector.Plugins["test"].Versions[1] = cdata.NewNode()
@@ -51,7 +51,7 @@ func TestPluginConfig(t *testing.T) {
 						Convey("we can get the merged conf for the given plugin", func() {
 							cd := cfg.Plugins.getPluginConfigDataNode(core.CollectorPluginType, "test", 1)
 							So(len(cd.Table()), ShouldEqual, 4)
-							So(cd.Table()["user"], ShouldResemble, ctypes.ConfigValueStr{"john"})
+							So(cd.Table()["user"], ShouldResemble, ctypes.ConfigValueStr{Value: "john"})
 						})
 					})
 				})

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -475,7 +475,7 @@ func TestPluginRestCalls(t *testing.T) {
 				col := core.CollectorPluginType
 				Convey("A global plugin config is added for all plugins", func() {
 					cdn := cdata.NewNode()
-					cdn.AddItem("password", ctypes.ConfigValueStr{"p@ssw0rd"})
+					cdn.AddItem("password", ctypes.ConfigValueStr{Value: "p@ssw0rd"})
 					r := setPluginConfigItem(port, "", "", "", cdn)
 					So(r.Body, ShouldHaveSameTypeAs, &rbody.SetPluginConfigItem{})
 					r1 := r.Body.(*rbody.SetPluginConfigItem)
@@ -489,7 +489,7 @@ func TestPluginRestCalls(t *testing.T) {
 
 					Convey("A plugin config is added for all publishers", func() {
 						cdn := cdata.NewNode()
-						cdn.AddItem("user", ctypes.ConfigValueStr{"john"})
+						cdn.AddItem("user", ctypes.ConfigValueStr{Value: "john"})
 						r := setPluginConfigItem(port, core.PublisherPluginType.String(), "", "", cdn)
 						So(r.Body, ShouldHaveSameTypeAs, &rbody.SetPluginConfigItem{})
 						r1 := r.Body.(*rbody.SetPluginConfigItem)
@@ -498,7 +498,7 @@ func TestPluginRestCalls(t *testing.T) {
 
 						Convey("A plugin config is added for all versions of a publisher", func() {
 							cdn := cdata.NewNode()
-							cdn.AddItem("path", ctypes.ConfigValueStr{"/usr/local/influxdb/bin"})
+							cdn.AddItem("path", ctypes.ConfigValueStr{Value: "/usr/local/influxdb/bin"})
 							r := setPluginConfigItem(port, "2", "influxdb", "", cdn)
 							So(r.Body, ShouldHaveSameTypeAs, &rbody.SetPluginConfigItem{})
 							r1 := r.Body.(*rbody.SetPluginConfigItem)
@@ -507,7 +507,7 @@ func TestPluginRestCalls(t *testing.T) {
 
 							Convey("A plugin config is added for a specific version of a publisher", func() {
 								cdn := cdata.NewNode()
-								cdn.AddItem("rate", ctypes.ConfigValueFloat{.8})
+								cdn.AddItem("rate", ctypes.ConfigValueFloat{Value: .8})
 								r := setPluginConfigItem(port, core.PublisherPluginType.String(), "influxdb", "", cdn)
 								So(r.Body, ShouldHaveSameTypeAs, &rbody.SetPluginConfigItem{})
 								r1 := r.Body.(*rbody.SetPluginConfigItem)


### PR DESCRIPTION
```
control/config_test.go:41: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
control/config_test.go:42: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
control/config_test.go:45: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
control/config_test.go:54: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
exit status 1
mgmt/rest/rest_func_test.go:489: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
mgmt/rest/rest_func_test.go:503: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
mgmt/rest/rest_func_test.go:512: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueStr composite literal uses unkeyed fields
mgmt/rest/rest_func_test.go:521: github.com/intelsdi-x/pulse/core/ctypes.ConfigValueFloat composite literal uses unkeyed fields
```
