### PR TITLE
Update Travis to test with Go 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: go
 go:
 - 1.5.3
-- 1.6
+- 1.6.1
 before_install:
 - bash scripts/gitcookie.sh
 - go get github.com/tools/godep


### PR DESCRIPTION
Summary of changes:
- Update Travis to test with Go 1.6.1

@intelsdi-x/snap-maintainers

