### PR TITLE
Fix #662: Task hangs on a large number of metrics

### DIFF
--- a/plugin/publisher/snap-publisher-file/file/file.go
+++ b/plugin/publisher/snap-publisher-file/file/file.go
@@ -64,7 +64,7 @@ func (f *filePublisher) Publish(contentType string, content []byte, config map[s
 		return errors.New(fmt.Sprintf("Unknown content type '%s'", contentType))
 	}
 
-	logger.Printf("publishing %v to %v", metrics, config)
+	logger.Printf("publishing %v metrics to %v", len(metrics), config)
 	file, err := os.OpenFile(config["file"].(ctypes.ConfigValueStr).Value, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 	defer file.Close()
 	if err != nil {


### PR DESCRIPTION
This issue was caused by a log statement in the file publisher plugin which printed the metrics to stdout.  If the log statement exceeded 4096 bytes the buffio errors and does not advance.  

* The routine that captures standard out and error has been fixed to handle the case where a plugin author prints a statement that exceeds 4096 bytes
* The file publisher plugin now prints the number of metrics being published to stdout