### PR TITLE
Add missing license header to pkg/cfgfile/cfgfile_test.go

### DIFF
--- a/pkg/cfgfile/cfgfile_test.go
+++ b/pkg/cfgfile/cfgfile_test.go
@@ -1,3 +1,22 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cfgfile
 
 import (


### PR DESCRIPTION
Fixes: License header missing on pkg/cfgfile/cfgfile_test.go

Summary of changes:
- Add license header to pkg/cfgfile/cfgfile_test.go

Testing done:
- None; no code changes.

@intelsdi-x/snap-maintainers

