### PR TITLE
Fixes #847 - task config should take precedence

### DIFF
--- a/core/cdata/node.go
+++ b/core/cdata/node.go
@@ -140,6 +140,26 @@ func (c ConfigDataNode) Merge(n ctree.Node) ctree.Node {
 	return c
 }
 
+// Merges a ConfigDataNode with this one but does not overwrite any
+// conflicting values. Any conflicts are decided by the callers value.
+func (c *ConfigDataNode) ReverseMerge(n ctree.Node) ctree.Node {
+	cd := n.(*ConfigDataNode)
+	new_table := make(map[string]ctypes.ConfigValue)
+	// Lock here since we are modifying c.table
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	t := cd.Table()
+	t2 := c.table
+	for k, v := range t {
+		new_table[k] = v
+	}
+	for k, v := range t2 {
+		new_table[k] = v
+	}
+	c.table = new_table
+	return c
+}
+
 // Deletes a field in ConfigDataNode. If the field does not exist Delete is
 // considered a no-op
 func (c ConfigDataNode) DeleteItem(k string) {


### PR DESCRIPTION
Fixes #847

Summary of changes:
- Added ReverseMerge() to ConfigDataNode that has the opposite overwriting behavior of Merge. It will not overwrite the callers values.
- Updated places that called Merge in a context where they expected the callers value to not be overwritten to instead use ReverseMerge()

Testing done:
- manual testing with conflicting configs:
```
{
    "control" :{
        "plugins" : {
            "collector" : {
                "all" : {
                        "password" :"bogus",
                        "test" : true,
                        "user" : "really bogus"
                }
            },
            "publisher" : {
                "all" : {
                    "file" : "/tmp/whatever"
                }
            }
        }
    }
}
```

Along with running the [example task](https://github.com/intelsdi-x/snap/blob/master/examples/tasks/mock-file.json).

@intelsdi-x/snap-maintainers