### PR TITLE
Fix #768: Return and check error from *schedulerWorkflow.BindPluginContentType() method

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -185,14 +185,20 @@ func (s *scheduler) createTask(sch schedule.Schedule, wfMap *wmap.WorkflowMap, s
 		return nil, te
 	}
 
-	// Bind plugin content type selections in workflow
-	err = wf.BindPluginContentTypes(s.metricManager)
-
 	// validate plugins and metrics
 	mts, plugins := s.gatherMetricsAndPlugins(wf)
 	errs := s.metricManager.ValidateDeps(mts, plugins)
 	if len(errs) > 0 {
 		te.errs = append(te.errs, errs...)
+		return nil, te
+	}
+
+	// Bind plugin content type selections in workflow
+	err = wf.BindPluginContentTypes(s.metricManager)
+	if err != nil {
+		te.errs = append(te.errs, serror.New(err))
+		f := buildErrorsLog(te.Errors(), logger)
+		f.Error("unable to bind plugin content types")
 		return nil, te
 	}
 

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -231,8 +231,7 @@ type wfContentTypes map[string]map[string][]string
 
 // BindPluginContentTypes
 func (s *schedulerWorkflow) BindPluginContentTypes(mm managesPluginContentTypes) error {
-	bindPluginContentTypes(s.publishNodes, s.processNodes, mm, []string{plugin.SnapGOBContentType})
-	return nil
+	return bindPluginContentTypes(s.publishNodes, s.processNodes, mm, []string{plugin.SnapGOBContentType})
 }
 
 func bindPluginContentTypes(pus []*publishNode, prs []*processNode, mm managesPluginContentTypes, lct []string) error {
@@ -271,7 +270,9 @@ func bindPluginContentTypes(pus []*publishNode, prs []*processNode, mm managesPl
 			}
 		}
 		//continue the walk down the nodes
-		bindPluginContentTypes(pr.PublishNodes, pr.ProcessNodes, mm, rct)
+		if err := bindPluginContentTypes(pr.PublishNodes, pr.ProcessNodes, mm, rct); err != nil {
+			return err
+		}
 	}
 	for _, pu := range pus {
 		act, _, err := mm.GetPluginContentTypes(pu.Name(), core.PublisherPluginType, pu.Version())


### PR DESCRIPTION
Fixes #768 

Summary of changes:
- Check for error returned by *schedulerWorkflow.BindPluginContentType during task creation
- Return output from bindPluginContentType() instead of nil in *schedulerWorkflow.BindPluginContentType()
- In bindPluginContentType(), check recursive call to bindPluginContentType() for an error and return the error if one is received.
- Moved the call to BindPluginContentType after validating metrics and plugins in the workflow. 

Testing done:
- Ran tests to verify tests pass.

@intelsdi-x/snap-maintainers