### PR TITLE
Added license info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ limitations under the License.
 
 ## License
 
-<DO NOT PUT SOMETHING HERE YET>
+Pulse is open sourced under the Apache 2.0 [License](https://github.com/intelsdi-x/pulse/blob/master/LICENSE).
 
 ## System Requirements
 


### PR DESCRIPTION
Did not see this as part of the jira stories and since we now have a license, it seemed fair game to edit. Let me know if the License section of README.md should still exist at all or just have people figure out to look at the LICENSE file. 
