### PR TITLE
Add Go 1.6 to the testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
 - 1.4.3
 - 1.5.3
+- 1.6
 before_install:
 - go get github.com/tools/godep
 - go get github.com/axw/gocov/gocov


### PR DESCRIPTION
This PR add Go 1.6 to the testing matrix in Travis for snap now that Go 1.6 has been officially released.