### PR TITLE
Remove golint download from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
 - go get github.com/tools/godep
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
-- go get -u github.com/golang/lint/golint
 - go get golang.org/x/tools/cmd/vet
 - go get golang.org/x/tools/cmd/goimports
 - go get github.com/smartystreets/goconvey/convey


### PR DESCRIPTION
This is a workaround until a decision can be made around removing Go 1.4.3 from the testing matrix.

Golint has dropped support for Go 1.4.3, and now requires Go 1.5 or Go 1.6. Our testing would download golint, but our test script does not actually run golint on our codebase. Removing the download should allow tests to continue to run for Go 1.4.3 until a decision can be made to remove it from the testing matrix.

Summary of changes:
- Remove downloading golint in .travis.yml

Testing done:
- None; that is the job of Travis for changes in .travis.yml

@intelsdi-x/snap-maintainers