### PR TITLE
Fixes #874 (snap panics on empty config sections)

### DIFF
--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -179,6 +180,84 @@ func GetDefaultConfig() *Config {
 		RestAuth:         defaultAuth,
 		RestAuthPassword: defaultAuthPassword,
 	}
+}
+
+// construct a new rest Config from a hash map
+func NewConfig(configMap map[string]interface{}) (*Config, error) {
+	c := GetDefaultConfig()
+	// set the Enable value (if it was included in the input hash map)
+	if v, ok := configMap["enable"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			boolVal, err := strconv.ParseBool(str)
+			if err != nil {
+				return nil, err
+			}
+			c.Enable = boolVal
+		} else {
+			return nil, fmt.Errorf("Error parsing 'enable' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the Port value (if it was included in the input hash map)
+	if v, ok := configMap["port"]; ok && v != nil {
+		if val, ok := v.(json.Number); ok {
+			tmpVal, err := val.Int64()
+			if err != nil {
+				return nil, err
+			}
+			c.Port = int(tmpVal)
+		} else {
+			return nil, fmt.Errorf("Error parsing 'port' from config; expected 'json.Number' but found '%T'", v)
+		}
+	}
+	// set the HTTPS value (if it was included in the input hash map)
+	if v, ok := configMap["https"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			boolVal, err := strconv.ParseBool(str)
+			if err != nil {
+				return nil, err
+			}
+			c.HTTPS = boolVal
+		} else {
+			return nil, fmt.Errorf("Error parsing 'https' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the RestCertificate value (if it was included in the input hash map)
+	if v, ok := configMap["rest_certificate"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.RestCertificate = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'rest_certificate' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the RestKey value (if it was included in the input hash map)
+	if v, ok := configMap["rest_key"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.RestKey = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'rest_key' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the RestAuth value (if it was included in the input hash map)
+	if v, ok := configMap["rest_auth"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			boolVal, err := strconv.ParseBool(str)
+			if err != nil {
+				return nil, err
+			}
+			c.RestAuth = boolVal
+		} else {
+			return nil, fmt.Errorf("Error parsing 'rest_auth' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the RestAuthPassword value (if it was included in the input hash map)
+	if v, ok := configMap["rest_auth_password"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.RestAuthPassword = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'rest_auth_password' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	return c, nil
 }
 
 // SetAPIAuth sets API authentication to enabled or disabled

--- a/mgmt/tribe/config.go
+++ b/mgmt/tribe/config.go
@@ -20,8 +20,11 @@ limitations under the License.
 package tribe
 
 import (
+	"encoding/json"
+	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/memberlist"
@@ -71,6 +74,60 @@ func GetDefaultConfig() *Config {
 		RestAPIPort:               defaultRestAPIPort,
 		RestAPIInsecureSkipVerify: defaultRestAPIInsecureSkipVerify,
 	}
+}
+
+// construct a new tribe Config from a hash map
+func NewConfig(configMap map[string]interface{}) (*Config, error) {
+	c := GetDefaultConfig()
+	// set the Name value (if it was included in the input hash map)
+	if v, ok := configMap["name"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.Name = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'name' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the Enable value (if it was included in the input hash map)
+	if v, ok := configMap["enable"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			boolVal, err := strconv.ParseBool(str)
+			if err != nil {
+				return nil, err
+			}
+			c.Enable = boolVal
+		} else {
+			return nil, fmt.Errorf("Error parsing 'enable' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the BindAddr value (if it was included in the input hash map)
+	if v, ok := configMap["bind_addr"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.BindAddr = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'bind_addr' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	// set the BindPort value (if it was included in the input hash map)
+	if v, ok := configMap["bind_port"]; ok && v != nil {
+		if val, ok := v.(json.Number); ok {
+			tmpVal, err := val.Int64()
+			if err != nil {
+				return nil, err
+			}
+			c.BindPort = int(tmpVal)
+		} else {
+			return nil, fmt.Errorf("Error parsing 'bind_port' from config; expected 'json.Number' but found '%T'", v)
+		}
+	}
+	// set the Seed value (if it was included in the input hash map)
+	if v, ok := configMap["seed"]; ok && v != nil {
+		if str, ok := v.(string); ok {
+			c.Seed = str
+		} else {
+			return nil, fmt.Errorf("Error parsing 'seed' from config; expected 'string' but found '%T'", v)
+		}
+	}
+	return c, nil
 }
 
 func getHostname() string {

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -19,6 +19,11 @@ limitations under the License.
 
 package scheduler
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // default configuration values
 const (
 	defaultWorkManagerQueueSize uint = 25
@@ -37,4 +42,34 @@ func GetDefaultConfig() *Config {
 		WorkManagerQueueSize: defaultWorkManagerQueueSize,
 		WorkManagerPoolSize:  defaultWorkManagerPoolSize,
 	}
+}
+
+// construct a new scheduler Config from a hash map
+func NewConfig(configMap map[string]interface{}) (*Config, error) {
+	c := GetDefaultConfig()
+	// set the WorkManagerQueueSize value (if it was included in the input hash map)
+	if v, ok := configMap["work_manager_queue_size"]; ok && v != nil {
+		if val, ok := v.(json.Number); ok {
+			tmpVal, err := val.Int64()
+			if err != nil {
+				return nil, err
+			}
+			c.WorkManagerQueueSize = uint(tmpVal)
+		} else {
+			return nil, fmt.Errorf("Error parsing 'work_manager_queue_size' from config; expected 'json.Number' but found '%T'", v)
+		}
+	}
+	// set the WorkManagerPoolSize value (if it was included in the input hash map)
+	if v, ok := configMap["work_manager_pool_size"]; ok && v != nil {
+		if val, ok := v.(json.Number); ok {
+			tmpVal, err := val.Int64()
+			if err != nil {
+				return nil, err
+			}
+			c.WorkManagerPoolSize = uint(tmpVal)
+		} else {
+			return nil, fmt.Errorf("Error parsing 'work_manager_pool_size' from config; expected 'json.Number' but found '%T'", v)
+		}
+	}
+	return c, nil
 }

--- a/snapd.go
+++ b/snapd.go
@@ -210,6 +210,11 @@ func main() {
 
 func action(ctx *cli.Context) {
 	// get default configuration
+	defCfg := getDefaultConfig()
+
+	// and create a second copy of that configuration for use when
+	// merging with the configuration read from the configuration
+	// file
 	cfg := getDefaultConfig()
 
 	// read config file
@@ -219,7 +224,7 @@ func action(ctx *cli.Context) {
 	// to the configuration that we have built so far, overriding the
 	// values that may have already been set (if any) for the
 	// same variables in that configuration
-	applyCmdLineFlags(cfg, ctx)
+	applyCmdLineFlags(defCfg, cfg, ctx)
 
 	// If logPath is set, we verify the logPath and set it so that all logging
 	// goes to the log file instead of stdout.
@@ -604,7 +609,7 @@ func setDurationVal(field time.Duration, ctx *cli.Context, flagName string) time
 
 // Apply the command line flags set (if any) to override the values
 // in the input configuration
-func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
+func applyCmdLineFlags(defCfg *Config, cfg *Config, ctx *cli.Context) {
 	invertBoolean := true
 	// apply any command line flags that might have been set, first for the
 	// snapd-related flags
@@ -612,12 +617,18 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	cfg.LogLevel = setIntVal(cfg.LogLevel, ctx, "log-level")
 	cfg.LogPath = setStringVal(cfg.LogPath, ctx, "log-path")
 	// next for the flags related to the control package
+	if cfg.Control == nil {
+		cfg.Control = defCfg.Control
+	}
 	cfg.Control.MaxRunningPlugins = setIntVal(cfg.Control.MaxRunningPlugins, ctx, "max-running-plugins")
 	cfg.Control.PluginTrust = setIntVal(cfg.Control.PluginTrust, ctx, "plugin-trust")
 	cfg.Control.AutoDiscoverPath = setStringVal(cfg.Control.AutoDiscoverPath, ctx, "auto-discover")
 	cfg.Control.KeyringPaths = setStringVal(cfg.Control.KeyringPaths, ctx, "keyring-paths")
 	cfg.Control.CacheExpiration = jsonutil.Duration{setDurationVal(cfg.Control.CacheExpiration.Duration, ctx, "cache-expiration")}
 	// next for the RESTful server related flags
+	if cfg.RestAPI == nil {
+		cfg.RestAPI = defCfg.RestAPI
+	}
 	cfg.RestAPI.Enable = setBoolVal(cfg.RestAPI.Enable, ctx, "disable-api", invertBoolean)
 	cfg.RestAPI.Port = setIntVal(cfg.RestAPI.Port, ctx, "api-port")
 	cfg.RestAPI.HTTPS = setBoolVal(cfg.RestAPI.HTTPS, ctx, "rest-https")
@@ -626,9 +637,15 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	cfg.RestAPI.RestAuth = setBoolVal(cfg.RestAPI.RestAuth, ctx, "rest-auth")
 	cfg.RestAPI.RestAuthPassword = setStringVal(cfg.RestAPI.RestAuthPassword, ctx, "rest-auth-pwd")
 	// next for the scheduler related flags
+	if cfg.Scheduler == nil {
+		cfg.Scheduler = defCfg.Scheduler
+	}
 	cfg.Scheduler.WorkManagerQueueSize = setUIntVal(cfg.Scheduler.WorkManagerQueueSize, ctx, "work-manager-queue-size")
 	cfg.Scheduler.WorkManagerPoolSize = setUIntVal(cfg.Scheduler.WorkManagerPoolSize, ctx, "work-manager-pool-size")
 	// and finally for the tribe-related flags
+	if cfg.Tribe == nil {
+		cfg.Tribe = defCfg.Tribe
+	}
 	cfg.Tribe.Name = setStringVal(cfg.Tribe.Name, ctx, "tribe-node-name")
 	cfg.Tribe.Enable = setBoolVal(cfg.Tribe.Enable, ctx, "tribe")
 	cfg.Tribe.BindAddr = setStringVal(cfg.Tribe.BindAddr, ctx, "tribe-addr")


### PR DESCRIPTION
Fixes #874 

Summary of changes:
- Added code to the `action()` and `applyCmdLineFlags()` methods of the `snapd.go` file that saves a copy of the default configuration and then reapplies the appropriate section of that default configuration in those cases where any of the (top-level) sections of the configuration read from the configuration file map to a `nil` value (in that situation, the original, default configuration for that section will have been overwritten by the `nil` value read from the configuration file)

Testing done:
- Started `snapd` with the `go run snapd.go --config ~/eg-snap-config.yaml` command, where the `~/eg-snap-config.yaml` configuration file that looks like this:
```yaml
---
# log_level for the snap daemon. Supported values are
# 1 - Debug, 2 - Info, 3 - Warning, 4 - Error, 5 - Fatal.
# Default value is 3.
log_level: 2

# log_path sets the path for logs for the snap daemon. By
# default snapd prints all logs to stdout. Any provided
# path will send snapd logs to a file called snapd.log in
# the provided directory.
#log_path: /some/log/dir

# Gomaxprocs sets the number of cores to use on the system
# for snapd to use. Default for gomaxprocs is 1
gomaxprocs: 2

# Control sections for configuration settings for the plugin
# control module of snapd.
control:
  # auto_discover_path sets a directory to auto load plugins on the start
  # of the snap daemon
  #auto_discover_path: /some/directory/with/plugins

  # cache_expiration sets the time interval for the plugin cache to use before
  # expiring collection results from collect plugins. Default value is 500ms
  cache_expiration: 750ms

  # max_running_plugins sets the size of the available plugin pool for each
  # plugin loaded in the system. Default value is 3
  max_running_plugins: 1

  # keyring_paths sets the directory(s) to search for keyring files for signed
  # plugins. This can be a comma separated list of directories
  keyring_paths: /some/path/with/keyring/files

  # plugin_trust_level sets the plugin trust level for snapd. The default state
  # for plugin trust level is enabled (1). When enabled, only signed plugins that can
  # be verified will be loaded into snapd. Signatures are verifed from
  # keyring files specided in keyring_path. Plugin trust can be disabled (0) which
  # will allow loading of all plugins whether signed or not. The warning state allows
  # for loading of signed and unsigned plugins. Warning messages will be displayed if
  # an unsigned plugin is loaded. Any signed plugins that can not be verified will
  # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
  plugin_trust_level: 0

  # plugins section contains plugin config settings that will be applied for
  # plugins across tasks.
  plugins:
    all:
      password: p@ssw0rd
    collector:
      all:
        user: jane
      pcm:
        all:
          path: /usr/local/pcm/bin
        versions:
          1:
            user: john
            someint: 1234
            somefloat: 3.14
            somebool: true
      psutil:
        all:
          path: /usr/local/bin/psutil
    publisher:
      influxdb:
        all:
          server: xyz.local
          password: $password
    processor:
      movingaverage:
        all:
          user: jane
        versions:
          1:
            user: tiffany
            password: new password

# scheduler configuration settings contains all settings for scheduler
# module
scheduler:
  # work_manager_queue_size sets the size of the worker queue inside snapd scheduler.
  # Default value is 25.
  #work_manager_queue_size: 10

  # work_manager_pool_size sets the size of the worker pool inside snapd scheduler.
  # Default value is 4.
  #work_manager_pool_size: 2

# rest sections contains all the configuration items for the REST API server.
restapi:
  # enable controls enabling or disabling the REST API for snapd. Default value is enabled.
  enable: true

  # https enables HTTPS for the REST API. If no default certificate and key are provided, then
  # the REST API will generate a private and public key to use for communication. Default
  # value is false
  #https: true

  # rest_auth enables authentication for the REST API. Default value is false
  #rest_auth: true

  # rest_auth_password sets the password to use for the REST API. Currently user and password
  # combinations are not supported.
  #rest_auth_password: changeme

  # rest_certificate is the path to the certificate to use for REST API when HTTPS is also enabled.
  #rest_certificate: /path/to/cert/file

  # rest_key is the path to the private key for the certificate in use by the REST API
  # when HTTPs is enabled.
  #rest_key: /path/to/private/key

  # port sets the port to start the REST API server on. Default is 8181
  port: 8282

# tribe section contains all configuration items for the tribe module
tribe:
  # enable controls enabling tribe for the snapd instance. Default value is false.
  #enable: false

  # bind_addr sets the IP address for tribe to bind.
  #bind_addr: 127.0.0.1

  # bind_port sets the port for tribe to listen on. Default value is 6000
  #bind_port: 16000

  # name sets the name to use for this snapd instance in the tribe
  # membership. Default value defaults to local hostname of the system.
  #name: localhost

  # seed sets the snapd instance to use as the seed for tribe communications
  #seed: 1.1.1.1:16000
```
(note that the `scheduler` and `tribe` sections of this YAML file are both completely commented out). There was no panic thrown when this configuration file was used with the changes in this PR applied.

@intelsdi-x/snap-maintainers