### PR TITLE
Variadic arguments in core.NewNamespace

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -724,13 +724,13 @@ func TestExportedMetricCatalog(t *testing.T) {
 	Convey(".MetricCatalog()", t, func() {
 		c := New(GetDefaultConfig())
 		lp := &loadedPlugin{}
-		mt := newMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), lp)
+		mt := newMetricType(core.NewNamespace("foo", "bar"), time.Now(), lp)
 		c.metricCatalog.Add(mt)
 		Convey("it returns a collection of core.MetricTypes", func() {
 			t, err := c.MetricCatalog()
 			So(err, ShouldBeNil)
 			So(len(t), ShouldEqual, 1)
-			So(t[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"foo", "bar"}))
+			So(t[0].Namespace(), ShouldResemble, core.NewNamespace("foo", "bar"))
 		})
 		Convey("If metric catalog fetch fails", func() {
 			c.metricCatalog = &mc{e: 2}
@@ -745,7 +745,7 @@ func TestMetricExists(t *testing.T) {
 	Convey("MetricExists()", t, func() {
 		c := New(GetDefaultConfig())
 		c.metricCatalog = &mc{}
-		So(c.MetricExists(core.NewNamespace([]string{"hi"}), -1), ShouldEqual, false)
+		So(c.MetricExists(core.NewNamespace("hi"), -1), ShouldEqual, false)
 	})
 }
 
@@ -810,7 +810,7 @@ func TestMetricConfig(t *testing.T) {
 		<-lpe.done
 		cd := cdata.NewNode()
 		m1 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 		}
 
 		Convey("So metric should not be valid without config", func() {
@@ -826,7 +826,7 @@ func TestMetricConfig(t *testing.T) {
 
 		Convey("So metric should not be valid if does not occur in the catalog", func() {
 			m := MockMetricType{
-				namespace: core.NewNamespace([]string{"intel", "mock", "bad"}),
+				namespace: core.NewNamespace("intel", "mock", "bad"),
 			}
 			errs := c.validateMetricTypeSubscription(m, cd)
 			So(errs, ShouldNotBeNil)
@@ -849,7 +849,7 @@ func TestMetricConfig(t *testing.T) {
 		<-lpe.done
 		var cd *cdata.ConfigDataNode
 		m1 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 		}
 
 		Convey("So metric should be valid with config", func() {
@@ -871,7 +871,7 @@ func TestMetricConfig(t *testing.T) {
 		<-lpe.done
 		cd := cdata.NewNode()
 		m1 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 			ver:       1,
 		}
 		errs := c.validateMetricTypeSubscription(m1, cd)
@@ -897,7 +897,7 @@ func TestRoutingCachingStrategy(t *testing.T) {
 			t.FailNow()
 		}
 		metric := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 			ver:       2,
 			cfg:       cdata.NewNode(),
 		}
@@ -957,7 +957,7 @@ func TestRoutingCachingStrategy(t *testing.T) {
 		if e != nil {
 			t.FailNow()
 		}
-		metric, err := c.metricCatalog.Get(core.NewNamespace([]string{"intel", "mock", "foo"}), 1)
+		metric, err := c.metricCatalog.Get(core.NewNamespace("intel", "mock", "foo"), 1)
 		metric.config = cdata.NewNode()
 		So(err, ShouldBeNil)
 		So(metric.Namespace().String(), ShouldResemble, "/intel/mock/foo")
@@ -1040,15 +1040,15 @@ func TestCollectDynamicMetrics(t *testing.T) {
 		}
 		<-lpe.done
 		cd := cdata.NewNode()
-		metrics, err := c.metricCatalog.Fetch(core.NewNamespace([]string{}))
+		metrics, err := c.metricCatalog.Fetch(core.NewNamespace())
 		So(err, ShouldBeNil)
 		So(len(metrics), ShouldEqual, 6)
 
-		m, err := c.metricCatalog.Get(core.NewNamespace([]string{"intel", "mock", "*", "baz"}), 2)
+		m, err := c.metricCatalog.Get(core.NewNamespace("intel", "mock", "*", "baz"), 2)
 		So(err, ShouldBeNil)
 		So(m, ShouldNotBeNil)
 
-		jsonm, err := c.metricCatalog.Get(core.NewNamespace([]string{"intel", "mock", "*", "baz"}), 1)
+		jsonm, err := c.metricCatalog.Get(core.NewNamespace("intel", "mock", "*", "baz"), 1)
 		So(err, ShouldBeNil)
 		So(jsonm, ShouldNotBeNil)
 
@@ -1170,7 +1170,7 @@ func TestFailedPlugin(t *testing.T) {
 		cfg.AddItem("panic", ctypes.ConfigValueBool{Value: true})
 		m := []core.Metric{
 			MockMetricType{
-				namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+				namespace: core.NewNamespace("intel", "mock", "foo"),
 				cfg:       cfg,
 			},
 		}
@@ -1249,15 +1249,15 @@ func TestCollectMetrics(t *testing.T) {
 
 		m := []core.Metric{}
 		m1 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 			cfg:       cd,
 		}
 		m2 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "bar"}),
+			namespace: core.NewNamespace("intel", "mock", "bar"),
 			cfg:       cd,
 		}
 		m3 := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "test"}),
+			namespace: core.NewNamespace("intel", "mock", "test"),
 			cfg:       cd,
 		}
 
@@ -1341,34 +1341,34 @@ func TestExpandWildcards(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(len(mts), ShouldEqual, 4)
 		Convey("expand metric with an asterisk", func() {
-			ns := core.NewNamespace([]string{"intel", "mock", "*"})
+			ns := core.NewNamespace("intel", "mock", "*")
 			c.MatchQueryToNamespaces(ns)
 			nss, err := c.ExpandWildcards(ns)
 			So(err, ShouldBeNil)
 			// "intel/mock/*" should be expanded to all available mock metrics
 			So(len(nss), ShouldEqual, len(mts))
 			So(nss, ShouldResemble, []core.Namespace{
-				core.NewNamespace([]string{"intel", "mock", "test"}),
-				core.NewNamespace([]string{"intel", "mock", "foo"}),
-				core.NewNamespace([]string{"intel", "mock", "bar"}),
-				core.NewNamespace([]string{"intel", "mock", "*", "baz"}),
+				core.NewNamespace("intel", "mock", "test"),
+				core.NewNamespace("intel", "mock", "foo"),
+				core.NewNamespace("intel", "mock", "bar"),
+				core.NewNamespace("intel", "mock", "*", "baz"),
 			})
 		})
 		Convey("expand metric with a tuple", func() {
-			ns := core.NewNamespace([]string{"intel", "mock", "(test|foo|bad)"})
+			ns := core.NewNamespace("intel", "mock", "(test|foo|bad)")
 			c.MatchQueryToNamespaces(ns)
 			nss, err := c.ExpandWildcards(ns)
 			So(err, ShouldBeNil)
 			// '/intel/mock/bad' does not exist in metric catalog and shouldn't be returned
 			So(len(nss), ShouldEqual, 2)
 			So(nss, ShouldResemble, []core.Namespace{
-				core.NewNamespace([]string{"intel", "mock", "test"}),
-				core.NewNamespace([]string{"intel", "mock", "foo"}),
+				core.NewNamespace("intel", "mock", "test"),
+				core.NewNamespace("intel", "mock", "foo"),
 			})
 		})
 		Convey("expanding for dynamic metrics", func() {
 			// if asterisk is acceptable by plugin in this location, leave that
-			ns := core.NewNamespace([]string{"intel", "mock", "*", "baz"})
+			ns := core.NewNamespace("intel", "mock", "*", "baz")
 			c.MatchQueryToNamespaces(ns)
 			nss, err := c.ExpandWildcards(ns)
 			So(err, ShouldBeNil)
@@ -1377,7 +1377,7 @@ func TestExpandWildcards(t *testing.T) {
 		})
 		Convey("expanding for invalid metric name", func() {
 			// if asterisk is acceptable by plugin in this location, leave that
-			ns := core.NewNamespace([]string{"intel", "mock", "invalid", "metric"})
+			ns := core.NewNamespace("intel", "mock", "invalid", "metric")
 			c.MatchQueryToNamespaces(ns)
 			nss, err := c.ExpandWildcards(ns)
 			So(err, ShouldNotBeNil)
@@ -1413,7 +1413,7 @@ func TestGatherCollectors(t *testing.T) {
 		<-lpe.done
 
 		mts, err := c.MetricCatalog()
-		ns := core.NewNamespace([]string{"intel", "mock", "foo"})
+		ns := core.NewNamespace("intel", "mock", "foo")
 		So(err, ShouldBeNil)
 		So(len(mts), ShouldEqual, 4)
 		Convey("it gathers the latest version", func() {
@@ -1518,7 +1518,7 @@ func TestPublishMetrics(t *testing.T) {
 
 			Convey("Publish to file", func() {
 				metrics := []plugin.MetricType{
-					*plugin.NewMetricType(core.NewNamespace([]string{"foo"}), time.Now(), nil, "", 1),
+					*plugin.NewMetricType(core.NewNamespace("foo"), time.Now(), nil, "", 1),
 				}
 				var buf bytes.Buffer
 				enc := gob.NewEncoder(&buf)
@@ -1571,7 +1571,7 @@ func TestProcessMetrics(t *testing.T) {
 
 			Convey("process metrics", func() {
 				metrics := []plugin.MetricType{
-					*plugin.NewMetricType(core.NewNamespace([]string{"foo"}), time.Now(), nil, "", 1),
+					*plugin.NewMetricType(core.NewNamespace("foo"), time.Now(), nil, "", 1),
 				}
 				var buf bytes.Buffer
 				enc := gob.NewEncoder(&buf)
@@ -1638,7 +1638,7 @@ func TestMetricSubscriptionToNewVersion(t *testing.T) {
 		So(lp.Name(), ShouldResemble, "mock")
 		//Subscribe deps to create pools.
 		metric := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 			cfg:       cdata.NewNode(),
 			ver:       0,
 		}
@@ -1700,7 +1700,7 @@ func TestMetricSubscriptionToOlderVersion(t *testing.T) {
 		So(lp.Name(), ShouldResemble, "mock")
 		//Subscribe deps to create pools.
 		metric := MockMetricType{
-			namespace: core.NewNamespace([]string{"intel", "mock", "foo"}),
+			namespace: core.NewNamespace("intel", "mock", "foo"),
 			cfg:       cdata.NewNode(),
 			ver:       0,
 		}

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -570,7 +570,7 @@ func (mc *metricCatalog) getVersions(ns []string) ([]*metricType, error) {
 }
 
 func getMetricNamespace(key string) core.Namespace {
-	return core.NewNamespace(strings.Split(key, "."))
+	return core.NewNamespace(strings.Split(key, ".")...)
 }
 
 func getLatest(c []*metricType) *metricType {

--- a/control/metrics_test.go
+++ b/control/metrics_test.go
@@ -32,13 +32,13 @@ import (
 func TestMetricType(t *testing.T) {
 	Convey("newMetricType()", t, func() {
 		Convey("returns a metricType", func() {
-			mt := newMetricType(core.NewNamespace([]string{"test"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("test"), time.Now(), new(loadedPlugin))
 			So(mt, ShouldHaveSameTypeAs, new(metricType))
 		})
 	})
 	Convey("metricType.Namespace()", t, func() {
 		Convey("returns the namespace of a metricType", func() {
-			ns := core.NewNamespace([]string{"test"})
+			ns := core.NewNamespace("test")
 			mt := newMetricType(ns, time.Now(), new(loadedPlugin))
 			So(mt.Namespace(), ShouldHaveSameTypeAs, ns)
 			So(mt.Namespace(), ShouldResemble, ns)
@@ -46,7 +46,7 @@ func TestMetricType(t *testing.T) {
 	})
 	Convey("metricType.Version()", t, func() {
 		Convey("returns the namespace of a metricType", func() {
-			ns := core.NewNamespace([]string{"test"})
+			ns := core.NewNamespace("test")
 			lp := &loadedPlugin{Meta: plugin.PluginMeta{Version: 1}}
 			mt := newMetricType(ns, time.Now(), lp)
 			So(mt.Version(), ShouldEqual, 1)
@@ -55,7 +55,7 @@ func TestMetricType(t *testing.T) {
 	Convey("metricType.LastAdvertisedTimestamp()", t, func() {
 		Convey("returns the LastAdvertisedTimestamp for the metricType", func() {
 			ts := time.Now()
-			mt := newMetricType(core.NewNamespace([]string{"test"}), ts, new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("test"), ts, new(loadedPlugin))
 			So(mt.LastAdvertisedTime(), ShouldHaveSameTypeAs, ts)
 			So(mt.LastAdvertisedTime(), ShouldResemble, ts)
 		})
@@ -64,7 +64,7 @@ func TestMetricType(t *testing.T) {
 		Convey("returns the key for the metricType", func() {
 			ts := time.Now()
 			lp := new(loadedPlugin)
-			mt := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp)
+			mt := newMetricType(core.NewNamespace("foo", "bar"), ts, lp)
 			key := mt.Key()
 			So(key, ShouldEqual, "/foo/bar/0")
 		})
@@ -72,7 +72,7 @@ func TestMetricType(t *testing.T) {
 			ts := time.Now()
 			lp2 := new(loadedPlugin)
 			lp2.Meta.Version = 2
-			mt := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp2)
+			mt := newMetricType(core.NewNamespace("foo", "bar"), ts, lp2)
 			key := mt.Key()
 			So(key, ShouldEqual, "/foo/bar/2")
 		})
@@ -84,14 +84,14 @@ func TestMetricMatching(t *testing.T) {
 		Convey("verify query support for static metrics", func() {
 			mc := newMetricCatalog()
 			ns := []core.Namespace{
-				core.NewNamespace([]string{"mock", "foo", "bar"}),
-				core.NewNamespace([]string{"mock", "foo", "baz"}),
-				core.NewNamespace([]string{"mock", "asdf", "bar"}),
-				core.NewNamespace([]string{"mock", "asdf", "baz"}),
-				core.NewNamespace([]string{"mock", "test", "1"}),
-				core.NewNamespace([]string{"mock", "test", "2"}),
-				core.NewNamespace([]string{"mock", "test", "3"}),
-				core.NewNamespace([]string{"mock", "test", "4"}),
+				core.NewNamespace("mock", "foo", "bar"),
+				core.NewNamespace("mock", "foo", "baz"),
+				core.NewNamespace("mock", "asdf", "bar"),
+				core.NewNamespace("mock", "asdf", "baz"),
+				core.NewNamespace("mock", "test", "1"),
+				core.NewNamespace("mock", "test", "2"),
+				core.NewNamespace("mock", "test", "3"),
+				core.NewNamespace("mock", "test", "4"),
 			}
 			lp := new(loadedPlugin)
 			ts := time.Now()
@@ -110,62 +110,62 @@ func TestMetricMatching(t *testing.T) {
 				mc.Add(v)
 			}
 			Convey("match /mock/foo/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "foo", "*"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "foo", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "foo", "bar"}),
-					core.NewNamespace([]string{"mock", "foo", "baz"}),
+					core.NewNamespace("mock", "foo", "bar"),
+					core.NewNamespace("mock", "foo", "baz"),
 				})
 
 			})
 			Convey("match /mock/test/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "test", "*"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "test", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 4)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "test", "1"}),
-					core.NewNamespace([]string{"mock", "test", "2"}),
-					core.NewNamespace([]string{"mock", "test", "3"}),
-					core.NewNamespace([]string{"mock", "test", "4"}),
+					core.NewNamespace("mock", "test", "1"),
+					core.NewNamespace("mock", "test", "2"),
+					core.NewNamespace("mock", "test", "3"),
+					core.NewNamespace("mock", "test", "4"),
 				})
 			})
 			Convey("match /mock/*/bar", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "*", "bar"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "*", "bar"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "foo", "bar"}),
-					core.NewNamespace([]string{"mock", "asdf", "bar"}),
+					core.NewNamespace("mock", "foo", "bar"),
+					core.NewNamespace("mock", "asdf", "bar"),
 				})
 			})
 			Convey("match /mock/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "*"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, len(ns))
 				So(nss, ShouldResemble, ns)
 			})
 			Convey("match /mock/(foo|asdf)/baz", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "(foo|asdf)", "baz"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "(foo|asdf)", "baz"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "foo", "baz"}),
-					core.NewNamespace([]string{"mock", "asdf", "baz"}),
+					core.NewNamespace("mock", "foo", "baz"),
+					core.NewNamespace("mock", "asdf", "baz"),
 				})
 			})
 			Convey("match /mock/test/(1|2|3)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "test", "(1|2|3)"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "test", "(1|2|3)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 3)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "test", "1"}),
-					core.NewNamespace([]string{"mock", "test", "2"}),
-					core.NewNamespace([]string{"mock", "test", "3"}),
+					core.NewNamespace("mock", "test", "1"),
+					core.NewNamespace("mock", "test", "2"),
+					core.NewNamespace("mock", "test", "3"),
 				})
 			})
 			Convey("invalid matching", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "not", "exist", "metric"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "not", "exist", "metric"))
 				So(err, ShouldNotBeNil)
 				So(nss, ShouldBeEmpty)
 				So(err.Error(), ShouldContainSubstring, "Metric not found:")
@@ -174,14 +174,14 @@ func TestMetricMatching(t *testing.T) {
 		Convey("verify query support for dynamic metrics", func() {
 			mc := newMetricCatalog()
 			ns := []core.Namespace{
-				core.NewNamespace([]string{"mock", "cgroups", "*", "bar"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "baz"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "in"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "out"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "test", "1"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "test", "2"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "test", "3"}),
-				core.NewNamespace([]string{"mock", "cgroups", "*", "test", "4"}),
+				core.NewNamespace("mock", "cgroups", "*", "bar"),
+				core.NewNamespace("mock", "cgroups", "*", "baz"),
+				core.NewNamespace("mock", "cgroups", "*", "in"),
+				core.NewNamespace("mock", "cgroups", "*", "out"),
+				core.NewNamespace("mock", "cgroups", "*", "test", "1"),
+				core.NewNamespace("mock", "cgroups", "*", "test", "2"),
+				core.NewNamespace("mock", "cgroups", "*", "test", "3"),
+				core.NewNamespace("mock", "cgroups", "*", "test", "4"),
 			}
 			lp := new(loadedPlugin)
 			ts := time.Now()
@@ -203,47 +203,47 @@ func TestMetricMatching(t *testing.T) {
 			So(len(mc.Keys()), ShouldEqual, len(ns))
 
 			Convey("match /mock/cgroups/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "cgroups", "*"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, len(ns))
 				So(nss, ShouldResemble, ns)
 			})
 			Convey("match /mock/cgroups/*/bar", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "cgroups", "*", "bar"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "bar"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 1)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "cgroups", "*", "bar"}),
+					core.NewNamespace("mock", "cgroups", "*", "bar"),
 				})
 			})
 			Convey("match /mock/cgroups/*/(bar|baz)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "cgroups", "*", "(bar|baz)"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "(bar|baz)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "cgroups", "*", "bar"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "baz"}),
+					core.NewNamespace("mock", "cgroups", "*", "bar"),
+					core.NewNamespace("mock", "cgroups", "*", "baz"),
 				})
 			})
 			Convey("match /mock/cgroups/*/test/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "cgroups", "*", "test", "*"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "test", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 4)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "1"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "2"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "3"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "4"}),
+					core.NewNamespace("mock", "cgroups", "*", "test", "1"),
+					core.NewNamespace("mock", "cgroups", "*", "test", "2"),
+					core.NewNamespace("mock", "cgroups", "*", "test", "3"),
+					core.NewNamespace("mock", "cgroups", "*", "test", "4"),
 				})
 			})
 			Convey("match /mock/cgroups/*/test/(1|2|3)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace([]string{"mock", "cgroups", "*", "test", "(1|2|3)"}))
+				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "test", "(1|2|3)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 3)
 				So(nss, ShouldResemble, []core.Namespace{
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "1"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "2"}),
-					core.NewNamespace([]string{"mock", "cgroups", "*", "test", "3"}),
+					core.NewNamespace("mock", "cgroups", "*", "test", "1"),
+					core.NewNamespace("mock", "cgroups", "*", "test", "2"),
+					core.NewNamespace("mock", "cgroups", "*", "test", "3"),
 				})
 			})
 		})
@@ -260,7 +260,7 @@ func TestMetricCatalog(t *testing.T) {
 	})
 	Convey("metricCatalog.Add()", t, func() {
 		Convey("adds a metricType to the metricCatalog", func() {
-			ns := core.NewNamespace([]string{"test"})
+			ns := core.NewNamespace("test")
 			mt := newMetricType(ns, time.Now(), new(loadedPlugin))
 			mt.description = "some description"
 			mc := newMetricCatalog()
@@ -275,9 +275,9 @@ func TestMetricCatalog(t *testing.T) {
 		ts := time.Now()
 		Convey("add multiple metricTypes and get them back", func() {
 			ns := []core.Namespace{
-				core.NewNamespace([]string{"test1"}),
-				core.NewNamespace([]string{"test2"}),
-				core.NewNamespace([]string{"test3"}),
+				core.NewNamespace("test1"),
+				core.NewNamespace("test2"),
+				core.NewNamespace("test3"),
 			}
 			lp := new(loadedPlugin)
 			mt := []*metricType{
@@ -299,11 +299,11 @@ func TestMetricCatalog(t *testing.T) {
 			lp2.Meta.Version = 2
 			lp35 := new(loadedPlugin)
 			lp35.Meta.Version = 35
-			m2 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp2)
+			m2 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp2)
 			mc.Add(m2)
-			m35 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp35)
+			m35 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp35)
 			mc.Add(m35)
-			m, err := mc.Get(core.NewNamespace([]string{"foo", "bar"}), -1)
+			m, err := mc.Get(core.NewNamespace("foo", "bar"), -1)
 			So(err, ShouldBeNil)
 			So(m, ShouldEqual, m35)
 		})
@@ -312,11 +312,11 @@ func TestMetricCatalog(t *testing.T) {
 			lp2.Meta.Version = 2
 			lp35 := new(loadedPlugin)
 			lp35.Meta.Version = 35
-			m2 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp2)
+			m2 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp2)
 			mc.Add(m2)
-			m35 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp35)
+			m35 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp35)
 			mc.Add(m35)
-			m, err := mc.Get(core.NewNamespace([]string{"foo", "bar"}), 2)
+			m, err := mc.Get(core.NewNamespace("foo", "bar"), 2)
 			So(err, ShouldBeNil)
 			So(m, ShouldEqual, m2)
 		})
@@ -325,18 +325,18 @@ func TestMetricCatalog(t *testing.T) {
 			lp2.Meta.Version = 2
 			lp35 := new(loadedPlugin)
 			lp35.Meta.Version = 35
-			m2 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp2)
+			m2 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp2)
 			mc.Add(m2)
-			m35 := newMetricType(core.NewNamespace([]string{"foo", "bar"}), ts, lp35)
+			m35 := newMetricType(core.NewNamespace("foo", "bar"), ts, lp35)
 			mc.Add(m35)
-			_, err := mc.Get(core.NewNamespace([]string{"foo", "bar"}), 7)
+			_, err := mc.Get(core.NewNamespace("foo", "bar"), 7)
 			So(err.Error(), ShouldContainSubstring, "Metric not found:")
 		})
 	})
 	Convey("metricCatalog.Table()", t, func() {
 		Convey("returns a copy of the table", func() {
 			mc := newMetricCatalog()
-			mt := newMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), &loadedPlugin{})
+			mt := newMetricType(core.NewNamespace("foo", "bar"), time.Now(), &loadedPlugin{})
 			mc.Add(mt)
 			//TODO test tree
 			//So(mc.Table(), ShouldHaveSameTypeAs, map[string][]*metricType{})
@@ -344,7 +344,7 @@ func TestMetricCatalog(t *testing.T) {
 		})
 	})
 	Convey("metricCatalog.Next()", t, func() {
-		ns := core.NewNamespace([]string{"test"})
+		ns := core.NewNamespace("test")
 		mt := newMetricType(ns, time.Now(), new(loadedPlugin))
 		mc := newMetricCatalog()
 		Convey("returns false on empty table", func() {
@@ -359,9 +359,9 @@ func TestMetricCatalog(t *testing.T) {
 	})
 	Convey("metricCatalog.Item()", t, func() {
 		ns := []core.Namespace{
-			core.NewNamespace([]string{"test1"}),
-			core.NewNamespace([]string{"test2"}),
-			core.NewNamespace([]string{"test3"}),
+			core.NewNamespace("test1"),
+			core.NewNamespace("test2"),
+			core.NewNamespace("test3"),
 		}
 		lp := new(loadedPlugin)
 		t := time.Now()
@@ -401,11 +401,11 @@ func TestMetricCatalog(t *testing.T) {
 		mc := newMetricCatalog()
 		ts := time.Now()
 		nss := []core.Namespace{
-			core.NewNamespace([]string{"mock", "test", "1"}),
-			core.NewNamespace([]string{"mock", "test", "2"}),
-			core.NewNamespace([]string{"mock", "test", "3"}),
-			core.NewNamespace([]string{"mock", "cgroups", "*", "in"}),
-			core.NewNamespace([]string{"mock", "cgroups", "*", "out"}),
+			core.NewNamespace("mock", "test", "1"),
+			core.NewNamespace("mock", "test", "2"),
+			core.NewNamespace("mock", "test", "3"),
+			core.NewNamespace("mock", "cgroups", "*", "in"),
+			core.NewNamespace("mock", "cgroups", "*", "out"),
 		}
 		Convey("removes a metricType from the catalog", func() {
 			// adding metrics to the catalog
@@ -427,7 +427,7 @@ func TestMetricCatalog(t *testing.T) {
 			mc.Remove(nss[0])
 
 			Convey("validate removing a single metric from the catalog", func() {
-				_mt, err := mc.Get(core.NewNamespace([]string{"mock", "test", "1"}), -1)
+				_mt, err := mc.Get(core.NewNamespace("mock", "test", "1"), -1)
 				So(_mt, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 
@@ -453,9 +453,9 @@ func TestMetricCatalog(t *testing.T) {
 
 func TestSubscribe(t *testing.T) {
 	ns := []core.Namespace{
-		core.NewNamespace([]string{"test1"}),
-		core.NewNamespace([]string{"test2"}),
-		core.NewNamespace([]string{"test3"}),
+		core.NewNamespace("test1"),
+		core.NewNamespace("test2"),
+		core.NewNamespace("test3"),
 	}
 	lp := new(loadedPlugin)
 	ts := time.Now()
@@ -478,7 +478,7 @@ func TestSubscribe(t *testing.T) {
 		Convey("then it gets correctly increments the count", func() {
 			err := mc.Subscribe([]string{"test1"}, -1)
 			So(err, ShouldBeNil)
-			m, err2 := mc.Get(core.NewNamespace([]string{"test1"}), -1)
+			m, err2 := mc.Get(core.NewNamespace("test1"), -1)
 			So(err2, ShouldBeNil)
 			So(m.subscriptions, ShouldEqual, 1)
 		})
@@ -487,9 +487,9 @@ func TestSubscribe(t *testing.T) {
 
 func TestUnsubscribe(t *testing.T) {
 	ns := []core.Namespace{
-		core.NewNamespace([]string{"test1"}),
-		core.NewNamespace([]string{"test2"}),
-		core.NewNamespace([]string{"test3"}),
+		core.NewNamespace("test1"),
+		core.NewNamespace("test2"),
+		core.NewNamespace("test3"),
 	}
 	lp := new(loadedPlugin)
 	ts := time.Now()
@@ -508,7 +508,7 @@ func TestUnsubscribe(t *testing.T) {
 			So(err, ShouldBeNil)
 			err1 := mc.Unsubscribe([]string{"test1"}, -1)
 			So(err1, ShouldBeNil)
-			m, err2 := mc.Get(core.NewNamespace([]string{"test1"}), -1)
+			m, err2 := mc.Get(core.NewNamespace("test1"), -1)
 			So(err2, ShouldBeNil)
 			So(m.subscriptions, ShouldEqual, 0)
 		})
@@ -528,7 +528,7 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestSubscriptionCount(t *testing.T) {
-	m := newMetricType(core.NewNamespace([]string{"test"}), time.Now(), &loadedPlugin{})
+	m := newMetricType(core.NewNamespace("test"), time.Now(), &loadedPlugin{})
 	Convey("it returns the subscription count", t, func() {
 		m.Subscribe()
 		So(m.SubscriptionCount(), ShouldEqual, 1)
@@ -543,17 +543,17 @@ func TestSubscriptionCount(t *testing.T) {
 func TestMetricNamespaceValidation(t *testing.T) {
 	Convey("validateMetricNamespace()", t, func() {
 		Convey("validation passes", func() {
-			ns := core.NewNamespace([]string{"mock", "foo", "bar"})
+			ns := core.NewNamespace("mock", "foo", "bar")
 			err := validateMetricNamespace(ns)
 			So(err, ShouldBeNil)
 		})
 		Convey("contains not allowed characters", func() {
-			ns := core.NewNamespace([]string{"mock", "foo", "(bar)"})
+			ns := core.NewNamespace("mock", "foo", "(bar)")
 			err := validateMetricNamespace(ns)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("contains unacceptable wildcardat at the end", func() {
-			ns := core.NewNamespace([]string{"mock", "foo", "*"})
+			ns := core.NewNamespace("mock", "foo", "*")
 			err := validateMetricNamespace(ns)
 			So(err, ShouldNotBeNil)
 		})

--- a/control/mttrie_test.go
+++ b/control/mttrie_test.go
@@ -36,8 +36,8 @@ func TestTrie(t *testing.T) {
 	Convey("Fetch", t, func() {
 		trie := NewMTTrie()
 		Convey("Add and collect split namespace", func() {
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), new(loadedPlugin))
-			mt2 := newMetricType(core.NewNamespace([]string{"intel", "baz", "qux"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), new(loadedPlugin))
+			mt2 := newMetricType(core.NewNamespace("intel", "baz", "qux"), time.Now(), new(loadedPlugin))
 			trie.Add(mt)
 			trie.Add(mt2)
 
@@ -46,13 +46,13 @@ func TestTrie(t *testing.T) {
 			So(len(in), ShouldEqual, 2)
 			for _, mt := range in {
 				So(mt, ShouldNotBeNil)
-				So(mt.Namespace(), ShouldHaveSameTypeAs, core.NewNamespace([]string{""}))
+				So(mt.Namespace(), ShouldHaveSameTypeAs, core.NewNamespace(""))
 			}
 		})
 		Convey("Add and collect with nodes with children", func() {
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo", "bar"}), time.Now(), new(loadedPlugin))
-			mt2 := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), new(loadedPlugin))
-			mt3 := newMetricType(core.NewNamespace([]string{"intel", "foo", "qux"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("intel", "foo", "bar"), time.Now(), new(loadedPlugin))
+			mt2 := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), new(loadedPlugin))
+			mt3 := newMetricType(core.NewNamespace("intel", "foo", "qux"), time.Now(), new(loadedPlugin))
 			trie.Add(mt)
 			trie.Add(mt2)
 			trie.Add(mt3)
@@ -62,8 +62,8 @@ func TestTrie(t *testing.T) {
 			So(len(in), ShouldEqual, 3)
 		})
 		Convey("Add and collect at node with mt and children", func() {
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo", "bar"}), time.Now(), new(loadedPlugin))
-			mt2 := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("intel", "foo", "bar"), time.Now(), new(loadedPlugin))
+			mt2 := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), new(loadedPlugin))
 			trie.Add(mt)
 			trie.Add(mt2)
 
@@ -72,29 +72,29 @@ func TestTrie(t *testing.T) {
 			So(len(in), ShouldEqual, 2)
 		})
 		Convey("add and collect single depth namespace", func() {
-			mt := newMetricType(core.NewNamespace([]string{"test"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("test"), time.Now(), new(loadedPlugin))
 			trie.Add(mt)
 			t, err := trie.Fetch([]string{"test"})
 			So(err, ShouldBeNil)
-			So(t[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"test"}))
+			So(t[0].Namespace(), ShouldResemble, core.NewNamespace("test"))
 		})
 		Convey("add and longer length with single child", func() {
-			mt := newMetricType(core.NewNamespace([]string{"d", "a", "n", "b", "a", "r"}), time.Now(), new(loadedPlugin))
+			mt := newMetricType(core.NewNamespace("d", "a", "n", "b", "a", "r"), time.Now(), new(loadedPlugin))
 			trie.Add(mt)
 			d, err := trie.Fetch([]string{"d", "a", "n", "b", "a", "r"})
 			So(err, ShouldBeNil)
-			So(d[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"d", "a", "n", "b", "a", "r"}))
+			So(d[0].Namespace(), ShouldResemble, core.NewNamespace("d", "a", "n", "b", "a", "r"))
 			dd, err := trie.Fetch([]string{"d", "a", "n"})
 			So(err, ShouldBeNil)
-			So(dd[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"d", "a", "n", "b", "a", "r"}))
+			So(dd[0].Namespace(), ShouldResemble, core.NewNamespace("d", "a", "n", "b", "a", "r"))
 		})
 		Convey("Multiple versions", func() {
 			lp := new(loadedPlugin)
 			lp.Meta.Version = 1
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), lp)
+			mt := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), lp)
 			lp2 := new(loadedPlugin)
 			lp2.Meta.Version = 2
-			mt2 := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), lp2)
+			mt2 := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), lp2)
 			trie.Add(mt)
 			trie.Add(mt2)
 			n, err := trie.Fetch([]string{"intel"})
@@ -109,7 +109,7 @@ func TestTrie(t *testing.T) {
 		Convey("Fetch with error: depth exceeded", func() {
 			lp := new(loadedPlugin)
 			lp.Meta.Version = 1
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), lp)
+			mt := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), lp)
 			trie.Add(mt)
 			_, err := trie.Fetch([]string{"intel", "foo", "bar", "baz"})
 			So(err, ShouldNotBeNil)
@@ -122,17 +122,17 @@ func TestTrie(t *testing.T) {
 		Convey("simple get", func() {
 			lp := new(loadedPlugin)
 			lp.Meta.Version = 1
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), lp)
+			mt := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), lp)
 			trie.Add(mt)
 			n, err := trie.Get([]string{"intel", "foo"})
 			So(err, ShouldBeNil)
 			So(len(n), ShouldEqual, 1)
-			So(n[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"intel", "foo"}))
+			So(n[0].Namespace(), ShouldResemble, core.NewNamespace("intel", "foo"))
 		})
 		Convey("error: no data at node", func() {
 			lp := new(loadedPlugin)
 			lp.Meta.Version = 1
-			mt := newMetricType(core.NewNamespace([]string{"intel", "foo"}), time.Now(), lp)
+			mt := newMetricType(core.NewNamespace("intel", "foo"), time.Now(), lp)
 			trie.Add(mt)
 			n, err := trie.Get([]string{"intel"})
 			So(n, ShouldBeNil)

--- a/control/plugin/client/httpjsonrpc_test.go
+++ b/control/plugin/client/httpjsonrpc_test.go
@@ -96,7 +96,7 @@ func (m *mockCollectorProxy) GetMetricTypes(args []byte, reply *[]byte) error {
 
 	pmts := []plugin.MetricType{}
 	pmts = append(pmts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+		Namespace_: core.NewNamespace("foo", "bar"),
 		Config_:    dargs.PluginConfig.ConfigDataNode,
 	})
 	*reply, _ = m.e.Encode(plugin.GetMetricTypesReply{MetricTypes: pmts})
@@ -217,7 +217,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 			mts, err := c.CollectMetrics([]core.Metric{
 				&plugin.MetricType{
-					Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+					Namespace_: core.NewNamespace("foo", "bar"),
 					Config_:    cdn,
 				},
 			})
@@ -250,7 +250,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 			time.Sleep(500 * time.Millisecond)
 			mts, err := c.CollectMetrics([]core.Metric{
 				&plugin.MetricType{
-					Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+					Namespace_: core.NewNamespace("foo", "bar"),
 					Config_:    cdn,
 				},
 			})
@@ -302,7 +302,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 		})
 
 		Convey("Process metrics", func() {
-			pmt := plugin.NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1)
+			pmt := plugin.NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1)
 			b, _ := json.Marshal([]plugin.MetricType{*pmt})
 			contentType, content, err := p.Process(plugin.SnapJSONContentType, b, nil)
 			So(contentType, ShouldResemble, plugin.SnapJSONContentType)
@@ -313,7 +313,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(pmts), ShouldEqual, 1)
 			So(pmts[0].Data(), ShouldEqual, 1)
-			So(pmts[0].Namespace(), ShouldResemble, core.NewNamespace([]string{"foo", "bar"}))
+			So(pmts[0].Namespace(), ShouldResemble, core.NewNamespace("foo", "bar"))
 		})
 	})
 
@@ -342,7 +342,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 		})
 
 		Convey("Publish metrics", func() {
-			pmt := plugin.NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1)
+			pmt := plugin.NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1)
 			b, _ := json.Marshal([]plugin.MetricType{*pmt})
 			err := p.Publish(plugin.SnapJSONContentType, b, nil)
 			So(err, ShouldBeNil)

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -37,8 +37,8 @@ type mockPlugin struct {
 }
 
 var mockMetricType = []MetricType{
-	*NewMetricType(core.NewNamespace([]string{"foo"}).AddDynamicElement("test", "something dynamic here").AddStaticElement("bar"), time.Now(), nil, "", 1),
-	*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", 2),
+	*NewMetricType(core.NewNamespace("foo").AddDynamicElement("test", "something dynamic here").AddStaticElement("bar"), time.Now(), nil, "", 1),
+	*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", 2),
 }
 
 func (p *mockPlugin) GetMetricTypes(cfg ConfigType) ([]MetricType, error) {

--- a/control/plugin/collector_test.go
+++ b/control/plugin/collector_test.go
@@ -41,7 +41,7 @@ func (f *MockPlugin) CollectMetrics(_ []MetricType) ([]MetricType, error) {
 
 func (c *MockPlugin) GetMetricTypes(_ ConfigType) ([]MetricType, error) {
 	return []MetricType{
-		{Namespace_: core.NewNamespace([]string{"foo", "bar"})},
+		{Namespace_: core.NewNamespace("foo", "bar")},
 	}, nil
 }
 

--- a/control/plugin/metric_test.go
+++ b/control/plugin/metric_test.go
@@ -32,8 +32,8 @@ import (
 func TestMetric(t *testing.T) {
 	Convey("error on invalid snap content type", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", 2),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", 2),
 		}
 		a, c, e := MarshalMetricTypes("foo", m)
 		m[0].Version_ = 1
@@ -61,8 +61,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using snap.* default to snap.gob", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.*", m)
 		So(e, ShouldBeNil)
@@ -83,8 +83,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using snap.gob", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.gob", m)
 		So(e, ShouldBeNil)
@@ -111,8 +111,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("marshall using snap.json", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.json", m)
 		So(e, ShouldBeNil)
@@ -139,8 +139,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("error on unmarshall using bad content type", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.json", m)
 		So(e, ShouldBeNil)
@@ -156,8 +156,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from snap.gob to snap.json", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.gob", m)
 		So(e, ShouldBeNil)
@@ -180,8 +180,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from snap.json to snap.*", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.json", m)
 		So(e, ShouldBeNil)
@@ -204,8 +204,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("swap from snap.json to snap.gob", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.json", m)
 		So(e, ShouldBeNil)
@@ -228,8 +228,8 @@ func TestMetric(t *testing.T) {
 
 	Convey("error on bad content type to swap", t, func() {
 		m := []MetricType{
-			*NewMetricType(core.NewNamespace([]string{"foo", "bar"}), time.Now(), nil, "", 1),
-			*NewMetricType(core.NewNamespace([]string{"foo", "baz"}), time.Now(), nil, "", "2"),
+			*NewMetricType(core.NewNamespace("foo", "bar"), time.Now(), nil, "", 1),
+			*NewMetricType(core.NewNamespace("foo", "baz"), time.Now(), nil, "", "2"),
 		}
 		a, c, e := MarshalMetricTypes("snap.json", m)
 		So(e, ShouldBeNil)

--- a/control/plugin/plugin_test.go
+++ b/control/plugin/plugin_test.go
@@ -40,14 +40,14 @@ func TestMetricType(t *testing.T) {
 	Convey("MetricType", t, func() {
 		now := time.Now()
 		m := &MetricType{
-			Namespace_:          core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_:          core.NewNamespace("foo", "bar"),
 			LastAdvertisedTime_: now,
 		}
 		Convey("New", func() {
 			So(m, ShouldHaveSameTypeAs, &MetricType{})
 		})
 		Convey("Get Namespace", func() {
-			So(m.Namespace(), ShouldResemble, core.NewNamespace([]string{"foo", "bar"}))
+			So(m.Namespace(), ShouldResemble, core.NewNamespace("foo", "bar"))
 		})
 		Convey("Get LastAdvertisedTimestamp", func() {
 			So(m.LastAdvertisedTime().Unix(), ShouldBeGreaterThan, now.Unix()-2)

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -128,7 +128,7 @@ func TestLoadPlugin(t *testing.T) {
 				So(p.all(), ShouldNotBeEmpty)
 				So(serr, ShouldBeNil)
 				So(len(p.all()), ShouldBeGreaterThan, 0)
-				mts, err := p.metricCatalog.Fetch(core.NewNamespace([]string{}))
+				mts, err := p.metricCatalog.Fetch(core.NewNamespace())
 				So(err, ShouldBeNil)
 				So(len(mts), ShouldBeGreaterThan, 2)
 				So(mts[0].Description(), ShouldResemble, "mock description")

--- a/control/strategy/cache_test.go
+++ b/control/strategy/cache_test.go
@@ -35,7 +35,7 @@ func TestCache(t *testing.T) {
 	Convey("puts and gets a metric", t, func() {
 		mc := NewCache(GlobalCacheExpiration)
 		foo := &plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_: core.NewNamespace("foo", "bar"),
 		}
 
 		mc.put("/foo/bar", 1, foo)
@@ -59,7 +59,7 @@ func TestCache(t *testing.T) {
 
 		mc := NewCache(400 * time.Millisecond)
 		foo := &plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_: core.NewNamespace("foo", "bar"),
 		}
 		mc.put("/foo/bar", 1, foo)
 		chrono.Chrono.Forward(401 * time.Millisecond)
@@ -71,7 +71,7 @@ func TestCache(t *testing.T) {
 		Convey("ticks hit count when a cache entry is hit", func() {
 			mc := NewCache(400 * time.Millisecond)
 			foo := &plugin.MetricType{
-				Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+				Namespace_: core.NewNamespace("foo", "bar"),
 			}
 			mc.put("/foo/bar", 1, foo)
 			mc.get("/foo/bar", 1)
@@ -85,7 +85,7 @@ func TestCache(t *testing.T) {
 
 			mc := NewCache(400 * time.Millisecond)
 			foo := &plugin.MetricType{
-				Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+				Namespace_: core.NewNamespace("foo", "bar"),
 			}
 
 			mc.put("/foo/bar", 1, foo)
@@ -101,7 +101,7 @@ func TestCache(t *testing.T) {
 
 			mc := NewCache(GlobalCacheExpiration)
 			foo := &plugin.MetricType{
-				Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+				Namespace_: core.NewNamespace("foo", "bar"),
 			}
 			mc.put("/foo/bar", 1, foo)
 			chrono.Chrono.Forward(301 * time.Millisecond)
@@ -118,10 +118,10 @@ func TestCache(t *testing.T) {
 
 		mc := NewCache(GlobalCacheExpiration)
 		foo := &plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_: core.NewNamespace("foo", "bar"),
 		}
 		baz := &plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "baz"}),
+			Namespace_: core.NewNamespace("foo", "baz"),
 		}
 		metricList := []core.Metric{foo, baz}
 		mc.updateCache(metricList)
@@ -133,7 +133,7 @@ func TestCache(t *testing.T) {
 		})
 		Convey("they should be retrievable via checkCache", func() {
 			nonCached := &plugin.MetricType{
-				Namespace_: core.NewNamespace([]string{"foo", "fooer"}),
+				Namespace_: core.NewNamespace("foo", "fooer"),
 			}
 			metricList = append(metricList, nonCached)
 			toCollect, fromCache := mc.checkCache(metricList)
@@ -155,11 +155,11 @@ func TestCache(t *testing.T) {
 		chrono.Chrono.Pause()
 		mc := NewCache(GlobalCacheExpiration)
 		v1 := plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_: core.NewNamespace("foo", "bar"),
 			Version_:   1,
 		}
 		v2 := plugin.MetricType{
-			Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+			Namespace_: core.NewNamespace("foo", "bar"),
 			Version_:   2,
 		}
 		metricList := []core.Metric{v1, v2}
@@ -167,7 +167,7 @@ func TestCache(t *testing.T) {
 		Convey("Should be cached separately", func() {
 			Convey("so only 1 should be returned from the cache", func() {
 				starMetric := &plugin.MetricType{
-					Namespace_: core.NewNamespace([]string{"foo", "bar"}),
+					Namespace_: core.NewNamespace("foo", "bar"),
 					Version_:   2,
 				}
 				// Check /foo/* with both versions

--- a/core/metric.go
+++ b/core/metric.go
@@ -92,7 +92,7 @@ func (n Namespace) IsDynamic() (bool, []int) {
 // NewNamespace takes an array of strings and returns a Namespace.  A Namespace
 // is an array of NamespaceElements.  The provided array of strings is used to
 // set the corresponding Value fields in the array of NamespaceElements.
-func NewNamespace(ns []string) Namespace {
+func NewNamespace(ns ...string) Namespace {
 	n := make([]NamespaceElement, len(ns))
 	for i, ns := range ns {
 		n[i] = NamespaceElement{Value: ns}
@@ -112,6 +112,15 @@ func (n Namespace) AddDynamicElement(name, description string) Namespace {
 func (n Namespace) AddStaticElement(value string) Namespace {
 	nse := NamespaceElement{Value: value}
 	return append(n, nse)
+}
+
+// AddStaticElements adds a static elements to the given Namespace.  A static
+// NamespaceElement is defined by having an empty Name field.
+func (n Namespace) AddStaticElements(values ...string) Namespace {
+	for _, value := range values {
+		n = append(n, NamespaceElement{Value: value})
+	}
+	return n
 }
 
 // NamespaceElement provides meta data related to the namespace.  This is of particular importance when

--- a/mgmt/rest/metric.go
+++ b/mgmt/rest/metric.go
@@ -72,7 +72,7 @@ func (s *Server) getMetricsFromTree(w http.ResponseWriter, r *http.Request, para
 			}
 		}
 
-		mets, err := s.mm.FetchMetrics(core.NewNamespace(ns[:len(ns)-1]), ver)
+		mets, err := s.mm.FetchMetrics(core.NewNamespace(ns[:len(ns)-1]...), ver)
 		if err != nil {
 			respond(404, rbody.FromError(err), w)
 			return
@@ -83,7 +83,7 @@ func (s *Server) getMetricsFromTree(w http.ResponseWriter, r *http.Request, para
 
 	// If no version was given, get all that fall at this namespace.
 	if v == "" {
-		mts, err := s.mm.GetMetricVersions(core.NewNamespace(ns))
+		mts, err := s.mm.GetMetricVersions(core.NewNamespace(ns...))
 		if err != nil {
 			respond(404, rbody.FromError(err), w)
 			return
@@ -98,7 +98,7 @@ func (s *Server) getMetricsFromTree(w http.ResponseWriter, r *http.Request, para
 		respond(400, rbody.FromError(err), w)
 		return
 	}
-	mt, err := s.mm.GetMetric(core.NewNamespace(ns), ver)
+	mt, err := s.mm.GetMetric(core.NewNamespace(ns...), ver)
 	if err != nil {
 		respond(404, rbody.FromError(err), w)
 		return

--- a/plugin/collector/snap-collector-mock1/mock/mock.go
+++ b/plugin/collector/snap-collector-mock1/mock/mock.go
@@ -85,11 +85,11 @@ func (f *Mock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error
 		return mts, fmt.Errorf("missing on-load plugin config entry 'test'")
 	}
 	if _, ok := cfg.Table()["test"]; ok {
-		mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace([]string{"intel", "mock", "test"})})
+		mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace("intel", "mock", "test")})
 	}
-	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace([]string{"intel", "mock", "foo"})})
-	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace([]string{"intel", "mock", "bar"})})
-	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace([]string{"intel", "mock"}).
+	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace("intel", "mock", "foo")})
+	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace("intel", "mock", "bar")})
+	mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace("intel", "mock").
 		AddDynamicElement("host", "name of the host").
 		AddStaticElement("baz")})
 	return mts, nil

--- a/plugin/collector/snap-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-collector-mock2/mock/mock.go
@@ -88,23 +88,23 @@ func (f *Mock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error
 	}
 	if _, ok := cfg.Table()["test"]; ok {
 		mts = append(mts, plugin.MetricType{
-			Namespace_:   core.NewNamespace([]string{"intel", "mock", "test"}),
+			Namespace_:   core.NewNamespace("intel", "mock", "test"),
 			Description_: "mock description",
 			Unit_:        "mock unit",
 		})
 	}
 	mts = append(mts, plugin.MetricType{
-		Namespace_:   core.NewNamespace([]string{"intel", "mock", "foo"}),
+		Namespace_:   core.NewNamespace("intel", "mock", "foo"),
 		Description_: "mock description",
 		Unit_:        "mock unit",
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_:   core.NewNamespace([]string{"intel", "mock", "bar"}),
+		Namespace_:   core.NewNamespace("intel", "mock", "bar"),
 		Description_: "mock description",
 		Unit_:        "mock unit",
 	})
 	mts = append(mts, plugin.MetricType{
-		Namespace_: core.NewNamespace([]string{"intel", "mock"}).
+		Namespace_: core.NewNamespace("intel", "mock").
 			AddDynamicElement("host", "name of the host").
 			AddStaticElement("baz"),
 		Description_: "mock description",

--- a/plugin/publisher/snap-publisher-file/file/file_test.go
+++ b/plugin/publisher/snap-publisher-file/file/file_test.go
@@ -37,7 +37,7 @@ import (
 func TestFilePublish(t *testing.T) {
 	var buf bytes.Buffer
 	metrics := []plugin.MetricType{
-		*plugin.NewMetricType(core.NewNamespace([]string{"foo"}), time.Now(), nil, "", 99),
+		*plugin.NewMetricType(core.NewNamespace("foo"), time.Now(), nil, "", 99),
 	}
 	config := make(map[string]ctypes.ConfigValue)
 	enc := gob.NewEncoder(&buf)

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -87,7 +87,7 @@ func convertCollectionNode(cnode *wmap.CollectWorkflowMapNode, wf *schedulerWork
 	mts := cnode.GetMetrics()
 	wf.metrics = make([]core.RequestedMetric, len(mts))
 	for i, m := range mts {
-		wf.metrics[i] = &metric{namespace: core.NewNamespace(m.Namespace()), version: m.Version()}
+		wf.metrics[i] = &metric{namespace: core.NewNamespace(m.Namespace()...), version: m.Version()}
 	}
 
 	// Get our config data tree


### PR DESCRIPTION
Fixes #883 and #884 

Summary of changes:
 - Changed signature of core.NewNamespace to variadic arguments
 - Introduced new function to add many static elements
 - Applied changes to unit tests

Testing done:
- all unit tests

@intelsdi-x/snap-maintainers