### PR TITLE
Fixes #840 Add Url to HREF field for available plugin

### DIFF
--- a/mgmt/rest/plugin.go
+++ b/mgmt/rest/plugin.go
@@ -293,6 +293,7 @@ func getPlugins(mm managesMetrics, detail bool, h string, plName string, plType 
 				HitCount:         p.HitCount(),
 				LastHitTimestamp: p.LastHit().Unix(),
 				ID:               p.ID(),
+				Href:             pluginURI(h, p),
 			}
 		}
 	}
@@ -342,7 +343,7 @@ func catalogedPluginToLoaded(host string, c core.CatalogedPlugin) *rbody.LoadedP
 		Signed:          c.IsSigned(),
 		Status:          c.Status(),
 		LoadedTimestamp: c.LoadedTimestamp().Unix(),
-		Href:            catalogedPluginURI(host, c),
+		Href:            pluginURI(host, c),
 	}
 }
 
@@ -441,13 +442,13 @@ func (s *Server) getPlugin(w http.ResponseWriter, r *http.Request, p httprouter.
 			Signed:          plugin.IsSigned(),
 			Status:          plugin.Status(),
 			LoadedTimestamp: plugin.LoadedTimestamp().Unix(),
-			Href:            catalogedPluginURI(r.Host, plugin),
+			Href:            pluginURI(r.Host, plugin),
 			ConfigPolicy:    configPolicy,
 		}
 		respond(200, pluginRet, w)
 	}
 }
 
-func catalogedPluginURI(host string, c core.CatalogedPlugin) string {
+func pluginURI(host string, c core.Plugin) string {
 	return fmt.Sprintf("%s://%s/v1/plugins/%s/%s/%d", protocolPrefix, host, c.TypeName(), c.Name(), c.Version())
 }


### PR DESCRIPTION
Fixes #840

Summary of changes:
- Added url to HREF field for available plugins returned from the rest api. 

Testing done:
- manual testing 
```json
 "available_plugins": [
      {
        "name": "mock",
        "version": 2,
        "type": "collector",
        "hitcount": 12,
        "last_hit_timestamp": 1460053388,
        "id": 1,
        "href": "http://localhost:8181/v1/plugins/collector/mock/2"
      }
    ]
```
@intelsdi-x/snap-maintainers

