### PR TITLE
Expose plugins ConfigPolicy via rest api

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -222,6 +222,10 @@ func (lp *loadedPlugin) LoadedTimestamp() *time.Time {
 	return &lp.LoadedTime
 }
 
+func (lp *loadedPlugin) Policy() *cpolicy.ConfigPolicy {
+	return lp.ConfigPolicy
+}
+
 // the struct representing the object responsible for
 // loading and unloading plugins
 type pluginManager struct {

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/cdata"
 )
 
@@ -80,6 +81,7 @@ type CatalogedPlugin interface {
 	Status() string
 	PluginPath() string
 	LoadedTimestamp() *time.Time
+	Policy() *cpolicy.ConfigPolicy
 }
 
 // the collection of cataloged plugins used

--- a/mgmt/rest/rbody/plugin.go
+++ b/mgmt/rest/rbody/plugin.go
@@ -89,13 +89,14 @@ func (p *PluginReturned) ResponseBodyType() string {
 }
 
 type LoadedPlugin struct {
-	Name            string `json:"name"`
-	Version         int    `json:"version"`
-	Type            string `json:"type"`
-	Signed          bool   `json:"signed"`
-	Status          string `json:"status"`
-	LoadedTimestamp int64  `json:"loaded_timestamp"`
-	Href            string `json:"href"`
+	Name            string        `json:"name"`
+	Version         int           `json:"version"`
+	Type            string        `json:"type"`
+	Signed          bool          `json:"signed"`
+	Status          string        `json:"status"`
+	LoadedTimestamp int64         `json:"loaded_timestamp"`
+	Href            string        `json:"href"`
+	ConfigPolicy    []PolicyTable `json:"policy,omitempty"`
 }
 
 type AvailablePlugin struct {


### PR DESCRIPTION
Add the rules from a plugins GetConfigPolicy() to the endpoint /v1/plugins/:type/:name/:version under the key "policy". See Issue #723.

