### PR TITLE
Fix 472: Need to call the functions to return Name, Version, and Type

### DIFF
--- a/pulse.go
+++ b/pulse.go
@@ -446,9 +446,9 @@ func action(ctx *cli.Context) {
 							"_module":          "pulsed",
 							"autodiscoverpath": path,
 							"plugin":           file,
-							"plugin-name":      pl.Name,
-							"plugin-version":   pl.Version,
-							"plugin-type":      pl.TypeName,
+							"plugin-name":      pl.Name(),
+							"plugin-version":   pl.Version(),
+							"plugin-type":      pl.TypeName(),
 						}).Info("Loading plugin")
 					}
 				}


### PR DESCRIPTION
Fix #472: Need to call the functions to return Name, Version, and Type of a core.CatalogedPlugin
