### PR TITLE
Refactored methods on core.Namespace: Strings() and String()

### DIFF
--- a/control/metrics.go
+++ b/control/metrics.go
@@ -409,18 +409,15 @@ func (mc *metricCatalog) Get(ns core.Namespace, version int) (*metricType, error
 func (mc *metricCatalog) GetVersions(ns core.Namespace) ([]*metricType, error) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
-	return mc.getVersions(strings.Split(ns.String(), "/"))
+	return mc.getVersions(ns.Strings())
 }
 
 // Fetch transactionally retrieves all metrics which fall under namespace ns
 func (mc *metricCatalog) Fetch(ns core.Namespace) ([]*metricType, error) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
-	var nss []string
-	if ns.String() != "/" {
-		nss = ns.Strings()
-	}
-	mtsi, err := mc.tree.Fetch(nss)
+
+	mtsi, err := mc.tree.Fetch(ns.Strings())
 	if err != nil {
 		log.WithFields(log.Fields{
 			"_module": "control",

--- a/core/metric.go
+++ b/core/metric.go
@@ -50,20 +50,18 @@ type Namespace []NamespaceElement
 // String returns the string representation of the namespace with "/" joining
 // the elements of the namespace.  A leading "/" is added.
 func (n Namespace) String() string {
-	ns := "/"
-	for i, x := range n {
-		ns += x.Value
-		if i != len(n)-1 {
-			ns += "/"
-		}
-	}
-	return ns
+	ns := n.Strings()
+	return "/" + strings.Join(ns, "/")
 }
 
 // Strings returns an array of strings that represent the elements of the
 // namespace.
 func (n Namespace) Strings() []string {
-	return strings.Split(strings.TrimPrefix(n.String(), "/"), "/")
+	var ns []string
+	for _, namespaceElement := range n {
+		ns = append(ns, namespaceElement.Value)
+	}
+	return ns
 }
 
 // Key returns a string representation of the namespace with "." joining


### PR DESCRIPTION
**Before:**
even `len(ns)` was 0, `len(ns.Strings())` was 1

**Now:**
when `len(ns)` is 0, `len(ns.Strings())` also equals 0 and something like below in Fetch() is no more needed:
```
var nss []string
-	if ns.String() != "/" {
-		nss = ns.Strings()
-	}
-	mtsi, err := mc.tree.Fetch(nss)
```

[*] where`ns` is a metric namespace (core.Namespace type)


### Summary of changes:
- refactored methods on core.Namespace: Strings() and String()
- the fragment `strings.Split(ns.String(), "/")` was replaced with `ns.Strings()` 
 
### Testing done:
- run task /examples/task/mock-file.json with mock1 plugin
- checking output from `snapctl metric list` command which calls `Fetch()` 




@intelsdi-x/snap-maintainers

