### PR TITLE
Fixes issue where errors were not being added

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -643,7 +643,7 @@ func (p *pluginControl) SubscribeDeps(taskID string, mts []core.Metric, plugins 
 	var serrs []serror.SnapError
 	collectors, errs := p.gatherCollectors(mts)
 	if len(errs) > 0 {
-		serrs = append(serrs)
+		serrs = append(serrs, errs...)
 	}
 
 	for _, gc := range collectors {


### PR DESCRIPTION
Fixes SubscribeDeps issue I noticed while working on something unrelated.

Summary of changes:
- Modified to correctly add errors from gatherCollectors

@intelsdi-x/snap-maintainers

Fixes issue where errors were not being added correctly in
SubscribeDeps. When gatherCollectors() errored these errors were being
ignored.