### PR TITLE
Fixes #608. Added snapctl t:n:v unload/config get option

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -92,7 +92,7 @@ var (
 			Subcommands: []cli.Command{
 				{
 					Name:   "load",
-					Usage:  "load <plugin path>",
+					Usage:  "load <plugin_path>",
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
@@ -100,7 +100,7 @@ var (
 				},
 				{
 					Name:   "unload",
-					Usage:  "unload",
+					Usage:  "unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>",
 					Action: unloadPlugin,
 					Flags: []cli.Flag{
 						flPluginType,
@@ -200,7 +200,7 @@ var (
 			Subcommands: []cli.Command{
 				{
 					Name:   "get",
-					Usage:  "get",
+					Usage:  "get <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>",
 					Action: getConfig,
 					Flags: []cli.Flag{
 						flPluginName,

--- a/cmd/snapctl/config.go
+++ b/cmd/snapctl/config.go
@@ -20,7 +20,9 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"text/tabwriter"
 
@@ -29,9 +31,42 @@ import (
 )
 
 func getConfig(ctx *cli.Context) {
-	ptyp := ctx.String("plugin-type")
-	pname := ctx.String("plugin-name")
-	pver := ctx.Int("plugin-version")
+	pDetails := filepath.SplitList(ctx.Args().First())
+	var ptyp string
+	var pname string
+	var pver int
+	var err error
+
+	if len(pDetails) == 3 {
+		ptyp = pDetails[0]
+		pname = pDetails[1]
+		pver, err = strconv.Atoi(pDetails[2])
+		if err != nil {
+			fmt.Println("Can't convert version string to integer")
+			cli.ShowCommandHelp(ctx, ctx.Command.Name)
+			os.Exit(1)
+		}
+	} else {
+		ptyp = ctx.String("plugin-type")
+		pname = ctx.String("plugin-name")
+		pver = ctx.Int("plugin-version")
+	}
+
+	if ptyp == "" {
+		fmt.Println("Must provide plugin type")
+		cli.ShowCommandHelp(ctx, ctx.Command.Name)
+		os.Exit(1)
+	}
+	if pname == "" {
+		fmt.Println("Must provide plugin name")
+		cli.ShowCommandHelp(ctx, ctx.Command.Name)
+		os.Exit(1)
+	}
+	if pver < 1 {
+		fmt.Println("Must provide plugin version")
+		cli.ShowCommandHelp(ctx, ctx.Command.Name)
+		os.Exit(1)
+	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	defer w.Flush()
 	printFields(w, false, 0,

--- a/cmd/snapctl/plugin.go
+++ b/cmd/snapctl/plugin.go
@@ -22,6 +22,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -66,9 +68,31 @@ func loadPlugin(ctx *cli.Context) {
 }
 
 func unloadPlugin(ctx *cli.Context) {
-	pType := ctx.String("plugin-type")
-	pName := ctx.String("plugin-name")
-	pVer := ctx.Int("plugin-version")
+	pDetails := filepath.SplitList(ctx.Args().First())
+	var pType string
+	var pName string
+	var pVer int
+	var err error
+
+	if len(pDetails) == 3 {
+		pType = pDetails[0]
+		pName = pDetails[1]
+		pVer, err = strconv.Atoi(pDetails[2])
+		if err != nil {
+			fmt.Println("Can't convert version string to integer")
+			cli.ShowCommandHelp(ctx, ctx.Command.Name)
+			os.Exit(1)
+		}
+	} else {
+		pType = ctx.String("plugin-type")
+		pName = ctx.String("plugin-name")
+		pVer = ctx.Int("plugin-version")
+	}
+	if pType == "" {
+		fmt.Println("Must provide plugin type")
+		cli.ShowCommandHelp(ctx, ctx.Command.Name)
+		os.Exit(1)
+	}
 	if pName == "" {
 		fmt.Println("Must provide plugin name")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)


### PR DESCRIPTION
For issue #608 
```
go run cmd/snapctl/*go plugin unload collector:mock1:1
Plugin unloaded
Name: mock1
Version: 1
Type: collector
```
```
go run cmd/snapctl/*go plugin unload -t collector -n mock2 -v 2
Plugin unloaded
Name: mock2
Version: 2
Type: collector
```
```
 go run cmd/snapctl/*go plugin unload collector:mock1:2
Error unloading plugin:
plugin not found
exit status 1
```
```
go run cmd/snapctl/*go plugin unload -h
NAME:
   unload - unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>

USAGE:
   command unload [command options] [arguments...]

OPTIONS:
   --plugin-type, -t 		The plugin type
   --plugin-name, -n 		The plugin name
   --plugin-version, -v '0'	The plugin version
```
```
go run cmd/snapctl/*go plugin unload collector:mock1
Must provide plugin type
NAME:
   unload - unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>

USAGE:
   command unload [command options] [arguments...]

OPTIONS:
   --plugin-type, -t 		The plugin type
   --plugin-name, -n 		The plugin name
   --plugin-version, -v '0'	The plugin version

exit status 1
```
```
go run cmd/snapctl/*go plugin unload -t collector -n mock2
Must provide plugin version
NAME:
   unload - unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>

USAGE:
   command unload [command options] [arguments...]

OPTIONS:
   --plugin-type, -t 		The plugin type
   --plugin-name, -n 		The plugin name
   --plugin-version, -v '0'	The plugin version
```