### PR TITLE
Fixes #825: changes index to watch id in scheduler/watcher.go

### DIFF
--- a/scheduler/watcher.go
+++ b/scheduler/watcher.go
@@ -122,11 +122,11 @@ func (t *taskWatcherCollection) handleMetricCollected(taskID string, m []core.Me
 		return
 	}
 	// Walk all watchers for a task ID
-	for i, v := range t.coll[taskID] {
+	for _, v := range t.coll[taskID] {
 		// Check if they have a catcher assigned
 		watcherLog.WithFields(log.Fields{
 			"task-id":         taskID,
-			"task-watcher-id": i,
+			"task-watcher-id": v.id,
 		}).Debug("calling taskwatcher collection func")
 		// Call the catcher
 		v.handler.CatchCollection(m)
@@ -145,11 +145,11 @@ func (t *taskWatcherCollection) handleTaskStarted(taskID string) {
 		return
 	}
 	// Walk all watchers for a task ID
-	for i, v := range t.coll[taskID] {
+	for _, v := range t.coll[taskID] {
 		// Check if they have a catcher assigned
 		watcherLog.WithFields(log.Fields{
 			"task-id":         taskID,
-			"task-watcher-id": i,
+			"task-watcher-id": v.id,
 		}).Debug("calling taskwatcher task started func")
 		// Call the catcher
 		v.handler.CatchTaskStarted()
@@ -168,11 +168,11 @@ func (t *taskWatcherCollection) handleTaskStopped(taskID string) {
 		return
 	}
 	// Walk all watchers for a task ID
-	for i, v := range t.coll[taskID] {
+	for _, v := range t.coll[taskID] {
 		// Check if they have a catcher assigned
 		watcherLog.WithFields(log.Fields{
 			"task-id":         taskID,
-			"task-watcher-id": i,
+			"task-watcher-id": v.id,
 		}).Debug("calling taskwatcher task stopped func")
 		// Call the catcher
 		v.handler.CatchTaskStopped()
@@ -191,11 +191,11 @@ func (t *taskWatcherCollection) handleTaskDisabled(taskID string, why string) {
 		return
 	}
 	// Walk all watchers for a task ID
-	for i, v := range t.coll[taskID] {
+	for _, v := range t.coll[taskID] {
 		// Check if they have a catcher assigned
 		watcherLog.WithFields(log.Fields{
 			"task-id":         taskID,
-			"task-watcher-id": i,
+			"task-watcher-id": v.id,
 		}).Debug("calling taskwatcher task disabled func")
 		// Call the catcher
 		v.handler.CatchTaskDisabled(why)


### PR DESCRIPTION
Fixes #825 

Summary of changes:
- Changes i to v.id as specified by @geauxvirtual's issue

Testing done:
- Ran snapd and started and stopped the task being watched and saw the counter go up.
```
go run cmd/snapctl/*go task list   ✭
ID 					 NAME 						 STATE 		 HIT 	 MISS 	 FAIL 	 CREATED 		 LAST FAILURE
2bbe68b8-964d-4714-8dd2-7cd487d31fba 	 Task-2bbe68b8-964d-4714-8dd2-7cd487d31fba 	 Stopped 	 41 	 0 	 0 	 5:30PM 4-04-2016
30991581-6260-4123-a3e1-a9569f9ba11e 	 Task-30991581-6260-4123-a3e1-a9569f9ba11e 	 Stopped 	 94 	 0 	 0 	 5:27PM 4-04-2016
```
```
DEBU[0294] calling taskwatcher task stopped func         _module=scheduler-watcher task-id=30991581-6260-4123-a3e1-a9569f9ba11e task-watcher-id=2
DEBU[0501] calling taskwatcher task stopped func         _module=scheduler-watcher task-id=2bbe68b8-964d-4714-8dd2-7cd487d31fba task-watcher-id=3
DEBU[0572] calling taskwatcher task started func         _module=scheduler-watcher task-id=2bbe68b8-964d-4714-8dd2-7cd487d31fba task-watcher-id=4
```
@intelsdi-x/snap-maintainers
