### PR TITLE
Remove dependency on glibc on linux platform.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,23 +12,23 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.7.1",
-			"Rev": "818ac4d0073424f4e0a46f45abaa147ccc1b5a24"
+			"Comment": "v0.7.4",
+			"Rev": "62d46939da30111dc3eae51dd36ad5cd146dd964"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/device",
-			"Comment": "v0.7.1",
-			"Rev": "818ac4d0073424f4e0a46f45abaa147ccc1b5a24"
+			"Comment": "v0.7.4",
+			"Rev": "62d46939da30111dc3eae51dd36ad5cd146dd964"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.7.1",
-			"Rev": "818ac4d0073424f4e0a46f45abaa147ccc1b5a24"
+			"Comment": "v0.7.4",
+			"Rev": "62d46939da30111dc3eae51dd36ad5cd146dd964"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.7.1",
-			"Rev": "818ac4d0073424f4e0a46f45abaa147ccc1b5a24"
+			"Comment": "v0.7.4",
+			"Rev": "62d46939da30111dc3eae51dd36ad5cd146dd964"
 		},
 		{
 			"ImportPath": "github.com/armon/go-metrics",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,18 +28,14 @@ BINDIR=$BUILDDIR/bin
 COLLECTORDIR=$BUILDDIR/$PLUGINDIR/collector
 PUBLISHERDIR=$BUILDDIR/$PLUGINDIR/publisher
 PROCESSORDIR=$BUILDDIR/$PLUGINDIR/processor
-BUILDCMD='go build -a -ldflags "-w"'
+BUILDCMD='go build -a -ldflags "-w" -tags netgo'
 
 echo
 echo "****  snap build ($GITVERSION)  ****"
 echo
 
-# Disable CGO for builds...unless Linux...because appc
+# Disable CGO for builds.
 export CGO_ENABLED=0
-platform=$(uname)
-if [[ $platform == "Linux" ]]; then
-	export CGO_ENABLED=1
-fi
 
 # Clean build bin dir
 rm -rf $BINDIR/*


### PR DESCRIPTION
With this change, we obtain a possibility to get truly static binaries, independent from glibc, which can be used under any linux distribution supporting elf binaries.
Binaries build using this updated appc/spec library will be usable under systems with libc different than glibc such as alpine linux (based on musl), openwrt (which could be build using klibc, musl, or uclibc), but also without any system, as a plain alone binary (probably under docker or other containerizing execution environment).

Warning: `Godeps.json` was modified manually. Could you describe in docs how to properly use `godep` in snap in time of updating library which is a dependency? `godep save -r ./...` gives me nice mess in resulting diff...