### PR TITLE
Fixes #833 Move plugin-config outside of tribe cmds

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -117,6 +117,21 @@ var (
 						flRunning,
 					},
 				},
+				{
+					Name: "config",
+					Subcommands: []cli.Command{
+						{
+							Name:   "get",
+							Usage:  "get <plugin_type>:<plugin_name>:<plugin_version> or get -t <plugin_type> -n <plugin_name> -v <plugin_version>",
+							Action: getConfig,
+							Flags: []cli.Flag{
+								flPluginName,
+								flPluginType,
+								flPluginVersion,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -195,22 +210,6 @@ var (
 					Name:   "members",
 					Usage:  "members <agreement_name>",
 					Action: agreementMembers,
-				},
-			},
-		},
-		{
-			Name:  "plugin-config",
-			Usage: tribeWarning,
-			Subcommands: []cli.Command{
-				{
-					Name:   "get",
-					Usage:  "get <plugin_type>:<plugin_name>:<plugin_version> or get -t <plugin_type> -n <plugin_version> -v <plugin_version>",
-					Action: getConfig,
-					Flags: []cli.Flag{
-						flPluginName,
-						flPluginType,
-						flPluginVersion,
-					},
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #833 

Summary of changes:
- Moved plugin-config command underneath the plugin command so the syntax will go from `snapctl plugin-config get ...` to `snapctl plugin config get ...`
- It will now be available outside of tribe mode. 

Testing done:
- Manual

@intelsdi-x/snap-maintainers

Move the plugin-config command in snapctl outside of tribe commands so
that it can be used when not in tribe mode. The new command will be
underneath the plugin set of commands in snapctl for consistency.