### PR TITLE
Update travis to test against latest Golang versions 1.6.2 and 1.5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-- 1.5.3
-- 1.6.1
+- 1.5.4
+- 1.6.2
 before_install:
 - bash scripts/gitcookie.sh
 - go get github.com/tools/godep


### PR DESCRIPTION
Summary of changes:
- Updates Travis to use Golang 1.6.2 and 1.5.4 in it's testing matrix.

Testing done:
- Verified snap builds and runs running Golang 1.6.2. The changes in Golang 1.5.4 were the same security fixes included with Go 1.6.1 that we have been testing with.

@intelsdi-x/snap-maintainers

