### PR TITLE
Nix 'written in go' from arch section in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ limitations under the License.
 
 **Pulse** architecture
 
-* Written in Go
 * Decoupled internal structure with a focus on event-driven handling
 
 ## License


### PR DESCRIPTION
Supersedes #487.
