### PR TITLE
Fix #787: Set gitcookie for go.googlesource.com due to rate limit for dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 - 1.5.3
 - 1.6
 before_install:
+- bash scripts/gitcookie.sh
 - go get github.com/tools/godep
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls

--- a/scripts/gitcookie.sh
+++ b/scripts/gitcookie.sh
@@ -1,0 +1,11 @@
+touch ~/.gitcookies
+chmod 0600 ~/.gitcookies
+
+git config --global http.cookiefile ~/.gitcookies
+
+tr , \\t <<\__END__ >>~/.gitcookies
+go.googlesource.com,FALSE,/,TRUE,2147483647,o,git-snappytheturtle1202.gmail.com=1/4zg9qf0zy1bmnMpEnqT7IL-rcL5_y8XP7bpfYE5DzN0
+go-review.googlesource.com,FALSE,/,TRUE,2147483647,o,git-snappytheturtle1202.gmail.com=1/4zg9qf0zy1bmnMpEnqT7IL-rcL5_y8XP7bpfYE5DzN0
+__END__
+
+


### PR DESCRIPTION
Fixes #787 

Summary of changes:
- Add script for setting gitcookie in Travis
- Update .travis.yml file to call script before loading dependencies

Testing done:
- For Travis to do.

@intelsdi-x/snap-maintainers
