### PR TITLE
snapctl: use default in `metric get`

### DIFF
--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -126,7 +126,7 @@ var (
 	// metric
 	flMetricVersion = cli.IntFlag{
 		Name:  "metric-version, v",
-		Usage: "The metric version",
+		Usage: "The metric version. Default (0) is latest",
 	}
 	flMetricNamespace = cli.StringFlag{
 		Name:  "metric-namespace, m",

--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -78,8 +78,8 @@ func listMetrics(ctx *cli.Context) {
 }
 
 func getMetric(ctx *cli.Context) {
-	if !ctx.IsSet("metric-namespace") || !ctx.IsSet("metric-version") {
-		fmt.Println("namespace and version are required")
+	if !ctx.IsSet("metric-namespace") {
+		fmt.Println("namespace is required")
 		fmt.Println("")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
 		return


### PR DESCRIPTION
##### Summary of changes:
The flag for metric version has a default, but `snapctl metric get`
still required both namespace and version to be passed in. Now, the default
(0 / latest) will be used when no `-v` is passed.
##### Testing done:
Locally:
![screen shot 2016-03-18 at 9 04 47 am](https://cloud.githubusercontent.com/assets/1194436/13883822/7f2b35f4-ece8-11e5-8279-e9bc4ae2bdc8.png)

@intelsdi-x/snap-maintainers