### PR TITLE
Added error for non JSON responses to client requests.

### DIFF
--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -185,8 +185,17 @@ func httpRespToAPIResp(rsp *http.Response) (*rbody.APIResponse, error) {
 		return nil, err
 	}
 	jErr := json.Unmarshal(b, resp)
+	// If unmarshaling fails show first part of response to help debug
+	// connection issues.
 	if jErr != nil {
-		return nil, jErr
+		bound := 1000
+		var invalidResp string
+		if len(b) > bound {
+			invalidResp = string(b[:bound])
+		} else {
+			invalidResp = string(b)
+		}
+		return nil, fmt.Errorf("Unknown API response: %s\n\n Received: %s", jErr, invalidResp)
 	}
 	if resp == nil {
 		// Catch corner case where JSON gives no error but resp is nil

--- a/mgmt/rest/rbody/body.go
+++ b/mgmt/rest/rbody/body.go
@@ -61,6 +61,9 @@ func (a *APIResponse) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		panic(err)
 	}
+	if ar.Meta == nil {
+		return errors.New("Unable to parse JSON response")
+	}
 	body, err := UnmarshalBody(ar.Meta.Type, ar.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
Handles non-json responses with better error message:
```
> snapctl -u 'http://localhost:8080'  plugin list
Error: Unknown API response.

 Received: Example response info.

exit status 1
```

The text after received is the response body truncated to 1000 chars for debugging. See #717.