### PR TITLE
Adds sending of error from getPool for all invalid keys

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -352,8 +352,8 @@ func (ap *availablePlugins) getPool(key string) (strategy.Pool, serror.SnapError
 		if v < 1 {
 			return ap.findLatestPool(tnv[0], tnv[1])
 		}
-
-		return nil, nil
+		// No key found
+		return nil, serror.New(ErrBadKey, map[string]interface{}{"key": key})
 	}
 
 	return pool, nil


### PR DESCRIPTION
Fixes #868: Adds sending of error from getPool for all invalid keys

Summary of changes-
- When getPool was called with an invalid key (i.e. "collector:bogus:1" in the case where a plugin with the name "bogus" doesn't exist), it was returning nil for the error and the pool instead of returning an error to let the caller know a pool was not found.

@intelsdi-x/snap-maintainers

