### PR TITLE
Fix #776

### DIFF
--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -74,6 +74,7 @@ type task struct {
 	deadlineDuration   time.Duration
 	hitCount           uint
 	missedIntervals    uint
+	failureMutex       sync.Mutex
 	failedRuns         uint
 	lastFailureMessage string
 	lastFailureTime    time.Time
@@ -351,8 +352,8 @@ func (t *task) waitForSchedule() {
 // RecordFailure updates the failed runs and last failure properties
 func (t *task) RecordFailure(e []error) {
 	// We synchronize this update to ensure it is atomic
-	t.Lock()
-	defer t.Unlock()
+	t.failureMutex.Lock()
+	defer t.failureMutex.Unlock()
 	t.failedRuns++
 	t.lastFailureTime = t.lastFireTime
 	t.lastFailureMessage = e[len(e)-1].Error()


### PR DESCRIPTION
Fixes #776

Summary of changes:
- Remove `t.Lock()` and `t.Unlock()` calls from `*task.RecordFailures()` as these calls were trying to lock an already locked task causes tasks that fail to hang.

Testing done:
- Verified tasks that fail do not hang and continue to run per schedule defined in task until consecutive failure limit is reached.

@intelsdi-x/snap-maintainers

*NOTE* This needs PR #780 to be merged first.