### PR TITLE
Correcting example task

### DIFF
--- a/examples/tasks/psutil-file_no-processor.yaml
+++ b/examples/tasks/psutil-file_no-processor.yaml
@@ -1,24 +1,16 @@
---- # The Header starts after this line
-  version: 1        # All tasks, like plugins, have versioning
-  schedule:         # How frequently should we run this task?
-    type: "simple"  # Simple means run forever at the interval below
-    interval: "1s"  # This accepts seconds ('s') and milliseconds  ('ms')
-  workflow:           # For a small number of statistics, we have tests as small
-    collect:          # as 10ms. For a large number, more than 1s may be needed.
-      metrics:        # Collector caching defaults to 500ms.
-        /intel/psutil/load/load1: {}   # Here are the specific metrics we collect
-        /intel/psutil/load/load15: {}    # out of the set of all available from
-        /intel/psutil/load/load5: {}     # our installed plugins. This list only
-        /intel/psutil/vm/available: {}   # requires psutil but could be more.
-        /intel/psutil/vm/free: {}
-        /intel/psutil/vm/used: {}
-      config:
-      process:      # Process is an optional part of the workflow. After collection,
-        -           # we have the option to have one or more processors followed by publishers
-          plugin_name: "passthru"
-          process: null
-          publish:
-            -
-              plugin_name: "file"
-              config:
-                file: "/tmp/snap_published_demo_file.log"
+---
+  version: 1
+  schedule:
+    type: "simple"
+    interval: "1s"
+  workflow: 
+    collect:
+      metrics:
+        /intel/psutil/load/load1: {}
+        /intel/psutil/load/load15: {}
+        /intel/psutil/load/load5: {}
+      publish:
+        -
+          plugin_name: "file"
+          config:
+            file: "/tmp/snap_published_demo_file.log"


### PR DESCRIPTION
* The current psutil w/o a processor is an exact copy of the psutil-file.yaml task and I'd like it to show an example without a processor
* I've added complex-example.yaml, which feeds from multiple collectors and branches into multiple publishers that's used in a presentation I give

Note, some of the Collectors used in the complex example are in development. They'll be out soon. 