### PR TITLE
Updated godep for Sirupsen/logrus

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,8 +8,8 @@
 		},
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
-			"Comment": "v0.7.3",
-			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"
+			"Comment": "v0.8.3",
+			"Rev": "cd321ca94de831148a41ea220fb3db7db88d45b3"
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",


### PR DESCRIPTION
Addresses:
```
bash -c "./scripts/deps.sh"
Checking snap root for deps
godep: error restoring dep (github.com/Sirupsen/logrus): Unable to find dependent package golang.org/x/sys/unix in context of /home/travis/gopath/src/github.com/Sirupsen/logrus
```