### PR TITLE
give fixed names to gob registered types

### DIFF
--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -260,16 +260,16 @@ func newNativeClient(address string, timeout time.Duration, t plugin.PluginType,
 }
 
 func init() {
-	gob.Register(*(&ctypes.ConfigValueStr{}))
-	gob.Register(*(&ctypes.ConfigValueInt{}))
-	gob.Register(*(&ctypes.ConfigValueFloat{}))
-	gob.Register(*(&ctypes.ConfigValueBool{}))
+	gob.RegisterName("conf_value_string", *(&ctypes.ConfigValueStr{}))
+	gob.RegisterName("conf_value_int", *(&ctypes.ConfigValueInt{}))
+	gob.RegisterName("conf_value_float", *(&ctypes.ConfigValueFloat{}))
+	gob.RegisterName("conf_value_bool", *(&ctypes.ConfigValueBool{}))
 
-	gob.Register(cpolicy.NewPolicyNode())
-	gob.Register(&cdata.ConfigDataNode{})
-	gob.Register(&cpolicy.StringRule{})
-	gob.Register(&cpolicy.IntRule{})
-	gob.Register(&cpolicy.FloatRule{})
+	gob.RegisterName("conf_policy_node", cpolicy.NewPolicyNode())
+	gob.RegisterName("conf_data_node", &cdata.ConfigDataNode{})
+	gob.RegisterName("conf_policy_string", &cpolicy.StringRule{})
+	gob.RegisterName("conf_policy_int", &cpolicy.IntRule{})
+	gob.RegisterName("conf_policy_float", &cpolicy.FloatRule{})
 }
 
 func upcaseInitial(str string) string {

--- a/control/plugin/session.go
+++ b/control/plugin/session.go
@@ -297,14 +297,14 @@ func NewSessionState(pluginArgsMsg string, plugin Plugin, meta *PluginMeta) (*Se
 }
 
 func init() {
-	gob.Register(*(&ctypes.ConfigValueInt{}))
-	gob.Register(*(&ctypes.ConfigValueStr{}))
-	gob.Register(*(&ctypes.ConfigValueFloat{}))
-	gob.Register(*(&ctypes.ConfigValueBool{}))
+	gob.RegisterName("conf_value_string", *(&ctypes.ConfigValueStr{}))
+	gob.RegisterName("conf_value_int", *(&ctypes.ConfigValueInt{}))
+	gob.RegisterName("conf_value_float", *(&ctypes.ConfigValueFloat{}))
+	gob.RegisterName("conf_value_bool", *(&ctypes.ConfigValueBool{}))
 
-	gob.Register(cpolicy.NewPolicyNode())
-	gob.Register(&cdata.ConfigDataNode{})
-	gob.Register(&cpolicy.StringRule{})
-	gob.Register(&cpolicy.IntRule{})
-	gob.Register(&cpolicy.FloatRule{})
+	gob.RegisterName("conf_policy_node", cpolicy.NewPolicyNode())
+	gob.RegisterName("conf_data_node", &cdata.ConfigDataNode{})
+	gob.RegisterName("conf_policy_string", &cpolicy.StringRule{})
+	gob.RegisterName("conf_policy_int", &cpolicy.IntRule{})
+	gob.RegisterName("conf_policy_float", &cpolicy.FloatRule{})
 }


### PR DESCRIPTION
Fixes #804 

When using vendoring in Go 1.6, reflection is used in gob.Register to create
a key for type lookups.  This `reflect.PkgPath()` call returns a "globally
unique" key for looking up types, and in the case of a vendored type, is
not valid for matching gob registration names.  This is because on the
server side, the type is registered as `import/path.(typename)`, but on
the client side (vendored) it looks like
`client/vendor/import/path.(typename)`.  Using fixed keys bypasses the
need for reflection and is safe on either side, even when using
vendoring.