### PR TITLE
Changed published timestamp into metric's collection timestamp

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -940,7 +940,7 @@ func TestPublishMetrics(t *testing.T) {
 		<-lpe.done
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("publisher:file:2")
+		lp, err2 := c.pluginManager.get("publisher:file:3")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "file")
 		So(lp.ConfigPolicy, ShouldNotBeNil)
@@ -948,7 +948,7 @@ func TestPublishMetrics(t *testing.T) {
 		Convey("Subscribe to file publisher with good config", func() {
 			n := cdata.NewNode()
 			config.Plugins.Publisher.Plugins[lp.Name()] = newPluginConfigItem(optAddPluginConfigItem("file", ctypes.ConfigValueStr{Value: "/tmp/pulse-TestPublishMetrics.out"}))
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("publisher:file:2")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("publisher:file:3")
 			So(errp, ShouldBeNil)
 			pool.subscribe("1", unboundSubscriptionType)
 			err := c.pluginRunner.runPlugin(lp.Path)
@@ -963,7 +963,7 @@ func TestPublishMetrics(t *testing.T) {
 				enc := gob.NewEncoder(&buf)
 				enc.Encode(metrics)
 				contentType := plugin.PulseGOBContentType
-				errs := c.PublishMetrics(contentType, buf.Bytes(), "file", 2, n.Table())
+				errs := c.PublishMetrics(contentType, buf.Bytes(), "file", 3, n.Table())
 				So(errs, ShouldBeNil)
 				ap := c.AvailablePlugins()
 				So(ap, ShouldNotBeEmpty)

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -248,7 +248,7 @@ func TestPulseClient(t *testing.T) {
 			So(p3.Err, ShouldBeNil)
 			So(p3.LoadedPlugins, ShouldNotBeEmpty)
 			So(p3.LoadedPlugins[0].Name, ShouldEqual, "file")
-			So(p3.LoadedPlugins[0].Version, ShouldEqual, 2)
+			So(p3.LoadedPlugins[0].Version, ShouldEqual, 3)
 			So(p3.LoadedPlugins[0].LoadedTime().Unix(), ShouldBeLessThanOrEqualTo, time.Now().Unix())
 		})
 		Convey("there should be three loaded plugins", func() {
@@ -451,10 +451,10 @@ func TestPulseClient(t *testing.T) {
 			So(p2.Version, ShouldEqual, 2)
 			So(p2.Type, ShouldEqual, "collector")
 
-			p3 := c.UnloadPlugin("publisher", "file", 2)
+			p3 := c.UnloadPlugin("publisher", "file", 3)
 			So(p3.Err, ShouldBeNil)
 			So(p3.Name, ShouldEqual, "file")
-			So(p3.Version, ShouldEqual, 2)
+			So(p3.Version, ShouldEqual, 3)
 			So(p3.Type, ShouldEqual, "publisher")
 		})
 		Convey("unload when only one plugin loaded", func() {

--- a/plugin/publisher/pulse-publisher-file/file/file.go
+++ b/plugin/publisher/pulse-publisher-file/file/file.go
@@ -25,11 +25,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"time"
-	// "fmt"
 	"os"
-	// "strings"
-	// "time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -40,7 +36,7 @@ import (
 
 const (
 	name       = "file"
-	version    = 2
+	version    = 3
 	pluginType = plugin.PublisherPluginType
 )
 
@@ -81,7 +77,7 @@ func (f *filePublisher) Publish(contentType string, content []byte, config map[s
 		if source == "" {
 			source = "unknown"
 		}
-		w.WriteString(fmt.Sprintf("%v|%v|%v|%v\n", time.Now().Local(), m.Namespace(), m.Data(), source))
+		w.WriteString(fmt.Sprintf("%v|%v|%v|%v\n", m.Timestamp(), m.Namespace(), m.Data(), source))
 	}
 	w.Flush()
 

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -87,7 +87,7 @@ func TestCollectPublishWorkflow(t *testing.T) {
 			w.CollectNode.AddMetric("/intel/dummy/foo", 2)
 			w.CollectNode.AddConfigItem("/intel/dummy/foo", "password", "secret")
 
-			pu := wmap.NewPublishNode("file", 2)
+			pu := wmap.NewPublishNode("file", 3)
 			pu.AddConfigItem("file", "/tmp/pulse-TestCollectPublishWorkflow.out")
 
 			pr := wmap.NewProcessNode("passthru", 1)


### PR DESCRIPTION
Publish `m.Timestamp()` instead `time.Now()` as a timestamp (for issue https://github.com/intelsdi-x/pulse/issues/465)

Output format does not change. Should plugin version be incremented in this case?
