### PR TITLE
Fixes #525 swap plugins of diff types

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -139,32 +139,37 @@ func TestSwapPlugin(t *testing.T) {
 		}
 		<-lpe.done
 		Convey("First plugin in catalog", t, func() {
-			Convey("Should have name mock2", func() {
-				So(c.PluginCatalog()[0].Name(), ShouldEqual, "mock2")
+			Convey("Should have name mock", func() {
+				So(c.PluginCatalog()[0].Name(), ShouldEqual, "mock")
 			})
 		})
 		mock1Path := strings.Replace(PluginPath, "snap-collector-mock2", "snap-collector-mock1", 1)
 		mockRP, _ := core.NewRequestedPlugin(mock1Path)
 		err := c.SwapPlugins(mockRP, c.PluginCatalog()[0])
-		<-lpe.done
-
-		// Swap plugin that was loaded with a different plugin
 		Convey("Swapping plugins", t, func() {
 			Convey("Should not error", func() {
 				So(err, ShouldBeNil)
 			})
+		})
+		if err != nil {
+			t.FailNow()
+		}
+		<-lpe.done
+
+		// Swap plugin that was loaded with a different version of the plugin
+		Convey("Swapping plugins", t, func() {
 			Convey("Should generate a swapped plugins event", func() {
-				Convey("So first plugin in catalog after swap should have name mock1", func() {
-					So(c.PluginCatalog()[0].Name(), ShouldEqual, "mock1")
+				Convey("So first plugin in catalog after swap should have name mock", func() {
+					So(c.PluginCatalog()[0].Name(), ShouldEqual, "mock")
 				})
-				Convey("So swapped plugins event should show loaded plugin name as mock1", func() {
-					So(lpe.plugin.LoadedPluginName, ShouldEqual, "mock1")
+				Convey("So swapped plugins event should show loaded plugin name as mock", func() {
+					So(lpe.plugin.LoadedPluginName, ShouldEqual, "mock")
 				})
 				Convey("So swapped plugins event should show loaded plugin version as 1", func() {
 					So(lpe.plugin.LoadedPluginVersion, ShouldEqual, 1)
 				})
-				Convey("So swapped plugins event should show unloaded plugin name as mock2", func() {
-					So(lpe.plugin.UnloadedPluginName, ShouldEqual, "mock2")
+				Convey("So swapped plugins event should show unloaded plugin name as mock", func() {
+					So(lpe.plugin.UnloadedPluginName, ShouldEqual, "mock")
 				})
 				Convey("So swapped plugins event should show unloaded plugin version as 2", func() {
 					So(lpe.plugin.UnloadedPluginVersion, ShouldEqual, 2)
@@ -172,6 +177,22 @@ func TestSwapPlugin(t *testing.T) {
 				Convey("So swapped plugins event should show plugin type as collector", func() {
 					So(lpe.plugin.PluginType, ShouldEqual, int(plugin.CollectorPluginType))
 				})
+			})
+		})
+
+		// Swap plugin with a different type of plugin
+		Convey("First plugin in catalog", t, func() {
+			Convey("Should have name mock", func() {
+				So(c.PluginCatalog()[0].Name(), ShouldEqual, "mock")
+			})
+		})
+
+		filePath := strings.Replace(PluginPath, "snap-collector-mock2", "snap-publisher-file", 1)
+		fileRP, _ := core.NewRequestedPlugin(filePath)
+		err = c.SwapPlugins(fileRP, c.PluginCatalog()[0])
+		Convey("Swapping mock and file plugins", t, func() {
+			Convey("Should error", func() {
+				So(err, ShouldNotBeNil)
 			})
 		})
 
@@ -193,6 +214,7 @@ func TestSwapPlugin(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 		})
+
 		c.Stop()
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -297,8 +319,8 @@ func TestLoad(t *testing.T) {
 
 		Convey("pluginControl.Load on successful load", t, func() {
 			Convey("should emit a plugin event message", func() {
-				Convey("with loaded plugin name is mock2", func() {
-					So(lpe.plugin.LoadedPluginName, ShouldEqual, "mock2")
+				Convey("with loaded plugin name is mock", func() {
+					So(lpe.plugin.LoadedPluginName, ShouldEqual, "mock")
 				})
 				Convey("with loaded plugin version as 2", func() {
 					So(lpe.plugin.LoadedPluginVersion, ShouldEqual, 2)
@@ -401,8 +423,8 @@ func TestUnload(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 			Convey("should generate an unloaded plugin event", func() {
-				Convey("where unloaded plugin name is mock2", func() {
-					So(lpe.plugin.UnloadedPluginName, ShouldEqual, "mock2")
+				Convey("where unloaded plugin name is mock", func() {
+					So(lpe.plugin.UnloadedPluginName, ShouldEqual, "mock")
 				})
 				Convey("where unloaded plugin version should equal 2", func() {
 					So(lpe.plugin.UnloadedPluginVersion, ShouldEqual, 2)
@@ -843,10 +865,10 @@ func TestCollectDynamicMetrics(t *testing.T) {
 		So(errs, ShouldBeNil)
 		So(metric, ShouldNotBeNil)
 		Convey("collects metrics from plugin using native client", func() {
-			lp, err := c.pluginManager.get("collector:mock2:2")
+			lp, err := c.pluginManager.get("collector:mock:2")
 			So(err, ShouldBeNil)
 			So(lp, ShouldNotBeNil)
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock2:2")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
 			So(errp, ShouldBeNil)
 			So(pool, ShouldNotBeNil)
 			pool.subscribe("1", unboundSubscriptionType)
@@ -866,10 +888,10 @@ func TestCollectDynamicMetrics(t *testing.T) {
 			So(len(mts), ShouldEqual, 10)
 			pool.unsubscribe("1")
 			Convey("collects metrics from plugin using httpjson client", func() {
-				lp, err := c.pluginManager.get("collector:mock1:1")
+				lp, err := c.pluginManager.get("collector:mock:1")
 				So(err, ShouldBeNil)
 				So(lp, ShouldNotBeNil)
-				pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock1:1")
+				pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
 				So(errp, ShouldBeNil)
 				So(pool, ShouldNotBeNil)
 				pool.subscribe("1", unboundSubscriptionType)
@@ -917,7 +939,7 @@ func TestCollectMetrics(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// Add a global plugin config
-		c.Config.Plugins.Collector.Plugins["mock1"] = newPluginConfigItem(optAddPluginConfigItem("test", ctypes.ConfigValueBool{Value: true}))
+		c.Config.Plugins.Collector.Plugins["mock"] = newPluginConfigItem(optAddPluginConfigItem("test", ctypes.ConfigValueBool{Value: true}))
 
 		// Load plugin
 		load(c, JSONRPC_PluginPath)
@@ -944,10 +966,10 @@ func TestCollectMetrics(t *testing.T) {
 		}
 
 		// retrieve loaded plugin
-		lp, err := c.pluginManager.get("collector:mock1:1")
+		lp, err := c.pluginManager.get("collector:mock:1")
 		So(err, ShouldBeNil)
 		So(lp, ShouldNotBeNil)
-		pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock1:1")
+		pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
 		So(errp, ShouldBeNil)
 		pool.subscribe("1", unboundSubscriptionType)
 		err = c.pluginRunner.runPlugin(lp.Details)

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -118,7 +118,7 @@ func TestLoadPlugin(t *testing.T) {
 
 			Convey("with a plugin config a plugin loads successfully", func() {
 				cfg := NewConfig()
-				cfg.Plugins.Collector.Plugins["mock2"] = newPluginConfigItem(optAddPluginConfigItem("test", ctypes.ConfigValueBool{Value: true}))
+				cfg.Plugins.Collector.Plugins["mock"] = newPluginConfigItem(optAddPluginConfigItem("test", ctypes.ConfigValueBool{Value: true}))
 				p := newPluginManager(OptSetPluginConfig(cfg.Plugins))
 				p.SetMetricCatalog(newMetricCatalog())
 				lp, serr := loadPlugin(p, PluginPath)
@@ -134,7 +134,7 @@ func TestLoadPlugin(t *testing.T) {
 
 			Convey("for a plugin requiring a config an incomplete config will result in a load failure", func() {
 				cfg := NewConfig()
-				cfg.Plugins.Collector.Plugins["mock2"] = newPluginConfigItem(optAddPluginConfigItem("test-fail", ctypes.ConfigValueBool{Value: true}))
+				cfg.Plugins.Collector.Plugins["mock"] = newPluginConfigItem(optAddPluginConfigItem("test-fail", ctypes.ConfigValueBool{Value: true}))
 				p := newPluginManager(OptSetPluginConfig(cfg.Plugins))
 				p.SetMetricCatalog(newMetricCatalog())
 				lp, err := loadPlugin(p, PluginPath)
@@ -185,7 +185,7 @@ func TestUnloadPlugin(t *testing.T) {
 
 					numPluginsLoaded := len(p.all())
 					So(numPluginsLoaded, ShouldEqual, 1)
-					lp, _ := p.get("collector:mock2:2")
+					lp, _ := p.get("collector:mock:2")
 					_, err = p.UnloadPlugin(lp)
 
 					So(err, ShouldBeNil)
@@ -198,7 +198,7 @@ func TestUnloadPlugin(t *testing.T) {
 					p := newPluginManager()
 					p.SetMetricCatalog(newMetricCatalog())
 					lp, err := loadPlugin(p, PluginPath)
-					glp, err2 := p.get("collector:mock2:2")
+					glp, err2 := p.get("collector:mock:2")
 					So(err2, ShouldBeNil)
 					glp.State = DetectedState
 					_, err = p.UnloadPlugin(lp)
@@ -212,7 +212,7 @@ func TestUnloadPlugin(t *testing.T) {
 					p.SetMetricCatalog(newMetricCatalog())
 					_, err := loadPlugin(p, PluginPath)
 
-					lp, err2 := p.get("collector:mock2:2")
+					lp, err2 := p.get("collector:mock:2")
 					So(err2, ShouldBeNil)
 					_, err = p.UnloadPlugin(lp)
 

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -162,7 +162,7 @@ func TestSnapClient(t *testing.T) {
 
 			So(p1.Err, ShouldBeNil)
 			So(p1.LoadedPlugins, ShouldNotBeEmpty)
-			So(p1.LoadedPlugins[0].Name, ShouldEqual, "mock1")
+			So(p1.LoadedPlugins[0].Name, ShouldEqual, "mock")
 			So(p1.LoadedPlugins[0].Version, ShouldEqual, 1)
 			So(p1.LoadedPlugins[0].LoadedTime().Unix(), ShouldBeLessThanOrEqualTo, time.Now().Unix())
 		})
@@ -189,7 +189,7 @@ func TestSnapClient(t *testing.T) {
 		Convey("an error should not be received loading second plugin", func() {
 			So(p2.Err, ShouldBeNil)
 			So(p2.LoadedPlugins, ShouldNotBeEmpty)
-			So(p2.LoadedPlugins[0].Name, ShouldEqual, "mock2")
+			So(p2.LoadedPlugins[0].Name, ShouldEqual, "mock")
 			So(p2.LoadedPlugins[0].Version, ShouldEqual, 2)
 			So(p2.LoadedPlugins[0].LoadedTime().Unix(), ShouldBeLessThanOrEqualTo, time.Now().Unix())
 		})
@@ -449,9 +449,9 @@ func TestSnapClient(t *testing.T) {
 			So(p1.Err, ShouldBeNil)
 			So(len(p1.LoadedPlugins), ShouldEqual, 3)
 
-			p2 := c.UnloadPlugin("collector", "mock2", 2)
+			p2 := c.UnloadPlugin("collector", "mock", 2)
 			So(p2.Err, ShouldBeNil)
-			So(p2.Name, ShouldEqual, "mock2")
+			So(p2.Name, ShouldEqual, "mock")
 			So(p2.Version, ShouldEqual, 2)
 			So(p2.Type, ShouldEqual, "collector")
 
@@ -465,11 +465,11 @@ func TestSnapClient(t *testing.T) {
 			p1 := c.GetPlugins(false)
 			So(p1.Err, ShouldBeNil)
 			So(len(p1.LoadedPlugins), ShouldEqual, 1)
-			So(p1.LoadedPlugins[0].Name, ShouldEqual, "mock1")
+			So(p1.LoadedPlugins[0].Name, ShouldEqual, "mock")
 
-			p2 := c.UnloadPlugin("collector", "mock1", 1)
+			p2 := c.UnloadPlugin("collector", "mock", 1)
 			So(p2.Err, ShouldBeNil)
-			So(p2.Name, ShouldEqual, "mock1")
+			So(p2.Name, ShouldEqual, "mock")
 			So(p2.Version, ShouldEqual, 1)
 			So(p2.Type, ShouldEqual, "collector")
 

--- a/plugin/collector/snap-collector-mock1/mock/mock.go
+++ b/plugin/collector/snap-collector-mock1/mock/mock.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Name of plugin
-	Name = "mock1"
+	Name = "mock"
 	// Version of plugin
 	Version = 1
 	// Type of plugin

--- a/plugin/collector/snap-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-collector-mock2/mock/mock.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Name of plugin
-	Name = "mock2"
+	Name = "mock"
 	// Version of plugin
 	Version = 2
 	// Type of plugin


### PR DESCRIPTION
#525 
Based on feedback from @danielscottt, mock 1 and mock 2 plugin names should just be mock since they're different versions of mock plugins. Made this change.

Also swap now verifies that the plugins are the same type and name.