### PR TITLE
Fixes #701 and #703

### DIFF
--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -64,7 +64,7 @@ func init() {
 			if err := f1.Parse(os.Args[idx : idx+2]); err == nil {
 				url = *prtURL
 			}
-		case "--u":
+		case "-u":
 			if err := f1.Parse(os.Args[idx : idx+2]); err == nil {
 				url = *prtU
 			}
@@ -72,7 +72,7 @@ func init() {
 			if err := f1.Parse(os.Args[idx : idx+2]); err == nil {
 				ver = *prtAv
 			}
-		case "--a":
+		case "-a":
 			if err := f1.Parse(os.Args[idx : idx+2]); err == nil {
 				ver = *prtA
 			}

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
+	"strings"
 	"time"
 
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
@@ -104,9 +104,13 @@ func (c *Client) WatchTask(id string) *WatchTasksResult {
 	}
 
 	url := fmt.Sprintf("%s/tasks/%v/watch", c.prefix, id)
-	resp, err := http.Get(url)
+	resp, err := c.http.Get(url)
 	if err != nil {
-		r.Err = err
+		if strings.Contains(err.Error(), "tls: oversized record") || strings.Contains(err.Error(), "malformed HTTP response") {
+			r.Err = fmt.Errorf("error connecting to API URI: %s. Do you have an http/https mismatch?", c.URL)
+		} else {
+			r.Err = err
+		}
 		r.Close()
 		return r
 	}


### PR DESCRIPTION
This PR fixes issues #701 and #703.

#701 is an issue around global option flags for snapctl. Typically, options are defined as --foo or -f. snapctl had options defined as --foo and --f. Commit `2e4d245` changes the short form options for url and api-version to -u and -a respectively.

#703 is an issue where watch task would not work when HTTPs was enabled for the rest api. In the client code for WatchTask, WatchTask was calling http.Get directly instead of using the configured http client in client. Commit `dd1ed36` changes http.Get to c.http.Get to use the http client configured for client which allows support for watching a task when HTTPs is enabled.