### PR TITLE
Fix #674: Merge global config into plugin config 

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -896,20 +896,20 @@ func (p *pluginControl) CollectMetrics(metricTypes []core.Metric, deadline time.
 func (p *pluginControl) PublishMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue) []error {
 	// merge global plugin config into the config for this request
 	cfg := p.Config.Plugins.getPluginConfigDataNode(core.PublisherPluginType, pluginName, pluginVersion).Table()
-	for k, v := range config {
-		cfg[k] = v
+	for k, v := range cfg {
+		config[k] = v
 	}
-	return p.pluginRunner.AvailablePlugins().publishMetrics(contentType, content, pluginName, pluginVersion, cfg)
+	return p.pluginRunner.AvailablePlugins().publishMetrics(contentType, content, pluginName, pluginVersion, config)
 }
 
 // ProcessMetrics
 func (p *pluginControl) ProcessMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue) (string, []byte, []error) {
 	// merge global plugin config into the config for this request
 	cfg := p.Config.Plugins.getPluginConfigDataNode(core.ProcessorPluginType, pluginName, pluginVersion).Table()
-	for k, v := range config {
-		cfg[k] = v
+	for k, v := range cfg {
+		config[k] = v
 	}
-	return p.pluginRunner.AvailablePlugins().processMetrics(contentType, content, pluginName, pluginVersion, cfg)
+	return p.pluginRunner.AvailablePlugins().processMetrics(contentType, content, pluginName, pluginVersion, config)
 }
 
 // GetPluginContentTypes returns accepted and returned content types for the


### PR DESCRIPTION
This PR fixes an issue where a plugin config was being merged into the global config for a plugin during the ProcessMetrics and PublishMetrics. The subsequent global config was then being passed into the processMetrics and publishMetrics functions. This caused a behavior described in issue #674 where two tasks publishing to the same plugin but with separate configs could end up both using the same config defined in the first running task if the first running task was started before the second task was created.