### PR TITLE
change default trust level to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ export SNAP_PATH=<snapDirectoryPath>/build
 ```
 And then you can use `$SNAP_PATH/bin` for your `<snapBinPath>`.
 ```
-$ <snapBinPath>/snapd --plugin-trust 0 --log-level 1
+$ <snapBinPath>/snapd --log-level 1
 ```
 This will bring up a snap agent without requiring plugin signing and set the logging level to debug. snap's REST API will be listening on port 8181. To learn more about the snap agent and how to use it look at [SNAPD.md](docs/SNAPD.md) and/or run `<snapBinPath>/snapd -h`.
 

--- a/docs/SNAPD.md
+++ b/docs/SNAPD.md
@@ -35,7 +35,7 @@ $ $SNAP_PATH/bin/snapd [global options] command [command options] [arguments...]
 --auto-discover, -a                          Auto discover paths separated by colons. [$SNAP_AUTODISCOVER_PATH]
 --max-running-plugins, -m '3'                The maximum number of instances of a loaded plugin to run [$SNAP_MAX_PLUGINS]
 --cache-expiration '500ms'                   The time limit for which a metric cache entry is valid [$SNAP_CACHE_EXPIRATION]
---plugin-trust, -t '1'                       0-2 (Disabled, Enabled, Warning) [$SNAP_TRUST_LEVEL]
+--plugin-trust, -t '0'                       0-2 (Disabled, Enabled, Warning) [$SNAP_TRUST_LEVEL]
 --keyring-paths, -k                          Keyring paths for signing verification separated by colons [$SNAP_KEYRING_PATHS]
 --rest-cert                                  A path to a certificate to use for HTTPS deployment of snap's REST API
 --config                                     A path to a config file
@@ -62,7 +62,7 @@ $SNAP_PATH/bin/snapd --version
 
 ### Output
 ```
-$ $SNAP_PATH/bin/snapd -l 1 -t 0
+$ $SNAP_PATH/bin/snapd -l 1
 ```
 ```
 INFO[0000] Starting snapd (version: v0.9.0-beta)

--- a/snapd.go
+++ b/snapd.go
@@ -87,7 +87,7 @@ var (
 		Name:   "plugin-trust, t",
 		Usage:  "0-2 (Disabled, Enabled, Warning)",
 		EnvVar: "SNAP_TRUST_LEVEL",
-		Value:  1,
+		Value:  0,
 	}
 	flKeyringPaths = cli.StringFlag{
 		Name:   "keyring-paths, k",


### PR DESCRIPTION
Starting `snapd`: Now with less `-t`!

```
$ snapd
INFO[0000] Starting snapd (version: v0.12.0-beta-68-g821a1b4)
INFO[0000] setting GOMAXPROCS to: 1 core(s)
INFO[0000] control started                               _block=start _module=control
INFO[0000] module started                                _module=snapd block=main snap-module=control
INFO[0000] scheduler started                             _block=start-scheduler _module=scheduler
INFO[0000] module started                                _module=snapd block=main snap-module=scheduler
INFO[0000] setting plugin trust level to: disabled
INFO[0000] auto discover path is disabled
INFO[0000] Configuring REST API with HTTPS set to: false  _module=_mgmt-rest
INFO[0000] Starting REST API on :8181                    _module=_mgmt-rest
INFO[0000] Rest API is enabled
INFO[0000] snapd started                                 _module=snapd block=main
INFO[0000] setting log level to: warning
```