### PR TITLE
Removed travis 1.4.3 and go vet imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-- 1.4.3
 - 1.5.3
 - 1.6
 before_install:
@@ -9,7 +8,6 @@ before_install:
 - go get github.com/tools/godep
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/vet
 - go get golang.org/x/tools/cmd/goimports
 - go get github.com/smartystreets/goconvey/convey
 - if [ ! -d $SNAP_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_SOURCE; fi # CI for forks not from intelsdi-x

--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -90,7 +90,6 @@ WORKDIR /go/src/github.com/intelsdi-x/snap
 ADD . /go/src/github.com/intelsdi-x/snap
 RUN go get github.com/tools/godep && \
     go get golang.org/x/tools/cmd/goimports && \
-    go get golang.org/x/tools/cmd/vet && \
     go get golang.org/x/tools/cmd/cover && \
     go get github.com/smartystreets/goconvey
 RUN scripts/deps.sh

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /go/src/github.com/intelsdi-x/snap
 ADD . /go/src/github.com/intelsdi-x/snap
 RUN go get github.com/tools/godep && \
     go get golang.org/x/tools/cmd/goimports && \
-    go get golang.org/x/tools/cmd/vet && \
     go get golang.org/x/tools/cmd/cover && \
     go get github.com/smartystreets/goconvey
 RUN scripts/deps.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,9 +21,8 @@
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. goimports     (https://github.com/bradfitz/goimports)
 # 3. golint        (https://github.com/golang/lint)
-# 4. go vet        (http://golang.org/cmd/vet)
-# 5. race detector (http://blog.golang.org/race-detector)
-# 6. test coverage (http://blog.golang.org/cover)
+# 4. race detector (http://blog.golang.org/race-detector)
+# 5. test coverage (http://blog.golang.org/cover)
 
 # If the following plugins don't exist, exit
 [ -f $SNAP_PATH/plugin/snap-collector-mock1 ] || { echo 'Error: $SNAP_PATH/plugin/snap-collector-mock1 does not exist. Run make to build it.' ; exit 1; }
@@ -41,8 +40,6 @@ echo "Getting GoConvey if not found"
 go get github.com/smartystreets/goconvey
 echo "Getting goimports if not found"
 go get golang.org/x/tools/cmd/goimports
-echo "Getting govet if not found"
-go get golang.org/x/tools/cmd/vet
 echo "Getting cover if not found"
 go get golang.org/x/tools/cmd/cover
 


### PR DESCRIPTION
Summary of changes:
-Removed 1.4.3 from travis.yml
-Removed vet imports

Testing done:
-Running in travis

Fixing:
```
0.54s$ go get golang.org/x/tools/cmd/vet
package golang.org/x/tools/cmd/vet
    imports golang.org/x/tools/cmd/vet
    imports golang.org/x/tools/cmd/vet: cannot find package "golang.org/x/tools/cmd/vet" in any of:
    /home/travis/.gimme/versions/go1.4.3.linux.amd64/src/golang.org/x/tools/cmd/vet (from $GOROOT)
    /home/travis/gopath/src/golang.org/x/tools/cmd/vet (from $GOPATH)
```
https://go-review.googlesource.com/#/c/20810/

@intelsdi-x/snap-maintainers

