### PR TITLE
Cron scheduler

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -123,6 +123,10 @@
 		{
 			"ImportPath": "github.com/vrischmann/jsonutil",
 			"Rev": "694784f9315ee9fc763c1d30f28753cba21307aa"
+		},
+		{
+			"ImportPath": "github.com/robfig/cron",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
 		}
 	]
 }

--- a/cmd/snapctl/Godeps/Godeps.json
+++ b/cmd/snapctl/Godeps/Godeps.json
@@ -14,6 +14,10 @@
 		{
 			"ImportPath": "github.com/ghodss/yaml",
 			"Rev": "c3eb24aeea63668ebdac08d2e252f20df8b6b1ae"
+		},
+		{
+			"ImportPath": "github.com/robfig/cron",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
 		}
 	]
 }

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015,2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ var (
 
 	flTaskSchedInterval = cli.StringFlag{
 		Name:  "interval, i",
-		Usage: "Interval for the task schedule [ex: 250ms, 1s, 30m]",
+		Usage: "Interval for the task schedule [ex (simple schedule): 250ms, 1s, 30m (cron schedule): \"0 * * * * *\"]",
 	}
 
 	flTaskSchedStartTime = cli.StringFlag{

--- a/docs/SNAPCTL.md
+++ b/docs/SNAPCTL.md
@@ -53,7 +53,7 @@ create      There are two ways to create a task.
 
                --task-manifest, -t          File path for task manifest to use for task creation.
 			   --workflow-manifest, -w      File path for workflow manifest to use for task creation
-			   --interval, -i               Interval for the task schedule [ex: 250ms, 1s, 30m]
+			   --interval, -i               Interval for the task schedule [ex (simple schedule): 250ms, 1s, 30m (cron schedule): "0 * * * * *"]
 			   --start-date                 Start date for the task schedule [defaults to today]
 			   --start-time                 Start time for the task schedule [defaults to now]
 			   --stop-date                  Stop date for the task schedule [defaults to today]

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -22,7 +22,20 @@ The header contains a version, used to differentiate between versions of the tas
 
 #### Schedule
 
-The schedule describes the schedule type and interval for running the task.  The type of a schedule could be a simple "run forever" schedule, which is what we see above as `"simple"` or something more complex.  __snap__ is designed in a way where custom schedulers can easily be dropped in.  If a custom schedule is used, it may require more key/value pairs in the schedule section of the manifest.  At the time of this writing, __snap__ has a simple schedule which is described above, and a window schedule.  The window schedule adds a start and stop time.  For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).
+The schedule describes the schedule type and interval for running the task.  The type of a schedule could be a simple "run forever" schedule, which is what we see above as `"simple"` or something more complex.  __snap__ is designed in a way where custom schedulers can easily be dropped in.  If a custom schedule is used, it may require more key/value pairs in the schedule section of the manifest.  At the time of this writing, __snap__ has three schedules:
+- **simple schedule** which is described above, 
+- **window schedule** which adds a start and stop time,
+- **cron schedule** which supports cron-like entries in ```interval``` field, like in this example (workflow will fire every hour on the half hour):
+```
+    "version": 1,
+    "schedule": {
+        "type": "cron",
+        "interval" : "0 30 * * * *"
+    },
+```
+More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
+
+For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).
 
 ### The Workflow
 

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015,2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import (
 )
 
 type Schedule struct {
-	// Type specifies the type of the schedule. Currently,the type of "simple" and "windowed" are supported.
+	// Type specifies the type of the schedule. Currently, the type of "simple", "windowed" and "cron" are supported.
 	Type string
 	// Interval specifies the time duration.
 	Interval string

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015,2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -342,6 +342,17 @@ func makeSchedule(s request.Schedule) (cschedule.Schedule, error) {
 		)
 
 		err = sch.Validate()
+		if err != nil {
+			return nil, err
+		}
+		return sch, nil
+	case "cron":
+		if s.Interval == "" {
+			return nil, errors.New("missing cron entry ")
+		}
+		sch := cschedule.NewCronSchedule(s.Interval)
+
+		err := sch.Validate()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/schedule/cron_schedule.go
+++ b/pkg/schedule/cron_schedule.go
@@ -1,0 +1,137 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"errors"
+	"time"
+
+	"github.com/robfig/cron"
+)
+
+// ErrMissingCronEntry indicates missing cron entry
+var ErrMissingCronEntry = errors.New("Cron entry is missing")
+
+// CronSchedule is a schedule that waits as long as specified in cron entry
+type CronSchedule struct {
+	entry    string
+	enabled  bool
+	state    ScheduleState
+	schedule *cron.Cron
+}
+
+// NewCronSchedule creates and starts new cron schedule and returns an instance of CronSchedule
+func NewCronSchedule(entry string) *CronSchedule {
+	schedule := cron.New()
+	return &CronSchedule{
+		entry:    entry,
+		schedule: schedule,
+		enabled:  false,
+	}
+}
+
+// GetState returns state of CronSchedule
+func (c *CronSchedule) GetState() ScheduleState {
+	return c.state
+}
+
+// Validate returns error if cron entry dosn't match crontab format
+func (c *CronSchedule) Validate() error {
+	if c.entry == "" {
+		return ErrMissingCronEntry
+	}
+	_, err := cron.Parse(c.entry)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Wait waits as long as specified in cron entry
+func (c *CronSchedule) Wait(last time.Time) Response {
+	var err error
+	now := time.Now()
+
+	// first run
+	if (last == time.Time{}) {
+		last = now
+	}
+	// schedule not enabled, either due to first run or invalid cron entry
+	if !c.enabled {
+		err = c.schedule.AddFunc(c.entry, func() {})
+		if err != nil {
+			c.state = Error
+		} else {
+			c.enabled = true
+		}
+	}
+
+	var misses uint
+	if c.enabled {
+		s := c.schedule.Entries()[0].Schedule
+
+		// calculate misses
+		for next := last; next.Before(now); {
+			next = s.Next(next)
+			if next.After(now) {
+				break
+			}
+			misses++
+		}
+
+		// wait
+		waitTime := s.Next(now)
+		time.Sleep(waitTime.Sub(now))
+	}
+
+	return &CronScheduleResponse{
+		state:    c.GetState(),
+		err:      err,
+		missed:   misses,
+		lastTime: time.Now(),
+	}
+}
+
+// CronScheduleResponse is the response from CronSchedule
+type CronScheduleResponse struct {
+	state    ScheduleState
+	err      error
+	missed   uint
+	lastTime time.Time
+}
+
+// State returns the state of the Schedule
+func (c *CronScheduleResponse) State() ScheduleState {
+	return c.state
+}
+
+// Error returns last error
+func (c *CronScheduleResponse) Error() error {
+	return c.err
+}
+
+// Missed returns any missed intervals
+func (c *CronScheduleResponse) Missed() uint {
+	return c.missed
+}
+
+// LastTime returns the last response time
+func (c *CronScheduleResponse) LastTime() time.Time {
+	return c.lastTime
+}

--- a/pkg/schedule/cron_schedule_test.go
+++ b/pkg/schedule/cron_schedule_test.go
@@ -1,0 +1,77 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedule
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCronSchedule(t *testing.T) {
+	Convey("Cron Schedule", t, func() {
+		Convey("valid cron entry", func() {
+			i := "0 * * * * *"
+			c := NewCronSchedule(i)
+			e := c.Validate()
+			So(e, ShouldBeNil)
+		})
+		Convey("missing cron entry", func() {
+			i := ""
+			c := NewCronSchedule(i)
+			e := c.Validate()
+			So(e, ShouldEqual, ErrMissingCronEntry)
+		})
+		Convey("invalid cron entry", func() {
+			i := "invalid cron entry"
+			c := NewCronSchedule(i)
+			e := c.Validate()
+			So(e, ShouldNotBeNil)
+		})
+		Convey("wait on valid cron entry", func() {
+			i := "@every 1s"
+			c := NewCronSchedule(i)
+			now := time.Now()
+			r := c.Wait(now)
+			So(r, ShouldNotBeNil)
+			So(r.State(), ShouldEqual, Active)
+			So(r.Error(), ShouldBeNil)
+			So(r.Missed(), ShouldEqual, 0)
+			lastTime := r.LastTime()
+			l := lastTime.After(now) && lastTime.Before(time.Now())
+			So(l, ShouldBeTrue)
+		})
+		Convey("counting misses in Wait()", func() {
+			i := "@every 1s"
+			c := NewCronSchedule(i)
+			now := time.Now()
+			r := c.Wait(now)
+			then := now.Add(-time.Duration(10) * time.Second)
+			r = c.Wait(then)
+			So(r, ShouldNotBeNil)
+			So(r.State(), ShouldEqual, Active)
+			So(r.Error(), ShouldBeNil)
+			So(r.Missed(), ShouldBeBetweenOrEqual, 10, 12)
+			lastTime := r.LastTime()
+			l := lastTime.After(now) && lastTime.Before(time.Now())
+			So(l, ShouldBeTrue)
+		})
+	})
+}


### PR DESCRIPTION
Implements #818. 

Summary of changes:
- Ability to use cron-like entries in task manifest file, for example:
```
{
    "version": 1,
    "schedule": {
        "type": "cron",
        "interval" : "@every 3s"
    },
    "workflow": {
``` 
or
```
{
    "version": 1,
    "schedule": {
        "type": "cron",
        "interval" : "0 * * * * *"
    },
    "workflow": {

```
More on supported cron expressions here: https://godoc.org/github.com/robfig/cron

Testing done:
- unit tests
- developer tests: snapctl workflow and task manifest, regression tests, different cron entries in task manifest

@intelsdi-x/snap-maintainers