### PR TITLE
Added a stopping state for StopTask

### DIFF
--- a/core/task.go
+++ b/core/task.go
@@ -37,6 +37,7 @@ const (
 	TaskSpinning
 	TaskFiring
 	TaskEnded
+	TaskStopping
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 		TaskSpinning: "Running",  // running
 		TaskFiring:   "Running",  // running (firing can happen so briefly we don't want to try and render it as a string state)
 		TaskEnded:    "Ended",    // ended, not resumable because the schedule will not fire again
+		TaskStopping: "Stopping", // channel has been closed, wait for TaskStopped state
 	}
 )
 

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -211,6 +211,7 @@ func (t *task) Stop() {
 	t.Lock()
 	defer t.Unlock()
 	if t.state == core.TaskFiring || t.state == core.TaskSpinning {
+		t.state = core.TaskStopping
 		close(t.killChan)
 	}
 }


### PR DESCRIPTION
Fix for PANIC: close of closed channel

``` go
tt := c.CreateTask(sch, wf, "baron", true)

t1 := c.StopTask(tt.ID)
//try stopping again to make sure channel is closed
t2 := c.StopTask(tt.ID) //<--this sometimes panics
```
