### PR TITLE
Fixes #385: Added swap plugins to snapctl

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -104,7 +104,7 @@ var (
 				},
 				{
 					Name:   "unload",
-					Usage:  "unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_version> -v <plugin_version>",
+					Usage:  "unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_name> -v <plugin_version>",
 					Action: unloadPlugin,
 					Flags: []cli.Flag{
 						flPluginType,

--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -113,6 +113,17 @@ var (
 					},
 				},
 				{
+					Name:   "swap",
+					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version>",
+					Action: swapPlugins,
+					Flags: []cli.Flag{
+						flPluginAsc,
+						flPluginType,
+						flPluginName,
+						flPluginVersion,
+					},
+				},
+				{
 					Name:   "list",
 					Usage:  "list",
 					Action: listPlugins,

--- a/mgmt/rest/rbody/body.go
+++ b/mgmt/rest/rbody/body.go
@@ -82,6 +82,8 @@ func UnmarshalBody(t string, b []byte) (Body, error) {
 		return unmarshalAndHandleError(b, &PluginsLoaded{})
 	case PluginUnloadedType:
 		return unmarshalAndHandleError(b, &PluginUnloaded{})
+	case PluginReturnedType:
+		return unmarshalAndHandleError(b, &PluginReturned{})
 	case ScheduledTaskListReturnedType:
 		return unmarshalAndHandleError(b, &ScheduledTaskListReturned{})
 	case ScheduledTaskReturnedType:


### PR DESCRIPTION
Fixes #385 and #834 

Summary of changes:
- Added swap plugins to snapctl via the client

Testing done:
- Swapping plugins with different types/names
- Swapping plugins with the same type and name
- Swapping a plugin with itself

Still need to add a test for rollback failure and remove swap plugins from control/control_test.go.

@intelsdi-x/snap-maintainers

