### PR TITLE
Modified task error codes for #467

### DIFF
--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -143,12 +143,12 @@ func TestPulseClient(t *testing.T) {
 			Convey("StopTask", func() {
 				t1 := c.StopTask(uuid)
 				So(t1.Err, ShouldNotBeNil)
-				So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("error 0: No task found with ID '%s' ", uuid))
+				So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("error 0: Task not found: ID(%s) ", uuid))
 			})
 			Convey("RemoveTask", func() {
 				t1 := c.RemoveTask(uuid)
 				So(t1.Err, ShouldNotBeNil)
-				So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("No task found with ID '%s'", uuid))
+				So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("Task not found: ID(%s)", uuid))
 			})
 			Convey("invalid task (missing metric)", func() {
 				tt := c.CreateTask(sch, wf, "baron", true)
@@ -389,7 +389,7 @@ func TestPulseClient(t *testing.T) {
 						}
 					}()
 					<-wait
-					So(r.Err.Error(), ShouldEqual, "No task found with ID '1'")
+					So(r.Err.Error(), ShouldEqual, "Task not found: ID(1)")
 				})
 				Convey("event stream", func() {
 					rest.StreamingBufferWindow = 0.01


### PR DESCRIPTION
#467

Not sure if the error codes are better as 500 or 400. Used 500 for now. 
400 Bad Request
The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
500 Internal Server Error
A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.

404 Error for task not found

```
go run cmd/pulsectl/*go task start 1     ✭
Error starting task:
error 0: Task not found
ID: 1
exit status 1
```

```
INFO[0016] API request                                   _module=_mgmt-rest index=2 method=PUT url=/v1/tasks/1/start
ERRO[0016] error starting task                           _block=start-task _error=Task not found _module=scheduler task-id=1
INFO[0016] API response                                  _module=_mgmt-rest index=2 method=PUT status=Not Found status-code=404 url=/v1/tasks/1/start
```

500 error 

```
go run cmd/pulsectl/*go task start 4b64e042-924a-4021-81aa-b18495605bb6
Task is already running
ID: 4b64e042-924a-4021-81aa-b18495605bb6
```

```
INFO[0030] API request                                   _module=_mgmt-rest index=9 method=GET url=/v1/tribe/agreements
INFO[0030] API response                                  _module=_mgmt-rest index=9 method=GET status=Not Found status-code=404 url=/v1/tribe/agreements
INFO[0030] API request                                   _module=_mgmt-rest index=10 method=PUT url=/v1/tasks/4b64e042-924a-4021-81aa-b18495605bb6/start
INFO[0030] task is already running                       _block=start-task _module=scheduler task-id=4b64e042-924a-4021-81aa-b18495605bb6 task-state=Running
INFO[0030] API response                                  _module=_mgmt-rest index=10 method=PUT status=Internal Server Error status-code=500 url=/v1/tasks/4b64e042-924a-4021-81aa-b18495605bb6/start
```
