### PR TITLE
rest: add tags to task watch events

### DIFF
--- a/mgmt/rest/rbody/task.go
+++ b/mgmt/rest/rbody/task.go
@@ -250,10 +250,11 @@ func (s *StreamedTaskEvent) ToJSON() string {
 }
 
 type StreamedMetric struct {
-	Namespace string      `json:"namespace"`
-	Data      interface{} `json:"data"`
-	Source    string      `json:"source"`
-	Timestamp time.Time   `json:"timestamp"`
+	Namespace string            `json:"namespace"`
+	Data      interface{}       `json:"data"`
+	Source    string            `json:"source"`
+	Timestamp time.Time         `json:"timestamp"`
+	Tags      map[string]string `json:"tags"`
 }
 
 type StreamedMetrics []StreamedMetric

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -365,6 +365,7 @@ func (t *TaskWatchHandler) CatchCollection(m []core.Metric) {
 			Data:      m[i].Data(),
 			Source:    m[i].Source(),
 			Timestamp: m[i].Timestamp(),
+			Tags:      m[i].Tags(),
 		}
 	}
 	t.mChan <- rbody.StreamedTaskEvent{


### PR DESCRIPTION
Summary of changes:
- Add `metricType` `Tags` to the server side events that come through via task watching

Testing done:
- locally observed events coming through do include Tags. 

@intelsdi-x/snap-maintainers