### PR TITLE
Fix #824: Add proper handling of subscription movement

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -368,6 +368,12 @@ func (ap *availablePlugins) collectMetrics(pluginKey string, metricTypes []core.
 	if pool == nil {
 		return nil, serror.New(ErrPoolNotFound, map[string]interface{}{"pool-key": pluginKey})
 	}
+	// If the strategy is nil but the pool exists we likely are waiting on the pool to be fully initialized
+	// because of a plugin load/unload event that is currently being processed. Prevents panic from using nil
+	// RoutingAndCaching.
+	if pool.Strategy() == nil {
+		return nil, errors.New("Plugin strategy not set")
+	}
 
 	metricsToCollect, metricsFromCache := pool.CheckCache(metricTypes, taskID)
 


### PR DESCRIPTION
Fixes #824 
Summary of changes:
Added a check in availablePlugins.collectMetrics for a nil strategy that
was causing a panic when metric subscriptions were in the process of
being moved.

Modified the handling of load/unload plugin events to properly handle
moving subscriptions between differing versions of a plugin that
provides the same metrics and added tests for this behavior in
control/control_test.go

Testing Done:
* Added test for the behavior in control/control_test.go
* Manual testing for different scenarios/orderings of load/unload
* Semi-automated testing via a script that loaded/unloaded plugins in rapid succession -- Even with rapid loading/unloading the mock plugins (which collect on interval ~1/second) had ~550 miss/fails for 10k hits. The failures happen when a collect is called while subscriptions are in the process of being moved (before this PR these failures would be instead be panics).

@intelsdi-x/snap-maintainers