### PR TITLE
Ensures scheduler jobs submissions are sent concurrently for a workflow.

### DIFF
--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -348,6 +348,16 @@ func (t *task) waitForSchedule() {
 	}
 }
 
+// RecordFailure updates the failed runs and last failure properties
+func (t *task) RecordFailure(e []error) {
+	// We synchronize this update to ensure it is atomic
+	t.Lock()
+	defer t.Unlock()
+	t.failedRuns++
+	t.lastFailureTime = t.lastFireTime
+	t.lastFailureMessage = e[len(e)-1].Error()
+}
+
 type taskCollection struct {
 	*sync.Mutex
 

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	schedulerLogger = log.WithField("_module", "scheduler-task")
+	taskLogger = schedulerLogger.WithField("_module", "scheduler-task")
 
 	// ErrTaskNotFound - The error message for task not found
 	ErrTaskNotFound = errors.New("Task not found")
@@ -256,7 +256,7 @@ func (t *task) Schedule() schedule.Schedule {
 func (t *task) spin() {
 	var consecutiveFailures uint
 	for {
-		schedulerLogger.Debug("task spin loop")
+		taskLogger.Debug("task spin loop")
 		// Start go routine to wait on schedule
 		go t.waitForSchedule()
 		// wait here on
@@ -273,7 +273,7 @@ func (t *task) spin() {
 				t.fire()
 				if t.lastFailureTime == t.lastFireTime {
 					consecutiveFailures++
-					schedulerLogger.WithFields(log.Fields{
+					taskLogger.WithFields(log.Fields{
 						"_block":                    "spin",
 						"task-id":                   t.id,
 						"task-name":                 t.name,
@@ -285,7 +285,7 @@ func (t *task) spin() {
 					consecutiveFailures = 0
 				}
 				if consecutiveFailures >= t.stopOnFailure {
-					schedulerLogger.WithFields(log.Fields{
+					taskLogger.WithFields(log.Fields{
 						"_block":               "spin",
 						"task-id":              t.id,
 						"task-name":            t.name,
@@ -393,7 +393,7 @@ func (t *taskCollection) add(task *task) error {
 		//If we don't already have this task in the collection save it
 		t.table[task.id] = task
 	} else {
-		schedulerLogger.WithFields(log.Fields{
+		taskLogger.WithFields(log.Fields{
 			"_module": "scheduler-taskCollection",
 			"_block":  "add",
 			"task id": task.id,
@@ -411,7 +411,7 @@ func (t *taskCollection) remove(task *task) error {
 	defer t.Unlock()
 	if _, ok := t.table[task.id]; ok {
 		if task.state != core.TaskStopped {
-			schedulerLogger.WithFields(log.Fields{
+			taskLogger.WithFields(log.Fields{
 				"_block":  "remove",
 				"task id": task.id,
 			}).Error(ErrTaskNotStopped)
@@ -419,7 +419,7 @@ func (t *taskCollection) remove(task *task) error {
 		}
 		delete(t.table, task.id)
 	} else {
-		schedulerLogger.WithFields(log.Fields{
+		taskLogger.WithFields(log.Fields{
 			"_block":  "remove",
 			"task id": task.id,
 		}).Error(ErrTaskNotFound)

--- a/scheduler/work_manager_test.go
+++ b/scheduler/work_manager_test.go
@@ -81,6 +81,7 @@ func (mj *mockJob) Errors() []error      { return mj.errors }
 func (mj *mockJob) StartTime() time.Time { return mj.starttime }
 func (mj *mockJob) Deadline() time.Time  { return mj.deadline }
 func (mj *mockJob) Type() jobType        { return collectJobType }
+func (mj *mockJob) TypeString() string   { return "" }
 func (mj *mockJob) TaskID() string       { return "" }
 
 // Complete the first incomplete rendez-vous (if there is one)
@@ -104,6 +105,14 @@ func (mj *mockJob) Run() {
 	}
 	mj.worked = true
 	mj.completePromise.Complete([]error{})
+}
+
+func (mj *mockJob) Name() string {
+	return "n/a"
+}
+
+func (mj *mockJob) Version() int {
+	return 0
 }
 
 func TestWorkerManager(t *testing.T) {

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -20,6 +20,8 @@ limitations under the License.
 package scheduler
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -28,6 +30,7 @@ import (
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/pkg/promise"
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 
@@ -119,5 +122,165 @@ func TestCollectPublishWorkflow(t *testing.T) {
 				})
 			})
 		})
+	})
+}
+
+// The mocks below are here for testing work submission
+type Mock1 struct {
+	count      int
+	errorIndex int
+	delay      time.Duration
+	queue      map[string]int
+}
+
+func (m *Mock1) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
+	return nil, nil
+}
+
+func (m *Mock1) Work(j job) queuedJob {
+	m.queue[j.TypeString()]++
+	return m
+}
+
+func (m *Mock1) Promise() promise.Promise {
+	return m
+}
+
+func (m *Mock1) Await() []error {
+	time.Sleep(m.delay)
+	m.count++
+	if m.count == m.errorIndex {
+		return []error{errors.New("I am an error")}
+	}
+	return nil
+}
+
+func (m *Mock1) AwaitUntil(time.Duration) []error {
+	return nil
+}
+
+func (m *Mock1) Complete([]error) {
+
+}
+
+func (m *Mock1) IsComplete() bool {
+	return false
+}
+
+func (m *Mock1) Job() job {
+	return nil
+}
+
+func (m *Mock1) AndThen(_ func([]error)) {
+}
+
+func (m *Mock1) AndThenUntil(_ time.Duration, _ func([]error)) {
+}
+
+func TestWorkJobs(t *testing.T) {
+	Convey("Test speed and concurrency of TestWorkJobs\n", t, func() {
+		Convey("submit multiple jobs\n", func() {
+			m := &Mock1{queue: make(map[string]int)}
+			m.delay = time.Millisecond * 100
+			pj := newCollectorJob(nil, time.Second*1, m, nil, "")
+			prs := make([]*processNode, 0)
+			pus := make([]*publishNode, 0)
+			counter := 0
+			t := &task{manager: m, id: "1", name: "mock"}
+			for x := 0; x < 3; x++ {
+				n := cdata.NewNode()
+				pr := &processNode{config: n, name: fmt.Sprintf("prjob%d", counter)}
+				pu := &publishNode{config: n, name: fmt.Sprintf("pujob%d", counter)}
+				counter++
+				prs = append(prs, pr)
+				pus = append(pus, pu)
+			}
+			workJobs(prs, pus, t, pj)
+			So(m.queue["processor"], ShouldEqual, 3)
+			So(m.queue["publisher"], ShouldEqual, 3)
+			So(t.failedRuns, ShouldEqual, 0)
+		})
+		Convey("submit multiple jobs with nesting", func() {
+			m := &Mock1{queue: make(map[string]int)}
+			m.delay = time.Millisecond * 100
+			pj := newCollectorJob(nil, time.Second*1, m, nil, "")
+			prs := make([]*processNode, 0)
+			pus := make([]*publishNode, 0)
+			counter := 0
+			t := &task{manager: m, id: "1", name: "mock"}
+			// 3 proc + 3 pub
+			for x := 0; x < 3; x++ {
+				n := cdata.NewNode()
+				pr := &processNode{config: n, name: fmt.Sprintf("prjob%d", counter)}
+				pu := &publishNode{config: n, name: fmt.Sprintf("pujob%d", counter)}
+				counter++
+				prs = append(prs, pr)
+				pus = append(pus, pu)
+			}
+			// 3 proc => 3 proc + 3 pub
+			for _, pr := range prs {
+				cprs := make([]*processNode, 0)
+				cpus := make([]*publishNode, 0)
+				for x := 0; x < 3; x++ {
+					n := cdata.NewNode()
+					cpr := &processNode{config: n, name: fmt.Sprintf("prjobchild%d", counter)}
+					cpu := &publishNode{config: n, name: fmt.Sprintf("pujobchild%d", counter)}
+					counter++
+					cprs = append(cprs, cpr)
+					cpus = append(cpus, cpu)
+				}
+				pr.ProcessNodes = cprs
+				pr.PublishNodes = cpus
+			}
+			workJobs(prs, pus, t, pj)
+			// (3*3)+3
+			So(m.queue["processor"], ShouldEqual, 12)
+			// (3*3)
+			So(m.queue["publisher"], ShouldEqual, 12)
+			So(t.failedRuns, ShouldEqual, 0)
+		})
+		Convey("submit multiple jobs where one has an error", func() {
+			m := &Mock1{queue: make(map[string]int)}
+			// make the 13th job fail
+			m.errorIndex = 13
+			m.delay = time.Millisecond * 100
+			pj := newCollectorJob(nil, time.Second*1, m, nil, "")
+			prs := make([]*processNode, 0)
+			pus := make([]*publishNode, 0)
+			counter := 0
+			t := &task{manager: m, id: "1", name: "mock"}
+			// 3 proc + 3 pub
+			for x := 0; x < 3; x++ {
+				n := cdata.NewNode()
+				pr := &processNode{config: n, name: fmt.Sprintf("prjob%d", counter)}
+				pu := &publishNode{config: n, name: fmt.Sprintf("pujob%d", counter)}
+				counter++
+				prs = append(prs, pr)
+				pus = append(pus, pu)
+			}
+			// 3 proc => 3 proc + 3 pub
+			for _, pr := range prs {
+				cprs := make([]*processNode, 0)
+				cpus := make([]*publishNode, 0)
+				for x := 0; x < 3; x++ {
+					n := cdata.NewNode()
+					cpr := &processNode{config: n, name: fmt.Sprintf("prjobchild%d", counter)}
+					cpu := &publishNode{config: n, name: fmt.Sprintf("pujobchild%d", counter)}
+					counter++
+					cprs = append(cprs, cpr)
+					cpus = append(cpus, cpu)
+				}
+				pr.ProcessNodes = cprs
+				pr.PublishNodes = cpus
+			}
+			workJobs(prs, pus, t, pj)
+			// (3*3)+3
+			So(m.queue["processor"], ShouldEqual, 12)
+			// (3*3)
+			So(m.queue["publisher"], ShouldEqual, 12)
+			So(t.failedRuns, ShouldEqual, 1)
+			So(t.lastFailureMessage, ShouldEqual, "I am an error")
+		})
+
 	})
 }

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -127,6 +128,7 @@ func TestCollectPublishWorkflow(t *testing.T) {
 
 // The mocks below are here for testing work submission
 type Mock1 struct {
+	sync.Mutex
 	count      int
 	errorIndex int
 	delay      time.Duration
@@ -168,6 +170,10 @@ func (m *Mock1) Complete([]error) {
 }
 
 func (m *Mock1) IsComplete() bool {
+	return false
+}
+
+func (m *Mock1) IsError() bool {
 	return false
 }
 

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -131,7 +131,6 @@ type Mock1 struct {
 	sync.Mutex
 	count      int
 	errorIndex int
-	delay      time.Duration
 	queue      map[string]int
 }
 
@@ -142,7 +141,6 @@ func (m *Mock1) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric,
 func (m *Mock1) Work(j job) queuedJob {
 	m.Lock()
 	defer m.Unlock()
-	time.Sleep(m.delay)
 	m.queue[j.TypeString()]++
 	return m
 }
@@ -253,7 +251,6 @@ func TestWorkJobs(t *testing.T) {
 			m3 := &Mock1{queue: make(map[string]int)}
 			// make the 13th job fail
 			m3.errorIndex = 13
-			m3.delay = time.Millisecond * 100
 			pj := newCollectorJob(nil, time.Second*1, m3, nil, "")
 			prs := make([]*processNode, 0)
 			pus := make([]*publishNode, 0)


### PR DESCRIPTION
The existing schedulerWorkflow.workJob() function would submit all processor and publisher jobs for a workflow in a synchronous manner. This would mean each job would block the next going into the queue until it was completed in the queue.

This change ensures the jobs are submitted as a batch for a workflow.