### PR TITLE
Linking Best Practices within Plugin Authoring

### DIFF
--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -141,7 +141,7 @@ func (e *ExecutablePlugin) WaitForResponse(timeout time.Duration) (*Response, er
 	return r, err
 }
 
-// Private method which handles behvaior for wait for response for daemon and non-daemon modes.
+// Private method which handles behavior for wait for response for daemon and non-daemon modes.
 func waitHandling(p pluginExecutor, timeout time.Duration, logpath string) (*Response, error) {
 	log := execLogger.WithField("_block", "waitHandling")
 

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -37,7 +37,7 @@ Before writing a plugin, you may sketch the type of metrics you want to collect 
 1. Plan your plugin
 2. Decide the CODEC for the plugin
 3. Download or clone snap
-4. Setup your development enviroment properly
+4. Setup your development environment properly
 5. Write the plugin that implements the type of interfaces defined in snap
 6. Test the plugin
 7. Expose the plugin

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -18,9 +18,19 @@ limitations under the License.
 -->
 
 ## About This
-The following is a recipe for authoring a plugin that fits smoothly within the snap framework. Like any recipe, the ingredients and the order in which you mix them are important. Like any good recipe, it will do you well to read the entire document, as well as the [Plugin Best Practices](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_BEST_PRACTICES.md), before you start cooking.
+The following is a recipe for authoring a plugin that fits smoothly within the snap framework. Like any recipe, the ingredients and the order in which you mix them are important. The major steps are:
 
-The last use of this analogy here: Bon Appétit! :stew:
+1. Outline your plugin metrics
+2. Decide the CODEC for the plugin
+3. Download or clone [snap](https://github.com/intelsdi-x/snap)
+4. Download or clone [snap-plugin-utilities](https://github.com/intelsdi-x/snap-plugin-utilities)
+5. Implement the required interfaces
+6. Test the plugin
+7. Expose the plugin
+
+Like any good recipe, it will do you well to read the entire document, as well as the [Plugin Best Practices](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_BEST_PRACTICES.md), before you start cooking.
+
+Bon Appétit! :stew:
 
 ## Plugin Authoring
 snap itself runs as a master daemon with the core functionality that may load and unload plugin processes via either CLI or HTTP APIs.
@@ -30,17 +40,6 @@ A snap plugin is a program, or a set of functions or services, written in Go or 
 Communication between snap and plugins uses RPC either through HTTP or TCP protocols. HTTP JSON-RPC is good for any language to use due to its nature of JSON representation of data while the native client is only suitable for plugins written in Golang. The data that plugins report to snap is in the form of JSON or GOB CODEC.
 
 Before starting writing snap plugins, check out the [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md) to see if any suit your needs. If not, you need to reference the plugin packages that defines the type of structures and interfaces inside snap and then write plugin endpoints to implement the defined interfaces.
-
-## Getting started with the plugin development
-Before writing a plugin, you may sketch the type of metrics you want to collect or understand what kind of metrics you like to publish. Basic steps are:
-
-1. Plan your plugin
-2. Decide the CODEC for the plugin
-3. Download or clone snap
-4. Setup your development environment properly
-5. Write the plugin that implements the type of interfaces defined in snap
-6. Test the plugin
-7. Expose the plugin
 
 ### Naming, Files, and Directory    
 snap supports three type of plugins. They are collectors, processors, and publishers.  The plugin project name should use the following format:  

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -17,10 +17,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+## About This
+The following is a recipe for authoring a plugin that fits smoothly within the snap framework. Like any recipe, the ingredients and the order in which you mix them are important. Like any good recipe, it will do you well to read the entire document, as well as the [Plugin Best Practices](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_BEST_PRACTICES.md), before you start cooking.
+
+The last use of this analogy here: Bon Appétit! :stew:
+
 ## Plugin Authoring
 snap itself runs as a master daemon with the core functionality that may load and unload plugin processes via either CLI or HTTP APIs.
 
-A snap plugin is a program, or a set of functions or services, written in Go or any language; that may seamlessly integrate with snap as executables. 
+A snap plugin is a program, or a set of functions or services, written in Go or any language; that may seamlessly integrate with snap as executables.
 
 Communication between snap and plugins uses RPC either through HTTP or TCP protocols. HTTP JSON-RPC is good for any language to use due to its nature of JSON representation of data while the native client is only suitable for plugins written in Golang. The data that plugins report to snap is in the form of JSON or GOB CODEC.
 
@@ -35,7 +40,7 @@ Before writing a plugin, you may sketch the type of metrics you want to collect 
 4. Setup your development enviroment properly
 5. Write the plugin that implements the type of interfaces defined in snap
 6. Test the plugin
-7. Expose the plugin 
+7. Expose the plugin
 
 ### Naming, Files, and Directory    
 snap supports three type of plugins. They are collectors, processors, and publishers.  The plugin project name should use the following format:  
@@ -116,7 +121,7 @@ While developing a plugin, unit and integration tests need to be performed. snap
 
 For example, to run a plugin integration test
 ```
-go test -v tag=integration ./… 
+go test -v tag=integration ./…
 ```
 
 For more build and test tips, please refer to our [contributing doc](https://github.com/intelsdi-x/snap/blob/master/CONTRIBUTING.md).

--- a/docs/PLUGIN_BEST_PRACTICES.md
+++ b/docs/PLUGIN_BEST_PRACTICES.md
@@ -1,6 +1,6 @@
-## Best practices in plugins development:
+## Best practices in plugin development:
 ### Leverage plugin configurability options
-1.  **Compile time configuration** - use `Plugin.PluginMeta` to define plugins's: name, version, type, accepted and returned content types, concurrency level, exclusiveness, secure communication settings and cache TTL. This type of configuration is usually specified in `main()` in which `plugin.Start()` method is called.
+1.  **Compile time configuration** - use `Plugin.PluginMeta` to define plugin's: name, version, type, accepted and returned content types, concurrency level, exclusiveness, secure communication settings and cache TTL. This type of configuration is usually specified in `main()` in which `plugin.Start()` method is called.
 2. **Run time configuration**
     - **Global** - This config is useful if configuration data are needed to obtain list of metrics (for example: user names, paths to tools, etc.). Values from Global cofig (as defined in config json) are available in `GetMetricTypes()` method.
     - **Task level** - This config is useful when you need to pass configuration per metric or plugin in order to collect the metrics. Use `GetConfigPolicy()` to set configurable items for plugin. Values from Task config are available in `CollectMetrics()` method.

--- a/docs/PLUGIN_BEST_PRACTICES.md
+++ b/docs/PLUGIN_BEST_PRACTICES.md
@@ -6,18 +6,18 @@
     - **Task level** - This config is useful when you need to pass configuration per metric or plugin in order to collect the metrics. Use `GetConfigPolicy()` to set configurable items for plugin. Values from Task config are available in `CollectMetrics()` method.
 
 ### Use `snap-plugin-utilities` library
-The library and guide are available [here](https://github.com/intelsdi-x/snap-plugin-utilities). The library consists of following helper packages:
+The library and guide is available [here](https://github.com/intelsdi-x/snap-plugin-utilities). The library consists of the following helper packages:
 * **`config`** - The config package provides helpful methods to retrieve global config items.
-* **`logger`** - The logger package wraps logrus package (https://github.com/Sirupsen/logrus). It sets logging from plugin to separate file. It adds caller function name to each message. It's best to use log level defined during `snapd` start.
+* **`logger`** - The logger package wraps the logrus package. (https://github.com/Sirupsen/logrus). It sets logging from a plugin to separate files and adds a caller function name to each message. It's best to use log level defined during `snapd` start.
 * **`ns`** - The ns package provides functions to extract namespace from maps, JSON and struct compositions. It is useful for situations when full knowledge of available metrics is not known at time when `GetMetricTypes()` is called.
-* **`pipline`** - Creates array of Pipes connected by channels. Each Pipe can do single processing on data transmitted by channels
-* **`source`** - The source package provides handy way of dealing with external command output. It can be used for continuous command execution (PCM like), or for single command calls.
-* **`stack`** - The stack package provides simple implementation of stack.
+* **`pipeline`** - Creates array of Pipes connected by channels. Each Pipe can perform a single process on data transmitted by channels.
+* **`source`** - The source package provides handy ways of dealing with external command output. It can be used for continuous command execution (PCM like), or for single command calls.
+* **`stack`** - The stack package provides simple implementation of a stack.
 
 ### Namespace definition
-* The `GetMetricTypes()` method returns namespaces for your metrics. The good idea is to start with your organization (for example: "intel"), then enumerate information starting from most general to most detailed. Examples: `/intel/server/mem/free` or `/intel/linux/iostat/avg-cpu/%idle`.
+* The `GetMetricTypes()` method returns namespaces for your metrics. For new metrics, it is a good idea to start with your organization (for example: "intel"), then enumerate information starting from most general to most detailed. Examples: `/intel/server/mem/free` or `/intel/linux/iostat/avg-cpu/%idle`.
 * Do not use any special character in namespaces other than: "%", "-" and "_".
-* When enumerating sources it's better to have them separated. For example:use `cpu/0` rather than `cpu0`.
+* When enumerating metric sources, it is always better to have them separated. For example: use `cpu/0` rather than `cpu0`.
 
 ### Testability
-It's highly recommended to deliver unit and integration tests with your code - use best practices for your language of choice to create testable code (for example in golang consider using dependency injection and interfaces).
+It is highly recommended to deliver unit and integration tests with your code - use best practices for your language of choice to create testable code (for example in golang consider using dependency injection and interfaces).


### PR DESCRIPTION
I noticed there was no reference to the Best Practices doc while reviewing authoring. 