### PR TITLE
Added a PR template for GitHub.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Fixes # .
+
+Summary of changes:
+- 
+- 
+- 
+
+Testing done:
+- 
+
+@intelsdi-x/snap-maintainers


### PR DESCRIPTION
As described in the [GitHub docs](https://github.com/blog/2111-issue-and-pull-request-templates), templates for issue and pull request descriptions are now supported.

Summary of changes:
- Adds a new file `.github/PULL_REQUEST_TEMPLATE.md` with a basic PR outline.

Testing done:
- n/a (can't test until this is committed...)

@intelsdi-x/snap-maintainers 