### PR TITLE
Added annotation to example task & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,10 @@ There are interesting examples of using snap in every plugin repository. For the
 ### Roadmap
 We have a few known features we want to take on from here while we remain open for feedback after public release. They are:
 
-* Windows support (spec pending)
-* Distributed Workflows (spec pending)
+* Authentication, authorization, and auditing (see issue [#286](https://github.com/intelsdi-x/snap/issues/286))
 * Workflow Routing (see issue [#539](https://github.com/intelsdi-x/snap/issues/539))
+* Windows support (see [#671](https://github.com/intelsdi-x/snap/issues/671))
+* Distributed Workflows (see [#539](https://github.com/intelsdi-x/snap/issues/539) and [#640](https://github.com/intelsdi-x/snap/issues/640))
 
 If you would like to propose a feature, please [open an Issue](https://github.com/intelsdi-x/snap/issues)) that includes RFC in it (for [request for comments](https://en.wikipedia.org/wiki/Request_for_Comments)).
 
@@ -283,4 +284,4 @@ Just tag **@intelsdi-x/snap-maintainers** if you need to get some attention on a
 We're also looking for new maintainers from the community. Please let us know if you would like to become one by opening an Issue titled "interested in becoming a maintainer." We are currently working on a more official process.
 
 ## Thank You
-And **thank you!** Your contribution, through code and participation, is incredibly important to us. 
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -17,8 +17,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-#Example tasks
-- **mock-file.json/yaml**
+A task describes the how, what, and when to do for a __snap__ job.  A task is described in a task _manifest_, which can be either JSON or YAML. For more information, see the [documentation for tasks](/docs/TASKS.md).
+
+# Examples in this folder
+
+- **mock-file.json/yaml**: a simple example of task structure in both JSON and YAML format.
   - schedule
     - interval (1s)
   - collector
@@ -27,16 +30,24 @@ limitations under the License.
     - passthru
   - publisher
     - file
-    
-- **ceph-file.json**
+
+- **psutil-file.yaml**: another simple example of collecting statistics and publishing them to a file. This file includes in-line comments to help get oriented with task structure.
   - schedule
     - interval (1s)
   - collector
-    - CEPH
+    - psutil
   - publisher
     - file
 
-- **psutil-influx.json**
+- **ceph-file.json**: collect numerous statistics around Ceph, a storage system for OpenStack.
+  - schedule
+    - interval (1s)
+  - collector
+    - Ceph
+  - publisher
+    - file
+
+- **psutil-influx.json**: a more complex example that collects information from psutil and publishes to an instance of InfluxDB running locally. See [influxdb-grafana](../influxdb-grafana/) for other files to get this running.
   - schedule
     - interval (1s)
   - collector

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -3,9 +3,9 @@
   schedule:         # How frequently should we run this task?
     type: "simple"  # Simple means run forever at the interval below
     interval: "1s"  # This accepts seconds ('s') and milliseconds  ('ms')
-  workflow:           # For a small number of statistics, you can go as small
-    collect:          # as 500ms. For a large number, more than 1s may be needed
-      metrics:
+  workflow:           # For a small number of statistics, we have tests as small
+    collect:          # as 10ms. For a large number, more than 1s may be needed.
+      metrics:        # Collector caching defaults to 500ms.
         /intel/psutil/load/load1: {}   # Here are the specific metrics we collect
         /intel/psutil/load/load15: {}    # out of the set of all available from
         /intel/psutil/load/load5: {}     # our installed plugins. This list only

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -1,0 +1,16 @@
+--- # The Header starts after this line
+  version: 1        # All tasks, like plugins, have versioning
+  schedule:         # How frequently should we run this task?
+    type: "simple"  # Simple means run forever at the interval below
+    interval: "1s"  # This accepts seconds ('s') and milliseconds  ('ms')
+  workflow:           # For a small number of statistics, you can go as small
+    collect:          # as 500ms. For a large number, more than 1s may be needed
+      metrics:
+        /intel/psutil/load/load1: {}   # Here are the specific metrics we collect
+        /intel/psutil/load/load15: {}    # out of the set of all available from
+        /intel/psutil/load/load5: {}     # our installed plugins. This list only
+      publish:                           # requires psutil but could be more.
+        -
+          plugin_name: "file"     # After collection, we have the option to have
+          config:                   # one or more processors followed by publishers
+            file: "/tmp/snap_published_demo_file.log"


### PR DESCRIPTION
* Added  which collects load statistics from psutil and publishes them to.. you guessed it
* Heavily annotated the task above to walk people through an example. We could (and should) do more like it
* Added some context to the tasks folder README
* Included links to Roadmap specs