### PR TITLE
Fix #795: Return both cached and collected metrics

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -411,7 +411,7 @@ func (ap *availablePlugins) collectMetrics(pluginKey string, metricTypes []core.
 	p.(*availablePlugin).hitCount++
 	p.(*availablePlugin).lastHitTime = time.Now()
 
-	return metrics, nil
+	return results, nil
 }
 
 func (ap *availablePlugins) publishMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) []error {


### PR DESCRIPTION
Fixes #795

Summary of changes:
- Return results slice that includes cache and collected metrics instead of metrics slice that only included metrics returned from the plugin.

Testing done:
- Verified both cached and collected metrics are returned.

@intelsdi-x/snap-maintainers

