### PR TITLE
Fixes #659: snapd shouldn't start if API port is already in use

### DIFF
--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -79,11 +79,15 @@ func startAPI() string {
 	r.BindConfigManager(c.Config)
 	r.BindMetricManager(c)
 	r.BindTaskManager(s)
-	err := r.Start("127.0.0.1:0")
-	if err != nil {
-		// Panic on an error
-		panic(err)
-	}
+	go func(ch <-chan error) {
+		// Block on the error channel. Will return exit status 1 for an error or just return if the channel closes.
+		err, ok := <-ch
+		if !ok {
+			return
+		}
+		log.Fatal(err)
+	}(r.Err())
+	r.Start("127.0.0.1:0")
 	time.Sleep(100 * time.Millisecond)
 	return fmt.Sprintf("http://localhost:%d", r.Port())
 }

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -135,9 +135,9 @@ func New(https bool, cpath, kpath string) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) Start(addrString string) error {
+func (s *Server) Start(addrString string) {
 	s.addRoutes()
-	return s.run(addrString)
+	s.run(addrString)
 }
 
 func (s *Server) Err() <-chan error {
@@ -148,20 +148,18 @@ func (s *Server) Port() int {
 	return s.addr.(*net.TCPAddr).Port
 }
 
-func (s *Server) run(addrString string) error {
+func (s *Server) run(addrString string) {
 	restLogger.Info("Starting REST API on ", addrString)
 	if s.tls != nil {
 		go s.serveTLS(addrString)
 	} else {
 		ln, err := net.Listen("tcp", addrString)
 		if err != nil {
-			return err
+			s.err <- err
 		}
 		s.addr = ln.Addr()
 		go s.serve(ln)
-
 	}
-	return nil
 }
 
 func (s *Server) serveTLS(addrString string) {

--- a/snapd.go
+++ b/snapd.go
@@ -490,7 +490,6 @@ func action(ctx *cli.Context) {
 		r, err := rest.New(restHttps, restCert, restKey)
 		if err != nil {
 			log.Fatal(err)
-			return
 		}
 		r.BindMetricManager(c)
 		r.BindConfigManager(c.Config)
@@ -498,8 +497,8 @@ func action(ctx *cli.Context) {
 		if tr != nil {
 			r.BindTribeManager(tr)
 		}
-		r.Start(fmt.Sprintf(":%d", apiPort))
 		go monitorErrors(r.Err())
+		r.Start(fmt.Sprintf(":%d", apiPort))
 		log.Info("Rest API is enabled")
 	} else {
 		log.Info("Rest API is disabled")
@@ -520,11 +519,11 @@ func action(ctx *cli.Context) {
 
 func monitorErrors(ch <-chan error) {
 	// Block on the error channel. Will return exit status 1 for an error or just return if the channel closes.
-	_, ok := <-ch
+	err, ok := <-ch
 	if !ok {
 		return
 	}
-	os.Exit(1)
+	log.Fatal(err)
 }
 
 // setMaxProcs configures runtime.GOMAXPROCS for snapd. GOMAXPROCS can be set by using


### PR DESCRIPTION
Terminal 1:
```
 go run snapd.go -t 0 -l 1                                            1 ↵ ✹ ✭
INFO[0000] Starting snapd (version: unknown)
INFO[0000] setting GOMAXPROCS to: 1 core(s)
INFO[0000] control started                               _block=start _module=control
INFO[0000] module started                                _module=snapd block=main snap-module=control
INFO[0000] scheduler started                             _block=start-scheduler _module=scheduler
INFO[0000] module started                                _module=snapd block=main snap-module=scheduler
INFO[0000] setting plugin trust level to: disabled
INFO[0000] auto discover path is disabled
INFO[0000] Configuring REST API with HTTPS set to: false  _module=_mgmt-rest
INFO[0000] Starting REST API on :8181                    _module=_mgmt-rest
INFO[0000] Rest API is enabled
INFO[0000] snapd started                                 _module=snapd block=main
INFO[0000] setting log level to: debug
```

Terminal 2:
```
INFO[0000] Starting snapd (version: unknown)
INFO[0000] setting GOMAXPROCS to: 1 core(s)
INFO[0000] control started                               _block=start _module=control
INFO[0000] module started                                _module=snapd block=main snap-module=control
INFO[0000] scheduler started                             _block=start-scheduler _module=scheduler
INFO[0000] module started                                _module=snapd block=main snap-module=scheduler
INFO[0000] setting plugin trust level to: disabled
INFO[0000] auto discover path is disabled
INFO[0000] Configuring REST API with HTTPS set to: false  _module=_mgmt-rest
INFO[0000] Starting REST API on :8181                    _module=_mgmt-rest
FATA[0000] listen tcp :8181: bind: address already in use
exit status 1
```