### PR TITLE
Fixes #449 pulsectl task watch gives an error if the task ID doesn't exist

### DIFF
--- a/cmd/pulsectl/task.go
+++ b/cmd/pulsectl/task.go
@@ -307,8 +307,7 @@ func watchTask(ctx *cli.Context) {
 	id := ctx.Args().First()
 	r := pClient.WatchTask(id)
 	if r.Err != nil {
-		fmt.Printf("Error starting task:\n%v\n", r.Err)
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
+		fmt.Println(r.Err)
 		os.Exit(1)
 	}
 	fmt.Printf("Watching Task (%s):\n", id)

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -22,6 +22,7 @@ package client
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -90,9 +91,20 @@ func (c *Client) WatchTask(id string) *WatchTasksResult {
 
 	url := fmt.Sprintf("%s/tasks/%v/watch", c.prefix, id)
 	resp, err := http.Get(url)
-
 	if err != nil {
 		r.Err = err
+		r.Close()
+		return r
+	}
+	if resp.StatusCode != 200 {
+		ar, err := httpRespToAPIResp(resp)
+		if err != nil {
+			r.Err = err
+		} else {
+			r.Err = errors.New(ar.Meta.Message)
+		}
+		r.Close()
+		return r
 	}
 
 	// Start watching

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -470,7 +470,7 @@ func (s *scheduler) HandleGomitEvent(e gomit.Event) {
 func (s *scheduler) getTask(id string) (*task, error) {
 	task := s.tasks.Get(id)
 	if task == nil {
-		return nil, fmt.Errorf("No task found with id '%v'", id)
+		return nil, fmt.Errorf("No task found with ID '%v'", id)
 	}
 	return task, nil
 }


### PR DESCRIPTION
#449

```
pulsectl task create -w mgmt/rest/wmap_sample/1.json -i 1s -d 1000s

Using workflow manifest to create task
Task created
ID: 4c9af3af-2bab-4974-aabb-f25953c56590
Name: Task-4c9af3af-2bab-4974-aabb-f25953c56590
State: Running
```

Non-existent task

```
pulsectl task watch 1                                            ✭
No task found with ID '1'
exit status 1
```

Existing task

```
pulsectl task watch 4c9af3af-2bab-4974-aabb-f25953c56590    1 ↵ ✭
Watching Task (4c9af3af-2bab-4974-aabb-f25953c56590):
NAMESPACE        DATA                                        TIMESTAMP                   SOURCE
/intel/dummy/foo     The dummy collected data! config data: user=%!s(<nil>) password={testval}   2015-10-29 14:23:36.058591308 -0700 PDT     tje/intel/dummy/foo tel.com 
```
