### PR TITLE
Made `workManager.Work` nonblocking.

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -99,7 +99,7 @@ type scheduler struct {
 }
 
 type managesWork interface {
-	Work(job) job
+	Work(job) queuedJob
 }
 
 // New returns an instance of the scheduler


### PR DESCRIPTION
_Summary:_
- Gives control over blocking semantics to the caller via a new type in package scope called `queuedJob`.
- Adds tests for `queuedJob`.
- Eliminates use of `time.Sleep` in one of the scheduler queue tests.
- Eliminates use of `time.Sleep` in one of the scheduler worker tests.
- Eliminates use of `time.Sleep` in the scheduler worker manager tests.
- Fixes #493.

_Testing done:_
- `make test`
- `GOMAXPROCS=1 make test`