### PR TITLE
Add metrics source info to the published file

### DIFF
--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -180,7 +180,7 @@ func TestPulseClient(t *testing.T) {
 		Convey("invalid task (missing publisher)", func() {
 			tf := c.CreateTask(sch, wf, "baron", false)
 			So(tf.Err, ShouldNotBeNil)
-			So(tf.Err.Error(), ShouldContainSubstring, "Plugin not found: type(publisher) name(file) version(1)")
+			So(tf.Err.Error(), ShouldContainSubstring, "Plugin not found: type(publisher) name(file)")
 		})
 		Convey("plugin already loaded", func() {
 			p1 := c.LoadPlugin(DUMMY_PLUGIN_PATH1)

--- a/mgmt/rest/wmap_sample/1.json
+++ b/mgmt/rest/wmap_sample/1.json
@@ -12,7 +12,6 @@
         "publish": [
             {
                 "plugin_name": "file",
-                "plugin_version": 1,
                 "config": {
                     "file": "/tmp/rest.test"
                 }

--- a/mgmt/rest/wmap_sample/bad.json
+++ b/mgmt/rest/wmap_sample/bad.json
@@ -8,7 +8,6 @@
         "publish": [
             {
                 "plugin_name": "file",
-                "plugin_version": 1,
                 "config": {
                     "file": "/tmp/rest.test"
                 }

--- a/plugin/publisher/pulse-publisher-file/file/file.go
+++ b/plugin/publisher/pulse-publisher-file/file/file.go
@@ -77,7 +77,11 @@ func (f *filePublisher) Publish(contentType string, content []byte, config map[s
 	}
 	w := bufio.NewWriter(file)
 	for _, m := range metrics {
-		w.WriteString(fmt.Sprintf("%v|%v|%v\n", time.Now().Local(), m.Namespace(), m.Data()))
+		source := m.Source()
+		if source == "" {
+			source = "unknown"
+		}
+		w.WriteString(fmt.Sprintf("%v|%v|%v|%v\n", time.Now().Local(), m.Namespace(), m.Data(), source))
 	}
 	w.Flush()
 


### PR DESCRIPTION
Add metrics source info to the published file

Before:
_[Timestamp | Metric namespace | Metric Data]_
`2015-10-29 11:18:24.611794149 -0400 EDT|[intel linux iostat avg-cpu %idle]|99.87`

After: 
_[Timestamp | Metric namespace | Metric Data | Metric Source]_
`2015-10-29 11:18:24.611794149 -0400 EDT|[intel linux iostat avg-cpu %idle]|99.87|gklab-108-166`
