### PR TITLE
Factor out promise abstraction

### DIFF
--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -1,0 +1,63 @@
+package promise
+
+import (
+	"sync"
+)
+
+// A disposable write-once latch, to act as a synchronization
+// barrier to signal completion of some asynchronous operation
+// (successful or otherwise).
+//
+// Functions that operate on this type (IsComplete, Complete,
+// Await) are idempotent and thread-safe.
+type Promise interface {
+	IsComplete() bool
+	Complete(errors []error)
+	Await() []error
+	AndThen(f func([]error))
+}
+
+func NewPromise() Promise {
+	return &promise{
+		complete:     false,
+		completeChan: make(chan struct{}),
+	}
+}
+
+type promise struct {
+	sync.Mutex
+
+	complete     bool
+	errors       []error
+	completeChan chan struct{}
+}
+
+// Returns whether this promise is complete yet, without blocking.
+func (p *promise) IsComplete() bool {
+	return p.complete
+}
+
+// Unblock all goroutines awaiting promise completion.
+func (p *promise) Complete(errors []error) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.complete {
+		p.complete = true
+		p.errors = errors
+		close(p.completeChan)
+	}
+}
+
+// Blocks the caller until the promise is marked complete.
+func (p *promise) Await() []error {
+	<-p.completeChan
+	return p.errors
+}
+
+// Invokes the supplied function after this promise completes.
+func (p *promise) AndThen(f func([]error)) {
+	go func() {
+		f(p.Await())
+	}()
+}

--- a/pkg/promise/promise_test.go
+++ b/pkg/promise/promise_test.go
@@ -1,0 +1,64 @@
+package promise
+
+import (
+	"sync"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPromise(t *testing.T) {
+	Convey("IsComplete()", t, func() {
+		Convey("it should return the completion status", func() {
+			p := NewPromise()
+			So(p.IsComplete(), ShouldBeFalse)
+			p.Complete([]error{})
+			So(p.IsComplete(), ShouldBeTrue)
+		})
+	})
+	Convey("Complete()", t, func() {
+		Convey("it should unblock any waiting goroutines", func() {
+			p := NewPromise()
+
+			numWaiters := 3
+			var wg sync.WaitGroup
+			wg.Add(numWaiters)
+
+			for i := 0; i < numWaiters; i++ {
+				go func() {
+					Convey("all waiting goroutines should see empty errors", t, func() {
+						errors := p.Await()
+						So(errors, ShouldBeEmpty)
+						wg.Done()
+					})
+				}()
+			}
+
+			p.Complete([]error{})
+			wg.Wait()
+		})
+	})
+	Convey("AndThen()", t, func() {
+		Convey("it should defer the supplied closure until after completion", func() {
+			p := NewPromise()
+
+			funcRan := false
+			c := make(chan struct{})
+
+			p.AndThen(func(errors []error) {
+				funcRan = true
+				close(c)
+			})
+
+			// The callback should not have been executed yet.
+			So(funcRan, ShouldBeFalse)
+
+			// Trigger callback execution by completing the queued job.
+			p.Complete([]error{})
+
+			// Wait for the deferred function to be executed.
+			<-c
+			So(funcRan, ShouldBeTrue)
+		})
+	})
+}

--- a/scheduler/queue.go
+++ b/scheduler/queue.go
@@ -117,7 +117,7 @@ func (q *queue) start() {
 					Job: e.Job(),
 				}
 				q.Err <- qe
-				e.Complete() // Signal job termination.
+				e.Promise().Complete([]error{qe}) // Signal job termination.
 				continue
 			}
 

--- a/scheduler/queue_test.go
+++ b/scheduler/queue_test.go
@@ -39,13 +39,13 @@ func TestQueue(t *testing.T) {
 		x := 0
 		q := newQueue(5, func(j queuedJob) {
 			x = 1
-			j.Complete()
+			j.Promise().Complete([]error{})
 		})
 		q.Start()
 		j := &collectorJob{coreJob: &coreJob{}}
 		qj := newQueuedJob(j)
 		q.Event <- qj
-		qj.Await()
+		qj.Promise().Await()
 		So(x, ShouldEqual, 1)
 		q.Stop()
 	})
@@ -54,7 +54,7 @@ func TestQueue(t *testing.T) {
 		x := []time.Time{}
 		q := newQueue(5, func(j queuedJob) {
 			x = append(x, j.Job().Deadline())
-			j.Complete()
+			j.Promise().Complete([]error{})
 		})
 		q.Start()
 
@@ -66,7 +66,7 @@ func TestQueue(t *testing.T) {
 			j := &collectorJob{coreJob: &coreJob{}}
 			j.deadline = time.Now().Add(time.Duration(i) * time.Second)
 			qj := newQueuedJob(j)
-			qj.AndThen(func(queuedJob) { wg.Done() })
+			qj.Promise().AndThen(func(errors []error) { wg.Done() })
 			q.Event <- qj
 		}
 

--- a/scheduler/work_manager_test.go
+++ b/scheduler/work_manager_test.go
@@ -102,7 +102,7 @@ func TestWorkerManager(t *testing.T) {
 
 			// Wait for all queued jobs to be marked complete.
 			for _, qj := range qjs {
-				qj.Await()
+				qj.Promise().Await()
 			}
 
 			// The work queue should be empty at this point.

--- a/scheduler/work_manager_test.go
+++ b/scheduler/work_manager_test.go
@@ -24,39 +24,37 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	. "github.com/intelsdi-x/snap/pkg/promise"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-// A mockJob can be either synchronus (will not return from Run()
-// until a receiver is ready on completeChan) or asynchronous.
+// A mockJob can be either asynchronous or synchronous (will not return from
+// Run() until a caller is ready in Await()).
 //
 // Test code can rendez-vous with synchronous mockJobs in Run()
 // by invoking Await(), which also unblocks the worker executing
 // the job.
 //
 // For asynchronous mockJobs, Await() blocks the caller until the
-// job does a buffered send on completeChan in Run().
+// job is completed in Run().
 type mockJob struct {
-	errors       []error
-	worked       bool
-	deadline     time.Time
-	starttime    time.Time
-	completeChan chan struct{}
+	errors          []error
+	sync            bool
+	worked          bool
+	deadline        time.Time
+	starttime       time.Time
+	completePromise Promise
+	syncPromise     Promise
 }
 
 func newMockJob(sync bool) *mockJob {
-	var completeChan chan struct{}
-	if sync {
-		completeChan = make(chan struct{})
-	} else {
-		completeChan = make(chan struct{}, 1)
-	}
-
 	return &mockJob{
-		worked:       false,
-		deadline:     time.Now().Add(1 * time.Second),
-		starttime:    time.Now(),
-		completeChan: completeChan,
+		sync:            sync,
+		worked:          false,
+		deadline:        time.Now().Add(1 * time.Second),
+		starttime:       time.Now(),
+		completePromise: NewPromise(),
+		syncPromise:     NewPromise(),
 	}
 }
 
@@ -64,11 +62,18 @@ func (mj *mockJob) Errors() []error      { return mj.errors }
 func (mj *mockJob) StartTime() time.Time { return mj.starttime }
 func (mj *mockJob) Deadline() time.Time  { return mj.deadline }
 func (mj *mockJob) Type() jobType        { return collectJobType }
-func (mj *mockJob) Await()               { <-mj.completeChan }
+
+func (mj *mockJob) Await() {
+	mj.syncPromise.Complete([]error{})
+	mj.completePromise.Await()
+}
 
 func (mj *mockJob) Run() {
 	mj.worked = true
-	mj.completeChan <- struct{}{}
+	if mj.sync {
+		mj.syncPromise.Await()
+	}
+	mj.completePromise.Complete([]error{})
 }
 
 func TestWorkerManager(t *testing.T) {
@@ -87,7 +92,7 @@ func TestWorkerManager(t *testing.T) {
 			manager := newWorkManager(CollectQSizeOption(1), CollectWkrSizeOption(1))
 			manager.Start()
 
-			j1 := newMockJob(true) // j1 does a blocking send on its completeChan
+			j1 := newMockJob(true) // j1 blocks in Run() until Await() is invoked.
 			j2 := newMockJob(false)
 			j3 := newMockJob(false)
 

--- a/scheduler/worker.go
+++ b/scheduler/worker.go
@@ -53,7 +53,7 @@ func (w *worker) start() {
 			// mark the job complete for one of two reasons:
 			// - this job was just run
 			// - the deadline was exceeded and this job will not run
-			q.Complete()
+			q.Promise().Complete(q.Job().Errors())
 
 		// the single kill-channel -- used when resizing worker pools
 		case <-w.kamikaze:

--- a/scheduler/worker_test.go
+++ b/scheduler/worker_test.go
@@ -57,7 +57,7 @@ func TestWorker(t *testing.T) {
 		chrono.Chrono.Forward(1500 * time.Millisecond)
 		qj := newQueuedJob(mj)
 		rcv <- qj
-		qj.Await()
+		qj.Promise().Await()
 		So(mj.worked, ShouldEqual, false)
 	})
 	Convey("stops the worker if kamikaze chan is closed", t, func() {

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -303,7 +303,7 @@ func (s *schedulerWorkflow) Start(t *task) {
 
 	// dispatch 'collect' job to be worked
 	// Block until the job has been either run or skipped.
-	errors := t.manager.Work(j).Await()
+	errors := t.manager.Work(j).Promise().Await()
 
 	if len(errors) != 0 {
 		t.failedRuns++
@@ -337,7 +337,7 @@ func (s *schedulerWorkflow) StateString() string {
 func (s *schedulerWorkflow) workJobs(prs []*processNode, pus []*publishNode, t *task, pj job) {
 	for _, pr := range prs {
 		j := newProcessJob(pj, pr.Name(), pr.Version(), pr.InboundContentType, pr.config.Table(), t.metricsManager)
-		errors := t.manager.Work(j).Await()
+		errors := t.manager.Work(j).Promise().Await()
 		if len(errors) != 0 {
 			t.failedRuns++
 			t.lastFailureTime = t.lastFireTime
@@ -349,7 +349,7 @@ func (s *schedulerWorkflow) workJobs(prs []*processNode, pus []*publishNode, t *
 	}
 	for _, pu := range pus {
 		j := newPublishJob(pj, pu.Name(), pu.Version(), pu.InboundContentType, pu.config.Table(), t.metricsManager)
-		errors := t.manager.Work(j).Await()
+		errors := t.manager.Work(j).Promise().Await()
 		if len(errors) != 0 {
 			t.failedRuns++
 			t.lastFailureTime = t.lastFireTime


### PR DESCRIPTION
This patch set makes the notion of a `Promise` more abstract and re-usable, and demonstrates usage in `queuedJob`.  Promise is pretty bare-bones right now.  Later, we could add more features.  One that is noticeably missing is the ability to supply a timeout for deferred executions.