### PR TITLE
Fix #864: Disable running go vet until consistent output can be achieved

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,9 +20,9 @@
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
 # 2. goimports     (https://github.com/bradfitz/goimports)
-# 3. golint        (https://github.com/golang/lint)
-# 4. go vet        (http://golang.org/cmd/vet)
-# 5. race detector (http://blog.golang.org/race-detector)
+# 3. golint        (https://github.com/golang/lint) (disabled)
+# 4. go vet        (http://golang.org/cmd/vet) (disabled)
+# 5. race detector (http://blog.golang.org/race-detector) (disabled)
 # 6. test coverage (http://blog.golang.org/cover)
 
 # If the following plugins don't exist, exit
@@ -32,7 +32,7 @@
 [ -f $SNAP_PATH/plugin/snap-publisher-file ] || { echo 'Error: $SNAP_PATH/plugin/snap-publisher-file does not exist. Run make to build it.' ; exit 1; }
 
 TEST_DIRS="cmd/ control/ core/ mgmt/ pkg/ snapd.go scheduler/"
-VET_DIRS="./cmd/... ./control/... ./core/... ./mgmt/... ./pkg/... ./scheduler/... ."
+# VET_DIRS="./cmd/... ./control/... ./core/... ./mgmt/... ./pkg/... ./scheduler/... ."
 
 set -e
 
@@ -61,8 +61,13 @@ test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
 # echo "golint"
 # golint ./...
 
-echo "go vet"
-go vet $VET_DIRS
+# Disabling running go vet currently due to the inconsistency in it's reported
+# outputs depending on whether the project was pulled down via 'go get' or 'git clone'.
+# We will look to re-enable go vet checking when we can provide consistency in outputs
+# no matter how a developer gets the project.
+#echo "go vet"
+#go vet $VET_DIRS
+
 # go test -race ./... - Lets disable for now
 
 # Run test coverage on each subdirectories and merge the coverage profile.


### PR DESCRIPTION
Fixes #864 

Summary of changes:
- Disabling `go vet` until we can consistently produce an output from the tool depending on how the project was downloaded.

Testing done:
- Verified `go vet` is no longer run

Explanation of change:
This is the second reported issue of `go vet` producing an error on a developer's machine that we never see in Travis or even on other test machines. The issue stems from how snap is downloaded and the differences when `go get` is used to using `git clone`.

When `go get` is used to download snap, the `go get` tool will first download the project into the developer's $GOPATH, walk the project and download all dependencies, then `go install` the project and all dependencies. This results in a compiled `.a` file under `$GOPATH/pkg/` for the project and dependencies (i.e $GOPATH/pkg/linux_amd64/github.com/intelsdi-x/snap/core.a).

When `git clone` is used to download a snap, a developer would clone the repo into the $GOPATH the developer is working on, then run `make` or `make deps`, which results in `godep` downloading all dependencies into the working $GOPATH. However, `godep` does not `go install` any of the dependencies or even the the snap project itself.

This is where the difference in the `go vet` tool output can be found. The `go vet` tool will only truly examine files it can see all the imports for. And to see these imports, the imports must be installed via `go install` to produce a `.a` file under $GOPATH/pkg. When these files do not exist, vet will log a message in verbose mode about not being able to load a dependency and then proceed to the next file. This is why we never see errors in Travis as `go vet` is just skipping files it can not load an import for. This is also the reason why we only see `go vet` fail when using `go get` to download the project.

For the reasons listed above, the use of `go vet` in our test script is being disabled until a more consistent output behavior can be established that will allow seeing these types of errors in Travis as part of our testing of code changes (which uses `git clone` to download the repo for testing).

@intelsdi-x/snap-maintainers
