### PR TITLE
Resolves #205 Updated pulsectl task to truncate count values

### DIFF
--- a/cmd/pulsectl/task.go
+++ b/cmd/pulsectl/task.go
@@ -27,6 +27,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -46,6 +47,39 @@ var (
 	dateParseFormat  = "1-02-2006"
 	unionParseFormat = timeParseFormat + " " + dateParseFormat
 )
+
+const (
+	K = 1000
+	M = 1000 * K
+	G = 1000 * M
+	T = 1000 * G
+	P = 1000 * T
+)
+
+func trunc(n int) string {
+	var u string
+
+	switch {
+	case n >= P:
+		u = "P"
+		n /= P
+	case n >= T:
+		u = "T"
+		n /= T
+	case n >= G:
+		u = "G"
+		n /= G
+	case n >= M:
+		u = "M"
+		n /= M
+	case n >= K:
+		u = "K"
+		n /= K
+	default:
+		return strconv.Itoa(n)
+	}
+	return strconv.Itoa(n) + u
+}
 
 type task struct {
 	Version  int
@@ -287,9 +321,9 @@ func listTask(ctx *cli.Context) {
 			task.ID,
 			task.Name,
 			task.State,
-			task.HitCount,
-			task.MissCount,
-			task.FailedCount,
+			trunc(task.HitCount),
+			trunc(task.MissCount),
+			trunc(task.FailedCount),
 			task.CreationTime().Format(unionParseFormat),
 			task.LastFailureMessage,
 		)


### PR DESCRIPTION
#205

(Formatting is messed up when pasted)
e.g.

```
pulsectl task list                                                      ✹ ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     81K     0   0   2:53PM 10-30-2015
pulsectl task list   ✹ ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     102K    0   0   2:53PM 10-30-2015
pulsectl task list   ✹ ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     130K    0   0   2:53PM 10-30-2015
pulsectl task list   ✹ ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     193K    0   0   2:53PM 10-30-2015
pulsectl task list   ✹ ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     325K    0   0   2:53PM 10-30-2015
pulsectl task list                                                        ✭
ID                   NAME                        STATE       HIT     MISS    FAIL    CREATED         LAST FAILURE
96af74a2-97b3-4b17-9759-6f7be1ed468d     Task-96af74a2-97b3-4b17-9759-6f7be1ed468d   Running     1M      0   0   2:53PM 10-30-2015
```
