### PR TITLE
Resolves #369 Made it so the header isn't written more than once

### DIFF
--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -240,8 +240,9 @@ func respond(code int, b rbody.Body, w http.ResponseWriter) {
 		},
 		Body: b,
 	}
-
-	w.WriteHeader(code)
+	if !w.(negroni.ResponseWriter).Written() {
+		w.WriteHeader(code)
+	}
 
 	j, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {


### PR DESCRIPTION
#369

If the header has already been written, it doesn't write it again. The alternative is to make a new response writer if this isn't the proper fix.
