### PR TITLE
Fixes #702: more specific error message when interval not set 

### DIFF
--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -162,6 +162,11 @@ func createTaskUsingWFManifest(ctx *cli.Context) {
 	path := ctx.String("workflow-manifest")
 	ext := filepath.Ext(path)
 	file, e := ioutil.ReadFile(path)
+
+	if !ctx.IsSet("interval") && !ctx.IsSet("i") {
+		fmt.Println("Workflow manifest requires interval to be set via flag.")
+		os.Exit(1)
+	}
 	if e != nil {
 		fmt.Printf("File error [%s]- %v\n", ext, e)
 		os.Exit(1)
@@ -186,7 +191,6 @@ func createTaskUsingWFManifest(ctx *cli.Context) {
 	}
 	// Get the task name
 	name := ctx.String("name")
-
 	// Get the interval
 	i := ctx.String("interval")
 	_, err := time.ParseDuration(i)


### PR DESCRIPTION
Added more specific error message when interval is not set when using a workflow manifest via snapctl.