### PR TITLE
Fixed typo in passthru processor

### DIFF
--- a/plugin/processor/snap-processor-passthru/main.go
+++ b/plugin/processor/snap-processor-passthru/main.go
@@ -28,5 +28,5 @@ import (
 
 func main() {
 	meta := passthru.Meta()
-	plugin.Start(meta, passthru.NewPassthruPublisher(), os.Args[1])
+	plugin.Start(meta, passthru.NewPassthruProcessor(), os.Args[1])
 }

--- a/plugin/processor/snap-processor-passthru/passthru/passthru.go
+++ b/plugin/processor/snap-processor-passthru/passthru/passthru.go
@@ -41,7 +41,7 @@ func Meta() *plugin.PluginMeta {
 	return plugin.NewPluginMeta(name, version, pluginType, []string{plugin.SnapGOBContentType}, []string{plugin.SnapGOBContentType})
 }
 
-func NewPassthruPublisher() *passthruProcessor {
+func NewPassthruProcessor() *passthruProcessor {
 	return &passthruProcessor{}
 }
 


### PR DESCRIPTION

Summary of changes:
- Fixed typo in function name in the passthru processor 

Testing done:
- Yes 

@intelsdi-x/snap-maintainers

