### PR TITLE
Fix for issue #451

### DIFF
--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -368,6 +368,7 @@ func watchTask(ctx *cli.Context) {
 			case "metric-event":
 				sort.Sort(e.Event)
 				for _, event := range e.Event {
+					fmt.Printf("\033[0J")
 					printFields(w, false, 0,
 						event.Namespace,
 						event.Data,


### PR DESCRIPTION
cmd/snapctl/task.go: CSI erase display from cursor to bottom of the screen before printFields()