### PR TITLE
Update Travis to test against Go 1.4.3 and Go 1.5.2 as these are the …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-- 1.4.2
-- 1.5
+- 1.4.3
+- 1.5.2
 before_install:
 - go get github.com/tools/godep
 - go get github.com/axw/gocov/gocov


### PR DESCRIPTION
Update Travis to test against Go 1.4.3 and Go 1.5.2 as these are the latest stable releases in the 1.4.x and 1.5.x.