### PR TITLE
Fix nondeterminism in work_manager_test.

### DIFF
--- a/scheduler/work_manager.go
+++ b/scheduler/work_manager.go
@@ -200,7 +200,7 @@ func (w *workManager) Stop() {
 
 // Work dispatches jobs to worker pools for processing.
 // a job is queued, a worker receives it, and then replies
-// on the job's  reply channel.
+// on the job's reply channel.
 func (w *workManager) Work(j job) job {
 	switch j.Type() {
 	case collectJobType:


### PR DESCRIPTION
The queueing error test in `work_manager_test` was observed to be flaky, both in CI and locally when running the tests on OS X.

This patch introduces the notion of a synchronous rendez-vous to the mock jobs used in `worker_manager_test`.  The rendez-vous channel is signaled after the mock job becomes runnable.  The goroutine running that job blocks on the rendez-vous channel, allowing the unit test coordination thread fine-grained control over the concurrency of the worker threads.  We use this new structure to induce a queueing error and avoid relying on concurrent sleep.

Fixes #493.

cc @danielscottt 
