### PR TITLE
Fixes #767

### DIFF
--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -144,6 +144,14 @@ func (c *Client) WatchTask(id string) *WatchTasksResult {
 				return
 			default:
 				line, _ := reader.ReadBytes('\n')
+				sline := string(line)
+				if sline == "" || sline == "\n" {
+					continue
+				}
+				if strings.HasPrefix(sline, "data:") {
+					sline = strings.TrimPrefix(sline, "data:")
+					line = []byte(sline)
+				}
 				ste := &rbody.StreamedTaskEvent{}
 				err := json.Unmarshal(line, ste)
 				if err != nil {

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -185,7 +185,7 @@ func (s *Server) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.
 		EventType: rbody.TaskWatchStreamOpen,
 		Message:   "Stream opened",
 	}
-	fmt.Fprintf(w, "%s\n", so.ToJSON())
+	fmt.Fprintf(w, "data: %s\n\n", so.ToJSON())
 	flusher.Flush()
 
 	// Get a channel for if the client notifies us it is closing the connection
@@ -203,10 +203,10 @@ func (s *Server) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.
 			case rbody.TaskWatchMetricEvent, rbody.TaskWatchTaskStarted:
 				// The client can decide to stop receiving on the stream on Task Stopped.
 				// We write the event to the buffer
-				fmt.Fprintf(w, "%s\n", e.ToJSON())
+				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
 			case rbody.TaskWatchTaskDisabled, rbody.TaskWatchTaskStopped:
 				// A disabled task should end the streaming and close the connection
-				fmt.Fprintf(w, "%s\n", e.ToJSON())
+				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
 				// Flush since we are sending nothing new
 				flusher.Flush()
 				// Close out watcher removing it from the scheduler


### PR DESCRIPTION
Fixes #767 - Watch API appears to be non-compliant with SSE

Summary of changes:
- Add a 'data' field to the event being sent per https://www.w3.org/TR/eventsource/#event-stream-interpretation 

Testing done:
- Unit
- Used the following javascript to test from the browser
```html
<html>
<head>
  <meta charset="utf-8" />
</head>
<body>
  <script>
    var source = new EventSource('http://10.24.142.68:8181/v1/tasks/b7445e21-29ba-41d7-bda8-49fe1d8267c4/watch');
    console.log(source)
    source.addEventListener('message', function(e) {
        console.log(e.data);
    }, false);
    source.onmessage = function(e) {
      document.body.innerHTML += e.data + '<br>';      
    };
    console.log(source)
  </script>
</body>
</html>
```

![sse](http://i.giphy.com/3o7abDacfUhNNYt4XK.gif)

@intelsdi-x/snap-maintainers
