### PR TITLE
Use the global TTL if it is greater than the (minimum) value provided by the plugin

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -367,7 +367,8 @@ func (p *apPool) applyPluginMeta(ap *availablePlugin) error {
 
 	// Set the cache TTL
 	cacheTTL := strategy.GlobalCacheExpiration
-	if ap.meta.CacheTTL != 0 {
+	// if the plugin exposes a default TTL that is greater the the global default use it
+	if ap.meta.CacheTTL != 0 && ap.meta.CacheTTL > strategy.GlobalCacheExpiration {
 		cacheTTL = ap.meta.CacheTTL
 	}
 

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -881,6 +881,8 @@ func TestCollectDynamicMetrics(t *testing.T) {
 			So(err, ShouldBeNil)
 			ttl, err = pool.CacheTTL()
 			So(err, ShouldBeNil)
+			// The minimum TTL advertised by the plugin is 100ms therefore the TTL for the
+			// pool should be the global cache expiration
 			So(ttl, ShouldEqual, strategy.GlobalCacheExpiration)
 			mts, errs := c.CollectMetrics([]core.Metric{m}, time.Now().Add(time.Second*1))
 			hits, err := pool.CacheHits(core.JoinNamespace(m.namespace), 2)

--- a/plugin/collector/snap-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-collector-mock2/mock/mock.go
@@ -110,7 +110,14 @@ func (f *Mock) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 
 //Meta returns meta data for testing
 func Meta() *plugin.PluginMeta {
-	return plugin.NewPluginMeta(Name, Version, Type, []string{plugin.SnapGOBContentType}, []string{plugin.SnapGOBContentType})
+	return plugin.NewPluginMeta(
+		Name,
+		Version,
+		Type,
+		[]string{plugin.SnapGOBContentType},
+		[]string{plugin.SnapGOBContentType},
+		plugin.CacheTTL(100*time.Millisecond),
+	)
 }
 
 //Random number generator


### PR DESCRIPTION
Fixes #641