### PR TITLE
fix #526: adds lookup for GetMetricVersions

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -219,7 +219,11 @@ func printFields(tw *tabwriter.Writer, indent bool, width int, fields ...interfa
 		argArray = append(argArray, strings.Repeat(" ", width))
 	}
 	for i, field := range fields {
-		argArray = append(argArray, field)
+		if field != nil {
+			argArray = append(argArray, field)
+		} else {
+			argArray = append(argArray, "")
+		}
 		if i < (len(fields) - 1) {
 			argArray = append(argArray, "\t")
 		}

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -556,7 +556,7 @@ type mc struct {
 	e int
 }
 
-func (m *mc) Fetch(ns []string) ([]*metricType, serror.SnapError) {
+func (m *mc) Fetch(ns []string) ([]*metricType, error) {
 	if m.e == 2 {
 		return nil, serror.New(errors.New("test"))
 	}
@@ -567,11 +567,15 @@ func (m *mc) resolvePlugin(mns []string, ver int) (*loadedPlugin, error) {
 	return nil, nil
 }
 
-func (m *mc) GetPlugin([]string, int) (*loadedPlugin, serror.SnapError) {
+func (m *mc) GetPlugin([]string, int) (*loadedPlugin, error) {
 	return nil, nil
 }
 
-func (m *mc) Get(ns []string, ver int) (*metricType, serror.SnapError) {
+func (m *mc) GetVersions([]string) ([]*metricType, error) {
+	return nil, nil
+}
+
+func (m *mc) Get(ns []string, ver int) (*metricType, error) {
 	if m.e == 1 {
 		return &metricType{
 			policy: &mockCDProc{},
@@ -580,14 +584,14 @@ func (m *mc) Get(ns []string, ver int) (*metricType, serror.SnapError) {
 	return nil, serror.New(errorMetricNotFound(ns))
 }
 
-func (m *mc) Subscribe(ns []string, ver int) serror.SnapError {
+func (m *mc) Subscribe(ns []string, ver int) error {
 	if ns[0] == "nf" {
 		return serror.New(errorMetricNotFound(ns))
 	}
 	return nil
 }
 
-func (m *mc) Unsubscribe(ns []string, ver int) serror.SnapError {
+func (m *mc) Unsubscribe(ns []string, ver int) error {
 	if ns[0] == "nf" {
 		return serror.New(errorMetricNotFound(ns))
 	}

--- a/control/metrics_test.go
+++ b/control/metrics_test.go
@@ -140,8 +140,6 @@ func TestMetricCatalog(t *testing.T) {
 			mc.Add(m35)
 			_, err := mc.Get([]string{"foo", "bar"}, 7)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/foo/bar")
-			So(err.Fields()["version"], ShouldEqual, 7)
 		})
 	})
 	Convey("metricCatalog.Table()", t, func() {
@@ -164,7 +162,6 @@ func TestMetricCatalog(t *testing.T) {
 			_mt, err := mc.Get(ns, -1)
 			So(_mt, ShouldBeNil)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/test")
 		})
 	})
 	Convey("metricCatalog.Next()", t, func() {
@@ -243,7 +240,6 @@ func TestSubscribe(t *testing.T) {
 		Convey("then it returns an error", func() {
 			err := mc.Subscribe([]string{"test4"}, -1)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/test4")
 		})
 	})
 	Convey("when the metric is in the table", t, func() {
@@ -289,7 +285,6 @@ func TestUnsubscribe(t *testing.T) {
 		Convey("then it returns metric not found error", func() {
 			err := mc.Unsubscribe([]string{"test4"}, -1)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/test4")
 		})
 	})
 	Convey("when the metric's count is already 0", t, func() {

--- a/control/mttrie.go
+++ b/control/mttrie.go
@@ -22,9 +22,6 @@ package control
 import (
 	"errors"
 	"fmt"
-
-	"github.com/intelsdi-x/snap/core"
-	"github.com/intelsdi-x/snap/core/serror"
 )
 
 /*
@@ -146,7 +143,7 @@ func (mtt *mttNode) Add(mt *metricType) {
 
 // Collect collects all children below a given namespace
 // and concatenates their metric types into a single slice
-func (mtt *mttNode) Fetch(ns []string) ([]*metricType, serror.SnapError) {
+func (mtt *mttNode) Fetch(ns []string) ([]*metricType, error) {
 	node, err := mtt.find(ns)
 	if err != nil {
 		return nil, err
@@ -171,7 +168,7 @@ func (mtt *mttNode) Fetch(ns []string) ([]*metricType, serror.SnapError) {
 }
 
 // Remove removes all children below a given namespace
-func (mtt *mttNode) Remove(ns []string) serror.SnapError {
+func (mtt *mttNode) Remove(ns []string) error {
 	_, err := mtt.find(ns)
 	if err != nil {
 		return err
@@ -189,17 +186,13 @@ func (mtt *mttNode) Remove(ns []string) serror.SnapError {
 
 // Get works like fetch, but only returns the MT at the given node
 // and does not gather the node's children.
-func (mtt *mttNode) Get(ns []string) ([]*metricType, serror.SnapError) {
+func (mtt *mttNode) Get(ns []string) ([]*metricType, error) {
 	node, err := mtt.find(ns)
 	if err != nil {
 		return nil, err
 	}
 	if node.mts == nil {
-		se := serror.New(errorMetricNotFound(ns))
-		se.SetFields(map[string]interface{}{
-			"name": core.JoinNamespace(ns),
-		})
-		return nil, se
+		return nil, errorMetricNotFound(ns)
 	}
 	var mts []*metricType
 	for _, mt := range node.mts {
@@ -226,14 +219,10 @@ func (mtt *mttNode) walk(ns []string) (*mttNode, int) {
 	return parent, len(ns)
 }
 
-func (mtt *mttNode) find(ns []string) (*mttNode, serror.SnapError) {
+func (mtt *mttNode) find(ns []string) (*mttNode, error) {
 	node, index := mtt.walk(ns)
 	if index != len(ns) {
-		se := serror.New(errorMetricNotFound(ns))
-		se.SetFields(map[string]interface{}{
-			"name": core.JoinNamespace(ns),
-		})
-		return nil, se
+		return nil, errorMetricNotFound(ns)
 	}
 	return node, nil
 }

--- a/control/mttrie_test.go
+++ b/control/mttrie_test.go
@@ -104,7 +104,6 @@ func TestTrie(t *testing.T) {
 			_, err := trie.Fetch([]string{"not", "present"})
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/not/present")
 		})
 		Convey("Fetch with error: depth exceeded", func() {
 			lp := new(loadedPlugin)
@@ -114,7 +113,6 @@ func TestTrie(t *testing.T) {
 			_, err := trie.Fetch([]string{"intel", "foo", "bar", "baz"})
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/intel/foo/bar/baz")
 
 		})
 	})
@@ -138,7 +136,6 @@ func TestTrie(t *testing.T) {
 			n, err := trie.Get([]string{"intel"})
 			So(n, ShouldBeNil)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
-			So(err.Fields()["name"], ShouldEqual, "/intel")
 		})
 	})
 }

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -121,11 +121,11 @@ func TestLoadPlugin(t *testing.T) {
 				cfg.Plugins.Collector.Plugins["mock2"] = newPluginConfigItem(optAddPluginConfigItem("test", ctypes.ConfigValueBool{Value: true}))
 				p := newPluginManager(OptSetPluginConfig(cfg.Plugins))
 				p.SetMetricCatalog(newMetricCatalog())
-				lp, err := loadPlugin(p, PluginPath)
+				lp, serr := loadPlugin(p, PluginPath)
 
 				So(lp, ShouldHaveSameTypeAs, new(loadedPlugin))
 				So(p.all(), ShouldNotBeEmpty)
-				So(err, ShouldBeNil)
+				So(serr, ShouldBeNil)
 				So(len(p.all()), ShouldBeGreaterThan, 0)
 				mts, err := p.metricCatalog.Fetch([]string{})
 				So(err, ShouldBeNil)

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -57,6 +57,7 @@ var (
 type managesMetrics interface {
 	MetricCatalog() ([]core.CatalogedMetric, error)
 	FetchMetrics([]string, int) ([]core.CatalogedMetric, error)
+	GetMetricVersions([]string) ([]core.CatalogedMetric, error)
 	GetMetric([]string, int) (core.CatalogedMetric, error)
 	Load(*core.RequestedPlugin) (core.CatalogedPlugin, serror.SnapError)
 	Unload(core.Plugin) (core.CatalogedPlugin, serror.SnapError)


### PR DESCRIPTION
This commit adds a lookup to fetch all metrics of a given namespace
without traversing to the leaves and collecting children.