### PR TITLE
Fixes 821: Watch not closed by server when snapd exits

### DIFF
--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -91,7 +91,8 @@ func startAPI() string {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.Start("127.0.0.1:0")
+	r.SetAddress("127.0.0.1:0")
+	r.Start()
 	time.Sleep(100 * time.Millisecond)
 	return fmt.Sprintf("http://localhost:%d", r.Port())
 }

--- a/mgmt/rest/client/client_tribe_func_test.go
+++ b/mgmt/rest/client/client_tribe_func_test.go
@@ -201,7 +201,8 @@ func startTribes(count int) []int {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.Start(":" + strconv.Itoa(mgtPort))
+		r.SetAddress(":" + strconv.Itoa(mgtPort))
+		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)
 		go func(port int) {

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -470,7 +470,8 @@ func startAPI(cfg *mockConfig) *restAPIInstance {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.Start("127.0.0.1:0")
+	r.SetAddress("127.0.0.1:0")
+	r.Start()
 	time.Sleep(time.Millisecond * 100)
 	return &restAPIInstance{
 		port:   r.Port(),

--- a/mgmt/rest/tribe_test.go
+++ b/mgmt/rest/tribe_test.go
@@ -701,7 +701,8 @@ func startTribes(count int, seed string) ([]int, int) {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.Start(":" + strconv.Itoa(mgtPort))
+		r.SetAddress(":" + strconv.Itoa(mgtPort))
+		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)
 		go func(port int) {


### PR DESCRIPTION
Fixes #821 

Summary of changes:
- Added REST to the core modules
- Made it so client receives on a killChan and when sigint is received on snapd, it closes the channel and therefore stops watch

Testing done:
- Ran existing tests
- Tested sigint/ctrl-c on snapd and it killed watch

@intelsdi-x/snap-maintainers

