### PR TITLE
Fixes #874 (snap panics on empty config sections; take 2)

### DIFF
--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -67,6 +67,9 @@ var (
 )
 
 // holds the configuration passed in through the SNAP config file
+//   Note: if this struct is modified, then the switch statement in the
+//         UnmarshalJSON method in this same file needs to be modified to
+//         match the field mapping that is defined here
 type Config struct {
 	Enable           bool   `json:"enable,omitempty"yaml:"enable,omitempty"`
 	Port             int    `json:"port,omitempty"yaml:"port,omitempty"`
@@ -179,6 +182,53 @@ func GetDefaultConfig() *Config {
 		RestAuth:         defaultAuth,
 		RestAuthPassword: defaultAuthPassword,
 	}
+}
+
+// UnmarshalJSON unmarshals valid json into a Config.  An example Config can be found
+// at github.com/intelsdi-x/snap/blob/master/examples/configs/snap-config-sample.json
+func (c *Config) UnmarshalJSON(data []byte) error {
+	// construct a map of strings to json.RawMessages (to defer the parsing of individual
+	// fields from the unmarshalled interface until later) and unmarshal the input
+	// byte array into that map
+	t := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(data, &t); err != nil {
+		return err
+	}
+	// loop through the individual map elements, parse each in turn, and set
+	// the appropriate field in this configuration
+	for k, v := range t {
+		switch k {
+		case "enable":
+			if err := json.Unmarshal(v, &(c.Enable)); err != nil {
+				return err
+			}
+		case "port":
+			if err := json.Unmarshal(v, &(c.Port)); err != nil {
+				return err
+			}
+		case "https":
+			if err := json.Unmarshal(v, &(c.HTTPS)); err != nil {
+				return err
+			}
+		case "rest_certificate":
+			if err := json.Unmarshal(v, &(c.RestCertificate)); err != nil {
+				return err
+			}
+		case "rest_key":
+			if err := json.Unmarshal(v, &(c.RestKey)); err != nil {
+				return err
+			}
+		case "rest_auth":
+			if err := json.Unmarshal(v, &(c.RestAuth)); err != nil {
+				return err
+			}
+		case "rest_auth_password":
+			if err := json.Unmarshal(v, &(c.RestAuthPassword)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // SetAPIAuth sets API authentication to enabled or disabled


### PR DESCRIPTION
Fixes #

Summary of changes:
- Added an `UnmarshalJSON` method to the `snapd.go` file to handle parsing of JSON/YAML global configuration files where sections of the file are left blank (i.e. the value associated with a particular key from the JSON/YAML file is `nil`)
- Added `UnmarshalJSON` methods to the code that manages the configuration for the `control`, `rest`, `tribe`, and `scheduler` packages; code was added to these new `UnmarshalJSON` methods to handle those situations where parts of those sections are set to `nil` values
- Added code to the new `UnmarshalJSON` method in the `snapd.go` file that calls the new `UnmarshalJSON` methods in the `control`, `rest`, `tribe`, and `scheduler` packages to parse those sections of the global configuration file

With these changes in place, I was able to successfully start `snapd` with a configuration file that included blank/empty sections (see testing, below) and avoid the panic that is seen with those sorts of (valid) global configuration files without these changes.

Testing done:
- Started snapd with the `go run snapd.go --config ./eg-snap-config.yaml` command, where the `./eg-snap-config.yaml` configuration file that looks like this:

```yaml
---
# log_level for the snap daemon. Supported values are
# 1 - Debug, 2 - Info, 3 - Warning, 4 - Error, 5 - Fatal.
# Default value is 3.
log_level: 1

# log_path sets the path for logs for the snap daemon. By
# default snapd prints all logs to stdout. Any provided
# path will send snapd logs to a file called snapd.log in
# the provided directory.
# log_path: /some/log/dir

# Gomaxprocs sets the number of cores to use on the system
# for snapd to use. Default for gomaxprocs is 1
gomaxprocs: 2

# Control sections for configuration settings for the plugin
# control module of snapd.
control:
  # auto_discover_path sets a directory to auto load plugins on the start
  # of the snap daemon
  # auto_discover_path: /some/directory/with/plugins

  # cache_expiration sets the time interval for the plugin cache to use before
  # expiring collection results from collect plugins. Default value is 500ms
  cache_expiration: 750ms

  # max_running_plugins sets the size of the available plugin pool for each
  # plugin loaded in the system. Default value is 3
  # max_running_plugins: 1

  # keyring_paths sets the directory(s) to search for keyring files for signed
  # plugins. This can be a comma separated list of directories
  # keyring_paths: /some/path/with/keyring/files

  # plugin_trust_level sets the plugin trust level for snapd. The default state
  # for plugin trust level is enabled (1). When enabled, only signed plugins that can
  # be verified will be loaded into snapd. Signatures are verifed from
  # keyring files specided in keyring_path. Plugin trust can be disabled (0) which
  # will allow loading of all plugins whether signed or not. The warning state allows
  # for loading of signed and unsigned plugins. Warning messages will be displayed if
  # an unsigned plugin is loaded. Any signed plugins that can not be verified will
  # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
  plugin_trust_level: 0

  # plugins section contains plugin config settings that will be applied for
  # plugins across tasks.
  plugins:
    all:
      password: p@ssw0rd
    collector:
      all:
        user: jane
      pcm:
        all:
          path: /usr/local/pcm/bin
        versions:
          1:
            user: john
            someint: 1234
            somefloat: 3.14
            somebool: true
      psutil:
        all:
          path: /usr/local/bin/psutil
    publisher:
      influxdb:
        all:
          server: xyz.local
          password: $password
    processor:
      movingaverage:
        all:
          user: jane
        versions:
          1:
            user: tiffany
            password: new password

# scheduler configuration settings contains all settings for scheduler
# module
scheduler:
  # work_manager_queue_size sets the size of the worker queue inside snapd scheduler.
  # Default value is 25.
  # work_manager_queue_size: 10

  # work_manager_pool_size sets the size of the worker pool inside snapd scheduler.
  # Default value is 4.
  # work_manager_pool_size: 2

# rest sections contains all the configuration items for the REST API server.
restapi:
  # enable controls enabling or disabling the REST API for snapd. Default value is enabled.
  enable: true

  # https enables HTTPS for the REST API. If no default certificate and key are provided, then
  # the REST API will generate a private and public key to use for communication. Default
  # value is false
  # https: true

  # rest_auth enables authentication for the REST API. Default value is false
  # rest_auth: true

  # rest_auth_password sets the password to use for the REST API. Currently user and password
  # combinations are not supported.
  # rest_auth_password: changeme

  # rest_certificate is the path to the certificate to use for REST API when HTTPS is also enabled.
  # rest_certificate: /path/to/cert/file

  # rest_key is the path to the private key for the certificate in use by the REST API
  # when HTTPs is enabled.
  # rest_key: /path/to/private/key

  # port sets the port to start the REST API server on. Default is 8181
  port: 8282

# tribe section contains all configuration items for the tribe module
tribe:
  # enable controls enabling tribe for the snapd instance. Default value is false.
  enable: false

  # bind_addr sets the IP address for tribe to bind.
  # bind_addr: 127.0.0.1

  # bind_port sets the port for tribe to listen on. Default value is 6000
  # bind_port: 16000

  # name sets the name to use for this snapd instance in the tribe
  # membership. Default value defaults to local hostname of the system.
  # name: localhost

  # seed sets the snapd instance to use as the seed for tribe communications
  # seed: 1.1.1.1:16000
```

(note the empty `tribe` and `scheduler` sections); the snapd process started without error.

@intelsdi-x/snap-maintainers