### PR TITLE
Fixes #820 - Task fails when metrics come from different versions of …

### DIFF
--- a/control/config.go
+++ b/control/config.go
@@ -84,6 +84,19 @@ func GetDefaultConfig() *Config {
 	}
 }
 
+// NewPluginsConfig returns a map of *pluginConfigItems where the key is the plugin name.
+func NewPluginsConfig() map[string]*pluginConfigItem {
+	return map[string]*pluginConfigItem{}
+}
+
+// NewPluginConfigItem returns a *pluginConfigItem.
+func NewPluginConfigItem() *pluginConfigItem {
+	return &pluginConfigItem{
+		cdata.NewNode(),
+		map[int]*cdata.ConfigDataNode{},
+	}
+}
+
 func newPluginTypeConfigItem() *pluginTypeConfigItem {
 	return &pluginTypeConfigItem{
 		make(map[string]*pluginConfigItem),

--- a/control/control.go
+++ b/control/control.go
@@ -577,6 +577,8 @@ func (p *pluginControl) gatherCollectors(mts []core.Metric) ([]core.Plugin, []se
 	// types.
 	colPlugins := make(map[string]*loadedPlugin)
 	for _, mt := range mts {
+		// If the version provided is <1 we will get the latest
+		// plugin for the given metric.
 		m, err := p.metricCatalog.Get(mt.Namespace(), mt.Version())
 		if err != nil {
 			serrs = append(serrs, serror.New(err, map[string]interface{}{
@@ -585,16 +587,8 @@ func (p *pluginControl) gatherCollectors(mts []core.Metric) ([]core.Plugin, []se
 			}))
 			continue
 		}
-		// if the metric subscription is to version -1, we need to carry
-		// that forward in the subscription.
-		if mt.Version() < 1 {
-			// make a copy of the loadedPlugin and overwrite the version.
-			npl := *m.Plugin
-			npl.Meta.Version = -1
-			colPlugins[npl.Key()] = &npl
-		} else {
-			colPlugins[m.Plugin.Key()] = m.Plugin
-		}
+
+		colPlugins[m.Plugin.Key()] = m.Plugin
 	}
 	if len(serrs) > 0 {
 		return plugins, serrs


### PR DESCRIPTION
Fixes # 820

Summary of changes:
- Fixes issue where we override the plugin for a given metric

Testing done:
- Updated workflow test to cover this case
- Manual

Scenario:
* Start snap and load 2 different versions of the same plugin 
  * The lesser version should contain a metric that is not available in the new version
* Load a task that retrieves a metric that is only available in the older plugin

Snapd config which causes `/intel/mock/test` to become available:
```
---
control:
  plugins:
    collector:
      mock:
        versions:
          1:
            test: true
```

Task definition:
```
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  workflow:
    collect:
      metrics:
        /intel/mock/bar: {}
        /intel/mock/foo: {}
        /intel/mock/test: {}
      config:
        /intel/mock:
          user: "root"
          password: "secret"
```
Before:
![before](http://i.giphy.com/3osxY8j6dhmyAjzG12.gif)
After:
![after](http://i.giphy.com/3o7WTtETC5bcqVUxe8.gif)

@intelsdi-x/snap-maintainers