### PR TITLE
start plugins synchronously

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -802,7 +802,7 @@ func TestCollectMetrics(t *testing.T) {
 		pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:dummy1:1")
 		So(errp, ShouldBeNil)
 		pool.subscribe("1", unboundSubscriptionType)
-		err = c.sendPluginSubscriptionEvent("1", lp)
+		err = c.pluginRunner.runPlugin(lp.Path)
 		So(err, ShouldBeNil)
 		m = append(m, m1, m2, m3)
 		time.Sleep(time.Millisecond * 1100)
@@ -886,18 +886,11 @@ func TestPublishMetrics(t *testing.T) {
 		Convey("Subscribe to file publisher with good config", func() {
 			n := cdata.NewNode()
 			config.Plugins.Publisher.Plugins[lp.Name()] = newPluginConfigItem(optAddPluginConfigItem("file", ctypes.ConfigValueStr{Value: "/tmp/pulse-TestPublishMetrics.out"}))
-			p := mockPlugin{
-				name:       "file",
-				pluginType: core.PublisherPluginType,
-				ver:        1,
-				config:     n,
-			}
 			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("publisher:file:1")
 			So(errp, ShouldBeNil)
 			pool.subscribe("1", unboundSubscriptionType)
-			errs := c.sendPluginSubscriptionEvent("1", p)
-			So(errs, ShouldBeNil)
-			<-lpe.done
+			err := c.pluginRunner.runPlugin(lp.Path)
+			So(err, ShouldBeNil)
 			time.Sleep(2500 * time.Millisecond)
 
 			Convey("Publish to file", func() {
@@ -944,18 +937,11 @@ func TestProcessMetrics(t *testing.T) {
 
 		Convey("Subscribe to passthru processor with good config", func() {
 			n := cdata.NewNode()
-			p := mockPlugin{
-				name:       "passthru",
-				pluginType: core.ProcessorPluginType,
-				ver:        1,
-				config:     n,
-			}
 			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("processor:passthru:1")
 			So(errp, ShouldBeNil)
 			pool.subscribe("1", unboundSubscriptionType)
-			errs := c.sendPluginSubscriptionEvent("1", p)
-			So(errs, ShouldBeNil)
-			<-lpe.done
+			err := c.pluginRunner.runPlugin(lp.Path)
+			So(err, ShouldBeNil)
 			time.Sleep(2500 * time.Millisecond)
 
 			Convey("process metrics", func() {


### PR DESCRIPTION
When a task starts it calls SubscribeDeps on control to prepare any
plugins it may need.  Previously, SubscribeDeps emitted events which
were picked up by the runner, who then started the plugins.  This
occasionally resulted in an error starting the task, because the async
process of starting the needed plugins had not completed yet.  This was
especially true with tasks with very small intervals, < 250ms for
example.

This commit causes SubscribeDeps to first subscribe, then check that the
pool is eligible.  If it is, then it runs a plugin directly.  The runner
no longer handles `PluginSubscriptionEvent`.
