### PR TITLE
Expose bool as supported type in func SupportedTypes()

### DIFF
--- a/core/ctypes/ctypes.go
+++ b/core/ctypes/ctypes.go
@@ -88,6 +88,8 @@ func SupportedTypes() []string {
 		ConfigValueInt{}.Type(),
 		// Float
 		ConfigValueFloat{}.Type(),
+		// Bool
+		ConfigValueBool{}.Type(),
 	}
 	return t
 }


### PR DESCRIPTION
ConfigValueBool.Type() is not exposed in func SupportedTypes() probably by some oversight.
