### PR TITLE
First implementation of dynamic query support

### DIFF
--- a/control/metrics.go
+++ b/control/metrics.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ package control
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -38,6 +39,14 @@ import (
 var (
 	errMetricNotFound   = errors.New("metric not found")
 	errNegativeSubCount = serror.New(errors.New("subscription count cannot be < 0"))
+	notAllowedChars     = map[string][]string{
+		"brackets":     {"(", ")", "[", "]", "{", "}"},
+		"spaces":       {" "},
+		"punctuations": {".", ",", ";", "?", "!"},
+		"slashes":      {"|", "\\", "/"},
+		"carets":       {"^"},
+		"quotations":   {"\"", "`", "'"},
+	}
 )
 
 func errorMetricNotFound(ns []string, ver ...int) error {
@@ -45,6 +54,26 @@ func errorMetricNotFound(ns []string, ver ...int) error {
 		return fmt.Errorf("Metric not found: %s (version: %d)", core.JoinNamespace(ns), ver[0])
 	}
 	return fmt.Errorf("Metric not found: %s", core.JoinNamespace(ns))
+}
+
+func errorMetricContainsNotAllowedChars(ns []string) error {
+	return fmt.Errorf("Metric namespace %s contains not allowed characters. Avoid using %s", ns, listNotAllowedChars())
+}
+
+func errorMetricEndsWithAsterisk(ns []string) error {
+	return fmt.Errorf("Metric namespace %s ends with an asterisk is not allowed", ns)
+}
+
+// listNotAllowedChars returns list of not allowed characters in metric's namespace as a string
+// which is used in construct errorMetricContainsNotAllowedChars as a recommendation
+// exemplary output: "brackets [( ) [ ] { }], spaces [ ], punctuations [. , ; ? !], slashes [| \ /], carets [^], quotations [" ` ']"
+func listNotAllowedChars() string {
+	var result string
+	for groupName, chars := range notAllowedChars {
+		result += fmt.Sprintf(" %s %s,", groupName, chars)
+	}
+	// trim the comma in the end
+	return strings.TrimSuffix(result, ",")
 }
 
 type metricCatalogItem struct {
@@ -160,23 +189,166 @@ func (m *metricType) Timestamp() time.Time {
 }
 
 type metricCatalog struct {
-	tree        *MTTrie
-	mutex       *sync.Mutex
-	keys        []string
+	tree  *MTTrie
+	mutex *sync.Mutex
+	keys  []string
+
+	// mKeys holds requested metric's keys which can include wildcards and matched to them the cataloged keys
+	mKeys       map[string][]string
 	currentIter int
 }
 
 func newMetricCatalog() *metricCatalog {
-	var k []string
 	return &metricCatalog{
 		tree:        NewMTTrie(),
 		mutex:       &sync.Mutex{},
 		currentIter: 0,
-		keys:        k,
+		keys:        []string{},
+		mKeys:       make(map[string][]string),
 	}
 }
 
+func (mc *metricCatalog) Keys() []string {
+	return mc.keys
+}
+
+// matchedNamespaces retrieves all matched items stored in mKey map under the key 'wkey' and converts them to namespaces
+func (mc *metricCatalog) matchedNamespaces(wkey string) ([][]string, error) {
+	// mkeys means matched metrics keys
+	mkeys := mc.mKeys[wkey]
+
+	if len(mkeys) == 0 {
+		return nil, errorMetricNotFound(getMetricNamespace(wkey))
+	}
+
+	// convert matched keys to a slice of namespaces
+	return convertKeysToNamespaces(mkeys), nil
+}
+
+// GetQueriedNamespaces returns all matched metrics namespaces for query 'ns' which can contain
+// an asterisk or tuple (refer to query support)
+func (mc *metricCatalog) GetQueriedNamespaces(ns []string) ([][]string, error) {
+	mc.mutex.Lock()
+	defer mc.mutex.Unlock()
+
+	// get metric key (might contain wildcard(s))
+	wkey := getMetricKey(ns)
+
+	return mc.matchedNamespaces(wkey)
+}
+
+// MatchQuery matches given 'ns' which could contain an asterisk or a tuple and add them to matching map under key 'ns'
+// The matched metrics namespaces are also returned (as a [][]string)
+func (mc *metricCatalog) MatchQuery(ns []string) ([][]string, error) {
+	mc.mutex.Lock()
+	defer mc.mutex.Unlock()
+
+	// get metric key (might contain wildcard(s))
+	wkey := getMetricKey(ns)
+
+	// adding matched namespaces to map
+	mc.addItemToMatchingMap(wkey)
+
+	return mc.matchedNamespaces(wkey)
+}
+
+func convertKeysToNamespaces(keys []string) [][]string {
+	// nss is a slice of slices which holds metrics namespaces
+	nss := [][]string{}
+	for _, key := range keys {
+		ns := getMetricNamespace(key)
+		if len(ns) != 0 {
+			nss = append(nss, ns)
+		}
+	}
+	return nss
+}
+
+// addItemToMatchingMap adds `wkey` to matching map (or updates if `wkey` exists) with corresponding cataloged keys as a content;
+// if this 'wkey' does not match to any cataloged keys, it will be removed from matching map
+func (mc *metricCatalog) addItemToMatchingMap(wkey string) {
+	matchedKeys := []string{}
+
+	// wkey contains `.` which should not be interpreted as regexp tokens, but as a single character
+	exp := strings.Replace(wkey, ".", "[.]", -1)
+
+	// change `*` into regexp `.*` which matches any characters
+	exp = strings.Replace(exp, "*", ".*", -1)
+
+	regex := regexp.MustCompile("^" + exp + "$")
+	for _, key := range mc.keys {
+		match := regex.FindStringSubmatch(key)
+		if match == nil {
+			continue
+		}
+		matchedKeys = appendIfMissing(matchedKeys, key)
+	}
+	if len(matchedKeys) == 0 {
+		mc.removeItemFromMatchingMap(wkey)
+	} else {
+		mc.mKeys[wkey] = matchedKeys
+	}
+}
+
+// removeItemFromMatchingMap removes `wkey` from matching map
+func (mc *metricCatalog) removeItemFromMatchingMap(wkey string) {
+	if _, exist := mc.mKeys[wkey]; exist {
+		delete(mc.mKeys, wkey)
+	}
+}
+
+// updateMatchingMap updates the contents of matching map
+func (mc *metricCatalog) updateMatchingMap() {
+	for wkey := range mc.mKeys {
+		// add (or update if exist) item `wkey'
+		mc.addItemToMatchingMap(wkey)
+	}
+}
+
+// removeMatchedKey iterates over all items in the mKey and removes `key` from its content
+func (mc *metricCatalog) removeMatchedKey(key string) {
+	for wkey, mkeys := range mc.mKeys {
+		for index, mkey := range mkeys {
+			if mkey == key {
+				// remove this key from slice
+				mc.mKeys[wkey] = append(mkeys[:index], mkeys[index+1:]...)
+			}
+		}
+		// if no matched key left, remove this item from map
+		if len(mc.mKeys[wkey]) == 0 {
+			mc.removeItemFromMatchingMap(wkey)
+		}
+	}
+}
+
+// validateMetricNamespace validates metric namespace in terms of containing not allowed characters and ending with an asterisk
+func validateMetricNamespace(ns []string) error {
+	name := strings.Join(ns, "")
+	for _, chars := range notAllowedChars {
+		for _, ch := range chars {
+			if strings.ContainsAny(name, ch) {
+				return errorMetricContainsNotAllowedChars(ns)
+			}
+		}
+	}
+	// plugin should NOT advertise metrics ending with a wildcard
+	if strings.HasSuffix(name, "*") {
+		return errorMetricEndsWithAsterisk(ns)
+	}
+
+	return nil
+}
+
 func (mc *metricCatalog) AddLoadedMetricType(lp *loadedPlugin, mt core.Metric) error {
+	if err := validateMetricNamespace(mt.Namespace()); err != nil {
+		log.WithFields(log.Fields{
+			"_module": "control",
+			"_file":   "metrics.go,",
+			"_block":  "add-loaded-metric-type",
+			"error":   fmt.Errorf("Metric namespace %s contains not allowed characters", mt.Namespace()),
+		}).Error("error adding loaded metric type")
+		return err
+	}
 	if lp.ConfigPolicy == nil {
 		err := errors.New("Config policy is nil")
 		log.WithFields(log.Fields{
@@ -187,7 +359,6 @@ func (mc *metricCatalog) AddLoadedMetricType(lp *loadedPlugin, mt core.Metric) e
 		}).Error("error adding loaded metric type")
 		return err
 	}
-
 	newMt := metricType{
 		Plugin:             lp,
 		namespace:          mt.Namespace(),
@@ -201,10 +372,14 @@ func (mc *metricCatalog) AddLoadedMetricType(lp *loadedPlugin, mt core.Metric) e
 	return nil
 }
 
+// RmUnloadedPluginMetrics removes plugin metrics which was unloaded,
+// consequently cataloged metrics are changed, so matching map is being updated too
 func (mc *metricCatalog) RmUnloadedPluginMetrics(lp *loadedPlugin) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
 	mc.tree.DeleteByPlugin(lp)
+	// update the contents of matching map (mKeys)
+	mc.updateMatchingMap()
 }
 
 // Add adds a metricType
@@ -213,6 +388,8 @@ func (mc *metricCatalog) Add(m *metricType) {
 	defer mc.mutex.Unlock()
 
 	key := getMetricKey(m.Namespace())
+
+	// adding key as a cataloged keys (mc.keys)
 	mc.keys = appendIfMissing(mc.keys, key)
 
 	mc.tree.Add(m)
@@ -237,7 +414,6 @@ func (mc *metricCatalog) GetVersions(ns []string) ([]*metricType, error) {
 func (mc *metricCatalog) Fetch(ns []string) ([]*metricType, error) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
-
 	mtsi, err := mc.tree.Fetch(ns)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -251,10 +427,16 @@ func (mc *metricCatalog) Fetch(ns []string) ([]*metricType, error) {
 	return mtsi, nil
 }
 
+// Remove removes a metricType from the catalog and from matching map
 func (mc *metricCatalog) Remove(ns []string) {
 	mc.mutex.Lock()
+	defer mc.mutex.Unlock()
+
 	mc.tree.Remove(ns)
-	mc.mutex.Unlock()
+
+	// remove all items from map mKey mapped for this 'ns'
+	key := getMetricKey(ns)
+	mc.removeMatchedKey(key)
 }
 
 // Item returns the current metricType in the collection.  The method Next()
@@ -375,14 +557,18 @@ func (mc *metricCatalog) getVersions(ns []string) ([]*metricType, error) {
 		}).Error("error getting plugin version")
 		return nil, err
 	}
-	if mts == nil {
-		return nil, errMetricNotFound
+	if len(mts) == 0 {
+		return nil, errorMetricNotFound(ns)
 	}
 	return mts, nil
 }
 
 func getMetricKey(metric []string) string {
 	return strings.Join(metric, ".")
+}
+
+func getMetricNamespace(key string) []string {
+	return strings.Split(key, ".")
 }
 
 func getLatest(c []*metricType) *metricType {

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -41,7 +41,7 @@ Communication between snap and plugins uses RPC either through HTTP or TCP proto
 
 Before starting writing snap plugins, check out the [Plugin Catalog](https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md) to see if any suit your needs. If not, you need to reference the plugin packages that defines the type of structures and interfaces inside snap and then write plugin endpoints to implement the defined interfaces.
 
-### Naming, Files, and Directory    
+### Plugin Naming, Files, and Directory    
 snap supports three type of plugins. They are collectors, processors, and publishers.  The plugin project name should use the following format:  
 >snap-plugin-[type]-[name]
 
@@ -60,6 +60,33 @@ snap-plugin-[type]-[name]
  |--main.go
  |--main_test.go
 ```
+
+### Metric Naming
+A plugin should **NOT** advertise metrics which namespaces contain:
+
+##### a) the following characters in a namespace:
+    - spaces
+    - brackets: `()[]{}`
+    - slashes:  `| \ /`
+    - carets:   `^`
+    - quotations:   `" ' \``
+    - other punctuations: `. , ; ? !`
+
+##### b) a wildcard in the end
+
+Example:
+
+Unacceptable metric namespace| Why |  Proposal
+----------|-----------|-----------
+/intel/foo/\* | a wildcard in the end | /intel/foo/\*/bar <br/> /intel/foo/\*/baz
+/intel/mock/bar(no) | not allowed characters | /intel/mock/bar_no
+/intel/mock/bar("no") | not allowed characters | /intel/mock/bar_no
+/intel/mock/bar^no | not allowed characters | /intel/mock/bar_no
+/intel/mock/bar.no | not allowed characters | /intel/mock/bar_no
+/intel/mock/bar!? | not allowed characters | /intel/mock/bar
+
+snap validates the metrics exposed by plugin and, if validation failed, return an error and not load the plugin.
+
 ### Mandatory packages
 There are three mandatory packages that every plugin must use. Other than those three packages, you can use other packages as necessary. There is no danger of colliding dependencies as plugins are separated processes. The mandatory packages are:
 ```

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -64,7 +64,20 @@ The workflow is a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) wh
 
 #### collect
 
-The collect section describes which metrics to collect.  Metrics can be enumerated explicitly via a concrete _namespace_, or a wildcard (`*`) can be used<sup>2</sup>.  The namespaces are keys to another nested object which may contain a specific version of a plugin, e.g.:
+The collect section describes which metrics to collect. Metrics can be enumerated explicitly via:
+ - a concrete _namespace_
+ - a wildcard, `*`
+ - a tuple, `(m1|m2|m3)`
+ 
+The tuple begins and ends with brackets and items inside are separeted by vertical bar. It works like logical `or`, so it gives an error only if none of these metrics can be collected.
+
+Metrics declared in task manifest | Collected metrics
+----------|----------|-----------
+/intel/mock/\* |  /intel/mock/foo <br/> /intel/mock/bar <br/> /intel/mock/\*/baz
+/intel/mock/(foo\|bar) |  /intel/mock/foo <br/> /intel/mock/bar <br/>
+/intel/mock/\*/baz |  /intel/mock/\*/baz
+
+The namespaces are keys to another nested object which may contain a specific version of a plugin, e.g.:
 
 ```yaml
 ---

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -28,12 +28,17 @@ import (
 	"github.com/intelsdi-x/snap/core/cdata"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/snap/core/serror"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 type mockCollector struct{}
 
 func (m *mockCollector) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
+	return nil, nil
+}
+
+func (m *mockCollector) ExpandWildcards([]string) ([][]string, serror.SnapError) {
 	return nil, nil
 }
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -107,6 +107,14 @@ func (m *mockMetricManager) SubscribeDeps(taskID string, mts []core.Metric, prs 
 
 func (m *mockMetricManager) UnsubscribeDeps(taskID string, mts []core.Metric, prs []core.Plugin) []serror.SnapError {
 	return nil
+}
+
+func (m *mockMetricManager) MatchQueryToNamespaces([]string) ([][]string, serror.SnapError) {
+	return nil, nil
+}
+
+func (m *mockMetricManager) ExpandWildcards([]string) ([][]string, serror.SnapError) {
+	return nil, nil
 }
 
 type mockMetricManagerError struct {

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -391,7 +391,7 @@ func (t *taskCollection) Get(id string) *task {
 }
 
 // Add given a reference to a task adds it to the collection of tasks.  An
-// error is returned if the task alredy exists in the collection.
+// error is returned if the task already exists in the collection.
 func (t *taskCollection) add(task *task) error {
 	t.Lock()
 	defer t.Unlock()

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/intelsdi-x/snap/core/control_event"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/core/scheduler_event"
+	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/pkg/promise"
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
@@ -262,6 +263,10 @@ type Mock1 struct {
 }
 
 func (m *Mock1) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
+	return nil, nil
+}
+
+func (m *Mock1) ExpandWildcards([]string) ([][]string, serror.SnapError) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Related to #676 

Summary of changes:
- adding dynamic query support (wildcard and tuple)
- adding validation of metric's namespace:
 - (part 1) not allowed characters, especially that ones which can be invalid interpreted as regexp tokens
 - (part 2) a wildcard in the end of namespace - that has been implemented yet - added after revising of all existing collector plugins; only one collector had such like metrics and was refactored. 

Testing done:
-  checking a query support for plugin with no-dynamic metrics 
-  checking a query support for plugin with dynamic metrics (if plugin accepts wildcards in this location the framework does not attempt to evaluate that)

@intelsdi-x/snap-maintainers

