### PR TITLE
Partially fixes #698 - Adds error checking for NewRequestedPlugin 

### DIFF
--- a/core/plugin_test.go
+++ b/core/plugin_test.go
@@ -38,42 +38,48 @@ var (
 
 func TestRequestedPlugin(t *testing.T) {
 	// Creating a plugin request
-	rp, err := NewRequestedPlugin(PluginPath)
+
 	Convey("Creating a plugin request from a valid path", t, func() {
-		Convey("Should return a RequestedPlugin type", func() {
-			So(rp, ShouldHaveSameTypeAs, &RequestedPlugin{})
-		})
+		rp, err := NewRequestedPlugin(PluginPath)
 		Convey("Should not return an error", func() {
 			So(err, ShouldBeNil)
-		})
-		Convey("Should set the path to the plugin", func() {
-			So(rp.Path(), ShouldEqual, PluginPath)
-		})
-		Convey("Should generate a checksum for the plugin", func() {
-			So(rp.CheckSum(), ShouldNotBeNil)
-			Convey("And checksum should match manually generated checksum", func() {
-				b, _ := ioutil.ReadFile(PluginPath)
-				So(rp.CheckSum(), ShouldResemble, sha256.Sum256(b))
+
+			Convey("Should return a RequestedPlugin type", func() {
+				So(rp, ShouldHaveSameTypeAs, &RequestedPlugin{})
 			})
-		})
-		Convey("And plugin signature should initially be nil", func() {
-			So(rp.Signature(), ShouldBeNil)
+
+			Convey("Should set the path to the plugin", func() {
+				So(rp.Path(), ShouldEqual, PluginPath)
+			})
+			Convey("Should generate a checksum for the plugin", func() {
+				So(rp.CheckSum(), ShouldNotBeNil)
+				Convey("And checksum should match manually generated checksum", func() {
+					b, _ := ioutil.ReadFile(PluginPath)
+					So(rp.CheckSum(), ShouldResemble, sha256.Sum256(b))
+				})
+			})
+			Convey("And plugin signature should initially be nil", func() {
+				So(rp.Signature(), ShouldBeNil)
+			})
+			// Set a signature for the plugin
+			rp.SetSignature([]byte{00, 00, 00})
+			Convey("A signature for the plugin can be added to a plugin request", func() {
+				Convey("So signature should not be nil", func() {
+					So(rp.Signature(), ShouldNotBeNil)
+				})
+				Convey("And signature should equal what we set it to", func() {
+					So(rp.Signature(), ShouldResemble, []byte{00, 00, 00})
+				})
+			})
+
 		})
 	})
-	// Set a signature for the plugin
-	rp.SetSignature([]byte{00, 00, 00})
-	Convey("A signature for the plugin can be added to a plugin request", t, func() {
-		Convey("So signature should not be nil", func() {
-			So(rp.Signature(), ShouldNotBeNil)
-		})
-		Convey("And signature should equal what we set it to", func() {
-			So(rp.Signature(), ShouldResemble, []byte{00, 00, 00})
-		})
-	})
-	// Create a plugin request and read a signature file for the plugin
-	rp1, _ := NewRequestedPlugin(PluginPath)
-	err1 := rp1.ReadSignatureFile(SignatureFile)
+
 	Convey("A signature file can be read in for a plugin request", t, func() {
+		rp1, err1 := NewRequestedPlugin(PluginPath)
+		So(err1, ShouldBeNil)
+		err1 = rp1.ReadSignatureFile(SignatureFile)
+
 		Convey("Should not receive an error reading signature file", func() {
 			So(err1, ShouldBeNil)
 		})
@@ -93,9 +99,12 @@ func TestRequestedPlugin(t *testing.T) {
 		})
 	})
 	// Create a plugin request and try to add a signature from an non-existant signature file
-	rp3, _ := NewRequestedPlugin(PluginPath)
-	err3 := rp3.ReadSignatureFile(SignatureFile + "foo")
+
 	Convey("When passing in a non-existant signature file", t, func() {
+		rp3, err3 := NewRequestedPlugin(PluginPath)
+		So(err3, ShouldBeNil)
+		err3 = rp3.ReadSignatureFile(SignatureFile + "foo")
+
 		Convey("signature should still be nil", func() {
 			So(rp3.Signature(), ShouldBeNil)
 		})


### PR DESCRIPTION
Now if plugins are missing, plugin_test.go will give errors like:

```
  Creating a plugin request from a valid path 
    Should not return an error ✘


Failures:

  * /Users/crosebor/go/src/github.com/intelsdi-x/snap/core/plugin_test.go 
  Line 45:
  Expected: nil
  Actual:   'open /Users/crosebor/go/src/github.com/intelsdi-x/snap/build/plugin/snap-collector-mock1: no such file or directory'


1 total assertion
```

Instead of

```
Creating a plugin request from a valid path 
    Should return a RequestedPlugin type ✔
    Should not return an error ✘
    Should set the path to the plugin 🔥
    Should generate a checksum for the plugin 🔥
    And plugin signature should initially be nil 🔥


Errors:

  * /Users/crosebor/go/src/github.com/intelsdi-x/snap/core/plugin_test.go 
  Line 50: - runtime error: invalid memory address or nil pointer dereference 
  goroutine 5 [running]:
  github.com/intelsdi-x/snap/core.TestRequestedPlugin.func1.3()
  	/Users/crosebor/go/src/github.com/intelsdi-x/snap/core/plugin_test.go:50 +0x14d
  github.com/jtolds/gls._m(0x0, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:39 +0x2b
  github.com/jtolds/gls.mark1(0x0, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:18 +0x2b
  github.com/jtolds/gls._m(0x1, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:41 +0x5a
  github.com/jtolds/gls.markS(0x1, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:16 +0x2b
  github.com/jtolds/gls.addStackTag(0x1, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:13 +0x37
  github.com/jtolds/gls.(*ContextManager).SetValues(0x8203c6c60, 0x8203d14d0, 0x8203c6f60)
  	/Users/crosebor/go/src/github.com/jtolds/gls/context.go:92 +0x4a9
  github.com/intelsdi-x/snap/core.TestRequestedPlugin.func1()
  	/Users/crosebor/go/src/github.com/intelsdi-x/snap/core/plugin_test.go:51 +0x442
  github.com/jtolds/gls._m(0x0, 0x8203c6d00)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:39 +0x2b
  github.com/jtolds/gls.markS(0x0, 0x8203c6d00)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:16 +0x2b
  github.com/jtolds/gls.addStackTag(0x0, 0x8203c6d00)
  	/Users/crosebor/go/src/github.com/jtolds/gls/stack_tags.go:13 +0x37
  github.com/jtolds/gls.(*ContextManager).SetValues(0x8203c6c60, 0x8203d1080, 0x8203c6d00)
  	/Users/crosebor/go/src/github.com/jtolds/gls/context.go:92 +0x4a9
  github.com/intelsdi-x/snap/core.TestRequestedPlugin(0x820432360)
  	/Users/crosebor/go/src/github.com/intelsdi-x/snap/core/plugin_test.go:62 +0x263
  testing.tRunner(0x820432360, 0x34ad80)
  	/usr/local/go/src/testing/testing.go:456 +0x98
  created by testing.RunTests
  	/usr/local/go/src/testing/testing.go:561 +0x86d
  
  goroutine 1 [chan receive]:
  testing.RunTests(0x295850, 0x34ad80, 0x1, 0x1, 0x1)
  	/usr/local/go/src/testing/testing.go:562 +0x8ad
  testing.(*M).Run(0x820459ee8, 0x10385c)
  	/usr/local/go/src/testing/testing.go:494 +0x70
  main.main()
  	github.com/intelsdi-x/snap/core/_test/_testmain.go:54 +0x116

....
```