### PR TITLE
Removed github token from docker run tests script

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,7 @@ ENV SNAP_PATH=/go/src/github.com/intelsdi-x/snap/build
 RUN apt-get update && \
     apt-get -y install facter
 WORKDIR /go/src/github.com/intelsdi-x/
-RUN git clone https://<GIT_TOKEN>@github.com/intelsdi-x/gomit.git
+RUN git clone https://github.com/intelsdi-x/gomit.git
 WORKDIR /go/src/github.com/intelsdi-x/snap
 ADD . /go/src/github.com/intelsdi-x/snap
 RUN go get github.com/tools/godep && \

--- a/scripts/run_tests_with_docker.sh
+++ b/scripts/run_tests_with_docker.sh
@@ -17,20 +17,5 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-die() {
-    echo >&2 $@
-    exit 1
-}
-
-if [ $# -eq  2 ]; then
-	GIT_TOKEN=$1
-fi
-
-if [ -z "${GIT_TOKEN}" ]; then
-	die "arg missing: github token is required so we can clone a private repo)"
-fi
-
-sed s/\<GIT_TOKEN\>/${GIT_TOKEN}/ scripts/Dockerfile > scripts/Dockerfile.tmp
-docker build -t intelsdi-x/snap-test -f scripts/Dockerfile.tmp .
-rm scripts/Dockerfile.tmp
+docker build -t intelsdi-x/snap-test -f scripts/Dockerfile .
 docker run -it intelsdi-x/snap-test scripts/test.sh


### PR DESCRIPTION
Since this repo is public, a github token is no longer needed.