### PR TITLE
Allow remote targets for nodes in a task workflow

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -404,7 +404,6 @@ func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDe
 
 func (p *pluginControl) Unload(pl core.Plugin) (core.CatalogedPlugin, serror.SnapError) {
 	up, err := p.pluginManager.UnloadPlugin(pl)
-	fmt.Println("Unloading plugin:", pl)
 	if err != nil {
 		return nil, err
 	}

--- a/grpc/controlproxy/controlproxy.go
+++ b/grpc/controlproxy/controlproxy.go
@@ -58,7 +58,7 @@ func (c ControlProxy) ExpandWildcards(namespace []string) ([][]string, serror.Sn
 func (c ControlProxy) PublishMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) []error {
 	req := GetPubProcReq(contentType, content, pluginName, pluginVersion, config, taskID)
 	reply, err := c.Client.PublishMetrics(context.Background(), req)
-	errs := make([]error, 0)
+	var errs []error
 	if err != nil {
 		errs = append(errs, err)
 		return errs
@@ -71,7 +71,7 @@ func (c ControlProxy) PublishMetrics(contentType string, content []byte, pluginN
 func (c ControlProxy) ProcessMetrics(contentType string, content []byte, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) (string, []byte, []error) {
 	req := GetPubProcReq(contentType, content, pluginName, pluginVersion, config, taskID)
 	reply, err := c.Client.ProcessMetrics(context.Background(), req)
-	errs := make([]error, 0)
+	var errs []error
 	if err != nil {
 		errs = append(errs, err)
 		return "", nil, errs
@@ -91,7 +91,7 @@ func (c ControlProxy) CollectMetrics(mts []core.Metric, deadline time.Time, task
 		TaskID: taskID,
 	}
 	reply, err := c.Client.CollectMetrics(context.Background(), req)
-	errs := make([]error, 0)
+	var errs []error
 	if err != nil {
 		errs = append(errs, err)
 		return nil, errs

--- a/scheduler/distributed_task_test.go
+++ b/scheduler/distributed_task_test.go
@@ -1,0 +1,156 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"net"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/intelsdi-x/snap/control"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/pkg/schedule"
+	"github.com/intelsdi-x/snap/scheduler/wmap"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	PluginPath = path.Join(SnapPath, "plugin")
+)
+
+func TestDistributedWorkflow(t *testing.T) {
+	Convey("Create a scheduler with 2 controls and load plugins", t, func() {
+		l, _ := net.Listen("tcp", ":0")
+		l.Close()
+		cfg := control.GetDefaultConfig()
+		cfg.ListenPort = l.Addr().(*net.TCPAddr).Port
+		c1 := control.New(cfg)
+		c1.Start()
+		m, _ := net.Listen("tcp", ":0")
+		m.Close()
+		cfg.ListenPort = m.Addr().(*net.TCPAddr).Port
+		port1 := cfg.ListenPort
+		c2 := control.New(cfg)
+		n, _ := net.Listen("tcp", ":0")
+		n.Close()
+		schcfg := GetDefaultConfig()
+		schcfg.ListenPort = n.Addr().(*net.TCPAddr).Port
+		sch := New(schcfg)
+		c2.Start()
+		sch.SetMetricManager(c1)
+		err := sch.Start()
+		So(err, ShouldBeNil)
+		// Load appropriate plugins into each control.
+		mock2Path := path.Join(PluginPath, "snap-collector-mock2")
+		passthruPath := path.Join(PluginPath, "snap-processor-passthru")
+		filePath := path.Join(PluginPath, "snap-publisher-file")
+
+		// mock2 and file onto c1
+
+		rp, err := core.NewRequestedPlugin(mock2Path)
+		So(err, ShouldBeNil)
+		_, err = c1.Load(rp)
+		So(err, ShouldBeNil)
+		rp, err = core.NewRequestedPlugin(filePath)
+		So(err, ShouldBeNil)
+		_, err = c1.Load(rp)
+		So(err, ShouldBeNil)
+		// passthru on c2
+		rp, err = core.NewRequestedPlugin(passthruPath)
+		So(err, ShouldBeNil)
+		passthru, err := c2.Load(rp)
+		So(err, ShouldBeNil)
+
+		Convey("Test task with one local and one remote node", func() {
+			//Create a task
+			//Create a workflowmap
+			wf := dsWFMap(port1)
+			t, errs := sch.CreateTask(schedule.NewSimpleSchedule(time.Second), wf, true)
+			So(len(errs.Errors()), ShouldEqual, 0)
+			So(t, ShouldNotBeNil)
+		})
+
+		Convey("Test task with invalid remote port", func() {
+			wf := dsWFMap(0)
+			t, errs := sch.CreateTask(schedule.NewSimpleSchedule(time.Second), wf, true)
+			So(len(errs.Errors()), ShouldEqual, 1)
+			So(t, ShouldBeNil)
+		})
+
+		Convey("Test task without remote plugin", func() {
+			_, err := c2.Unload(passthru)
+			So(err, ShouldBeNil)
+			wf := dsWFMap(port1)
+			t, errs := sch.CreateTask(schedule.NewSimpleSchedule(time.Second), wf, true)
+			So(len(errs.Errors()), ShouldEqual, 1)
+			So(t, ShouldBeNil)
+		})
+
+		Convey("Test task failing when control is stopped while task is running", func() {
+			wf := dsWFMap(port1)
+			interval := time.Millisecond * 100
+			t, errs := sch.CreateTask(schedule.NewSimpleSchedule(interval), wf, true)
+			So(len(errs.Errors()), ShouldEqual, 0)
+			So(t, ShouldNotBeNil)
+			c2.Stop()
+			// Give task time to fail
+			time.Sleep(time.Second)
+			tasks := sch.GetTasks()
+			var task core.Task
+			for _, v := range tasks {
+				task = v
+			}
+			So(task.State(), ShouldEqual, core.TaskDisabled)
+		})
+
+	})
+
+}
+
+func dsWFMap(port int) *wmap.WorkflowMap {
+	wf := new(wmap.WorkflowMap)
+
+	c := wmap.NewCollectWorkflowMapNode()
+	c.Config["/intel/mock/foo"] = make(map[string]interface{})
+	c.Config["/intel/mock/foo"]["password"] = "required"
+	pr := &wmap.ProcessWorkflowMapNode{
+		Name:    "passthru",
+		Version: -1,
+		Config:  make(map[string]interface{}),
+		Target:  fmt.Sprintf("127.0.0.1:%v", port),
+	}
+	pu := &wmap.PublishWorkflowMapNode{
+		Name:    "file",
+		Version: -1,
+		Config:  make(map[string]interface{}),
+	}
+	pu.Config["file"] = "/dev/null"
+	pr.Add(pu)
+	c.Add(pr)
+	e := c.AddMetric("/intel/mock/foo", 2)
+	if e != nil {
+		panic(e)
+	}
+	wf.CollectNode = c
+
+	return wf
+}

--- a/scheduler/managers.go
+++ b/scheduler/managers.go
@@ -43,7 +43,11 @@ func newManagers(mm managesMetrics) managers {
 // via Get() calls.
 func (m *managers) Add(key string, val managesMetrics) {
 	m.mutex.Lock()
-	m.remoteManagers[key] = val
+	if key == "" {
+		m.local = val
+	} else {
+		m.remoteManagers[key] = val
+	}
 	m.mutex.Unlock()
 }
 

--- a/scheduler/managers.go
+++ b/scheduler/managers.go
@@ -1,0 +1,50 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import "sync"
+
+type managers struct {
+	mutex          *sync.RWMutex
+	remoteManagers map[string]managesMetrics
+}
+
+func newManagers() managers {
+	return managers{
+		mutex:          &sync.RWMutex{},
+		remoteManagers: make(map[string]managesMetrics),
+	}
+}
+
+func (m *managers) Add(key string, val managesMetrics) {
+	m.mutex.Lock()
+	m.remoteManagers[key] = val
+	m.mutex.Unlock()
+}
+
+func (m *managers) Get(key string) managesMetrics {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	if val, ok := m.remoteManagers[key]; ok {
+		return val
+	} else {
+		return nil
+	}
+}

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -115,7 +115,7 @@ func newTask(s schedule.Schedule, wf *schedulerWorkflow, m *workManager, mm mana
 	for _, opt := range opts {
 		opt(task)
 	}
-	task.RemoteManagers = newManagers()
+	task.RemoteManagers = newManagers(mm)
 	err := createTaskClients(&task.RemoteManagers, wf)
 	if err != nil {
 		return nil, err

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -45,7 +45,8 @@ func TestTask(t *testing.T) {
 		So(errs, ShouldBeEmpty)
 		c := &mockMetricManager{}
 		c.setAcceptedContentType("rabbitmq", core.PublisherPluginType, 5, []string{plugin.SnapGOBContentType})
-		err := wf.BindPluginContentTypes(c, nil)
+		mgrs := newManagers(c)
+		err := wf.BindPluginContentTypes(&mgrs)
 		So(err, ShouldBeNil)
 		Convey("task + simple schedule", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -45,11 +45,12 @@ func TestTask(t *testing.T) {
 		So(errs, ShouldBeEmpty)
 		c := &mockMetricManager{}
 		c.setAcceptedContentType("rabbitmq", core.PublisherPluginType, 5, []string{plugin.SnapGOBContentType})
-		err := wf.BindPluginContentTypes(c)
+		err := wf.BindPluginContentTypes(c, nil)
 		So(err, ShouldBeNil)
 		Convey("task + simple schedule", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task.Spin()
 			time.Sleep(time.Millisecond * 10) // it is a race so we slow down the test
 			So(task.state, ShouldEqual, core.TaskSpinning)
@@ -59,14 +60,16 @@ func TestTask(t *testing.T) {
 
 		Convey("Task specified-name test", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter, core.SetTaskNameOption("My name is unique"))
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter, core.SetTaskNameOption("My name is unique"))
+			So(err, ShouldBeNil)
 			task.Spin()
 			So(task.GetName(), ShouldResemble, "My name is unique")
 
 		})
 		Convey("Task default-name test", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task.Spin()
 			So(task.GetName(), ShouldResemble, "Task-"+task.ID())
 
@@ -74,7 +77,8 @@ func TestTask(t *testing.T) {
 
 		Convey("Task deadline duration test", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter, core.TaskDeadlineDurationOption(20*time.Second))
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter, core.TaskDeadlineDurationOption(20*time.Second))
+			So(err, ShouldBeNil)
 			task.Spin()
 			So(task.deadlineDuration, ShouldEqual, 20*time.Second)
 			task.Option(core.TaskDeadlineDurationOption(20 * time.Second))
@@ -85,8 +89,10 @@ func TestTask(t *testing.T) {
 
 		Convey("Tasks are created and creation of task table is checked", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
-			task1 := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
+			task1, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task1.Spin()
 			task.Spin()
 			tC := newTaskCollection()
@@ -100,7 +106,8 @@ func TestTask(t *testing.T) {
 
 		Convey("Task is created and starts to spin", func() {
 			sch := schedule.NewSimpleSchedule(time.Second * 5)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task.Spin()
 			So(task.state, ShouldEqual, core.TaskSpinning)
 			Convey("Task is Stopped", func() {
@@ -112,7 +119,8 @@ func TestTask(t *testing.T) {
 
 		Convey("task fires", func() {
 			sch := schedule.NewSimpleSchedule(time.Nanosecond * 100)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task.Spin()
 			time.Sleep(time.Millisecond * 50)
 			So(task.hitCount, ShouldBeGreaterThan, 2)
@@ -122,19 +130,21 @@ func TestTask(t *testing.T) {
 
 		Convey("Enable a running task", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 10)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 			task.Spin()
-			err := task.Enable()
+			err = task.Enable()
 			So(err, ShouldNotBeNil)
 			So(task.State(), ShouldEqual, core.TaskSpinning)
 		})
 
 		Convey("Enable a disabled task", func() {
 			sch := schedule.NewSimpleSchedule(time.Millisecond * 10)
-			task := newTask(sch, wf, newWorkManager(), c, emitter)
+			task, err := newTask(sch, wf, newWorkManager(), c, emitter)
+			So(err, ShouldBeNil)
 
 			task.state = core.TaskDisabled
-			err := task.Enable()
+			err = task.Enable()
 			So(err, ShouldBeNil)
 			So(task.State(), ShouldEqual, core.TaskStopped)
 		})
@@ -146,7 +156,8 @@ func TestTask(t *testing.T) {
 		So(errs, ShouldBeEmpty)
 
 		sch := schedule.NewSimpleSchedule(time.Millisecond * 10)
-		task := newTask(sch, wf, newWorkManager(), &mockMetricManager{}, emitter)
+		task, err := newTask(sch, wf, newWorkManager(), &mockMetricManager{}, emitter)
+		So(err, ShouldBeNil)
 		So(task.id, ShouldNotBeEmpty)
 		So(task.id, ShouldNotBeNil)
 		taskCollection := newTaskCollection()
@@ -180,7 +191,8 @@ func TestTask(t *testing.T) {
 			})
 
 			Convey("Create another task and compare the id", func() {
-				task2 := newTask(sch, wf, newWorkManager(), &mockMetricManager{}, emitter)
+				task2, err := newTask(sch, wf, newWorkManager(), &mockMetricManager{}, emitter)
+				So(err, ShouldBeNil)
 				So(task2.id, ShouldNotEqual, task.ID())
 			})
 

--- a/scheduler/wmap/string.go
+++ b/scheduler/wmap/string.go
@@ -74,6 +74,8 @@ func (p *ProcessWorkflowMapNode) String(pad string) string {
 	for k, v := range p.Config {
 		out += pad + "      " + fmt.Sprintf("%s=%+v\n", k, v)
 	}
+	out += pad + "   Target:" + p.Target + "\n"
+
 	out += pad + "   Process Nodes:\n"
 	for _, pr := range p.ProcessNodes {
 		out += pr.String(pad + "   ")

--- a/scheduler/wmap/wmap.go
+++ b/scheduler/wmap/wmap.go
@@ -171,6 +171,13 @@ func (c *CollectWorkflowMapNode) GetMetrics() []Metric {
 	return metrics
 }
 
+func NewCollectWorkflowMapNode() *CollectWorkflowMapNode {
+	return &CollectWorkflowMapNode{
+		Metrics: make(map[string]metricInfo),
+		Config:  make(map[string]map[string]interface{}),
+	}
+}
+
 // GetConfigTree converts config data for collection node in wmap into a proper cdata.ConfigDataTree
 func (c *CollectWorkflowMapNode) GetConfigTree() (*cdata.ConfigDataTree, error) {
 	cdt := cdata.NewTree()
@@ -224,6 +231,7 @@ type ProcessWorkflowMapNode struct {
 	PublishNodes []PublishWorkflowMapNode `json:"publish,omitempty"yaml:"publish"`
 	// TODO processor config
 	Config map[string]interface{} `json:"config,omitempty"yaml:"config"`
+	Target string                 `json:"target"yaml:"target"`
 }
 
 func NewProcessNode(name string, version int) *ProcessWorkflowMapNode {
@@ -265,6 +273,7 @@ type PublishWorkflowMapNode struct {
 	Version int    `json:"plugin_version"yaml:"plugin_version"`
 	// TODO publisher config
 	Config map[string]interface{} `json:"config,omitempty"yaml:"config"`
+	Target string                 `json:"target"yaml:"target"`
 }
 
 func NewPublishNode(name string, version int) *PublishWorkflowMapNode {


### PR DESCRIPTION
Summary of changes:
- Added optional field to nodes in a task workflow, "target". This is a `hostname:port` field which gives the address of a remote target to execute this stage of the workflow against. If not filled out the implied control instance is the local control.

- Added checks for control being started to collect/process/publish metrics in control to help making testing of a 'dead' (i.e. stopped) control instance easier.

- Added the ability for a task to deal with remote steps in a workflow. It does this by, on task creation, walking the workflow and creating controlproxy clients to speak to all the remote nodes in the workflow. All dependency management (subscribe/unsubscribedeps) as well as content type checks have been updated to also check remote dependencies.

Testing done:
- Manual testing of task manifest that span multiple control instances.
- Tests added to scheduler/distributed_task_test.go

@intelsdi-x/snap-maintainers
