### PR TITLE
Fixes #889 - Moves the setting of the log level for snapd into an earlier call.

### DIFF
--- a/snapd.go
+++ b/snapd.go
@@ -221,6 +221,10 @@ func action(ctx *cli.Context) {
 	// same variables in that configuration
 	applyCmdLineFlags(cfg, ctx)
 
+	// Switch log level to user defined
+	log.Info("setting log level to: ", l[cfg.LogLevel])
+	log.SetLevel(getLevel(cfg.LogLevel))
+
 	// If logPath is set, we verify the logPath and set it so that all logging
 	// goes to the log file instead of stdout.
 	logPath := cfg.LogPath
@@ -506,10 +510,6 @@ func action(ctx *cli.Context) {
 			"block":   "main",
 			"_module": "snapd",
 		}).Info("snapd started")
-
-	// Switch log level to user defined
-	log.Info("setting log level to: ", l[cfg.LogLevel])
-	log.SetLevel(getLevel(cfg.LogLevel))
 
 	select {} //run forever and ever
 }


### PR DESCRIPTION
Fixes #889

Summary of changes:
- The logrus log level was being set after many of the initial startup calls that log are made.
- This fix just moves the log level setting to just after both command line flags and configuration file are loaded.

Testing done:
- Validation that logging outputs correctly.

@intelsdi-x/snap-maintainers

