### PR TITLE
Fixes for #626 and #628

### DIFF
--- a/control/metrics_test.go
+++ b/control/metrics_test.go
@@ -84,9 +84,9 @@ func TestMetricCatalog(t *testing.T) {
 		ts := time.Now()
 		Convey("add multiple metricTypes and get them back", func() {
 			ns := [][]string{
-				[]string{"test1"},
-				[]string{"test2"},
-				[]string{"test3"},
+				{"test1"},
+				{"test2"},
+				{"test3"},
 			}
 			lp := new(loadedPlugin)
 			mt := []*metricType{
@@ -180,9 +180,9 @@ func TestMetricCatalog(t *testing.T) {
 	})
 	Convey("metricCatalog.Item()", t, func() {
 		ns := [][]string{
-			[]string{"test1"},
-			[]string{"test2"},
-			[]string{"test3"},
+			{"test1"},
+			{"test2"},
+			{"test3"},
 		}
 		lp := new(loadedPlugin)
 		t := time.Now()
@@ -221,9 +221,9 @@ func TestMetricCatalog(t *testing.T) {
 
 func TestSubscribe(t *testing.T) {
 	ns := [][]string{
-		[]string{"test1"},
-		[]string{"test2"},
-		[]string{"test3"},
+		{"test1"},
+		{"test2"},
+		{"test3"},
 	}
 	lp := new(loadedPlugin)
 	ts := time.Now()
@@ -255,9 +255,9 @@ func TestSubscribe(t *testing.T) {
 
 func TestUnsubscribe(t *testing.T) {
 	ns := [][]string{
-		[]string{"test1"},
-		[]string{"test2"},
-		[]string{"test3"},
+		{"test1"},
+		{"test2"},
+		{"test3"},
 	}
 	lp := new(loadedPlugin)
 	ts := time.Now()

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -47,7 +47,7 @@ func (p *mockPlugin) GetMetricTypes(cfg PluginConfigType) ([]PluginMetricType, e
 
 func (p *mockPlugin) CollectMetrics(mockPluginMetricTypes []PluginMetricType) ([]PluginMetricType, error) {
 	for i := range mockPluginMetricTypes {
-		mockPluginMetricTypes[i].Labels_ = []core.Label{core.Label{Index: 0, Name: "test"}}
+		mockPluginMetricTypes[i].Labels_ = []core.Label{{Index: 0, Name: "test"}}
 		mockPluginMetricTypes[i].Tags_ = map[string]string{"key": "value"}
 	}
 	return mockPluginMetricTypes, nil

--- a/control/plugin/collector_test.go
+++ b/control/plugin/collector_test.go
@@ -40,7 +40,7 @@ func (f *MockPlugin) CollectMetrics(_ []PluginMetricType) ([]PluginMetricType, e
 
 func (c *MockPlugin) GetMetricTypes(_ PluginConfigType) ([]PluginMetricType, error) {
 	return []PluginMetricType{
-		PluginMetricType{Namespace_: []string{"foo", "bar"}},
+		{Namespace_: []string{"foo", "bar"}},
 	}, nil
 }
 

--- a/mgmt/rest/client/metric.go
+++ b/mgmt/rest/client/metric.go
@@ -139,7 +139,7 @@ func (g *GetMetricsResult) Len() int {
 
 func convertCatalog(c *rbody.MetricsReturned) []*rbody.Metric {
 	mci := make([]*rbody.Metric, len(*c))
-	for i, _ := range *c {
+	for i := range *c {
 		mci[i] = &(*c)[i]
 	}
 	return mci

--- a/mgmt/rest/client/plugin.go
+++ b/mgmt/rest/client/plugin.go
@@ -148,7 +148,7 @@ type AvailablePlugin struct {
 
 func convertLoadedPlugins(r []rbody.LoadedPlugin) []LoadedPlugin {
 	lp := make([]LoadedPlugin, len(r))
-	for i, _ := range r {
+	for i := range r {
 		lp[i] = LoadedPlugin{&r[i]}
 	}
 	return lp
@@ -156,7 +156,7 @@ func convertLoadedPlugins(r []rbody.LoadedPlugin) []LoadedPlugin {
 
 func convertAvailablePlugins(r []rbody.AvailablePlugin) []AvailablePlugin {
 	lp := make([]AvailablePlugin, len(r))
-	for i, _ := range r {
+	for i := range r {
 		lp[i] = AvailablePlugin{&r[i]}
 	}
 	return lp

--- a/mgmt/rest/plugin.go
+++ b/mgmt/rest/plugin.go
@@ -259,7 +259,7 @@ func (s *Server) unloadPlugin(w http.ResponseWriter, r *http.Request, p httprout
 func (s *Server) getPlugins(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	var detail bool
 	// make this a function because DRY
-	for k, _ := range r.URL.Query() {
+	for k := range r.URL.Query() {
 		if k == "details" {
 			detail = true
 		}

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -359,7 +359,7 @@ type TaskWatchHandler struct {
 
 func (t *TaskWatchHandler) CatchCollection(m []core.Metric) {
 	sm := make([]rbody.StreamedMetric, len(m))
-	for i, _ := range m {
+	for i := range m {
 		sm[i] = rbody.StreamedMetric{
 			Namespace: core.JoinNamespace(m[i].Namespace()),
 			Data:      m[i].Data(),

--- a/mgmt/tribe/tribe.go
+++ b/mgmt/tribe/tribe.go
@@ -1088,7 +1088,7 @@ func (t *tribe) handleMemberLeave(n *memberlist.Node) {
 		if m.PluginAgreement != nil {
 			delete(t.agreements[m.PluginAgreement.Name].Members, n.Name)
 		}
-		for k, _ := range m.TaskAgreements {
+		for k := range m.TaskAgreements {
 			delete(t.agreements[k].Members, n.Name)
 		}
 		delete(t.members, n.Name)

--- a/plugin/collector/snap-collector-mock1/main_test.go
+++ b/plugin/collector/snap-collector-mock1/main_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	PluginName = "snap-collector-mock1"
 	PluginType = "collector"
-	SnapPath  = os.Getenv("SNAP_PATH")
+	SnapPath   = os.Getenv("SNAP_PATH")
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/collector/snap-collector-mock1/mock/mock.go
+++ b/plugin/collector/snap-collector-mock1/mock/mock.go
@@ -98,7 +98,7 @@ func (f *Mock) GetMetricTypes(cfg plugin.PluginConfigType) ([]plugin.PluginMetri
 	mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"intel", "mock", "bar"}})
 	mts = append(mts, plugin.PluginMetricType{
 		Namespace_: []string{"intel", "mock", "*", "baz"},
-		Labels_:    []core.Label{core.Label{Index: 2, Name: "host"}},
+		Labels_:    []core.Label{{Index: 2, Name: "host"}},
 	})
 	return mts, nil
 }

--- a/plugin/collector/snap-collector-mock2/main_test.go
+++ b/plugin/collector/snap-collector-mock2/main_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	PluginName = "snap-collector-mock2"
 	PluginType = "collector"
-	SnapPath  = os.Getenv("SNAP_PATH")
+	SnapPath   = os.Getenv("SNAP_PATH")
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/collector/snap-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-collector-mock2/mock/mock.go
@@ -91,7 +91,7 @@ func (f *Mock) GetMetricTypes(cfg plugin.PluginConfigType) ([]plugin.PluginMetri
 	mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"intel", "mock", "bar"}})
 	mts = append(mts, plugin.PluginMetricType{
 		Namespace_: []string{"intel", "mock", "*", "baz"},
-		Labels_:    []core.Label{core.Label{Index: 2, Name: "host"}},
+		Labels_:    []core.Label{{Index: 2, Name: "host"}},
 	})
 	return mts, nil
 }

--- a/plugin/publisher/snap-publisher-file/main_test.go
+++ b/plugin/publisher/snap-publisher-file/main_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	PluginName = "snap-publisher-file"
 	PluginType = "publisher"
-	SnapPath  = os.Getenv("SNAP_PATH")
+	SnapPath   = os.Getenv("SNAP_PATH")
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,7 +38,7 @@ set -e
 
 # Automatic checks
 echo "gofmt"
-test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+test -z "$(gofmt -s -l -d $TEST_DIRS | tee /dev/stderr)"
 
 echo "goimports"
 test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"


### PR DESCRIPTION
This PR fixes issues #626 and #628.

#626 addresses gofmt -s issues reported by goreportcard.com.
#628 adds the -s flag to the gofmt command in scripts/test.sh in order for gofmt -s to be run make test is execute and throw an error if gofmt -s returns any issues.