### PR TITLE
Fixes #891: Remove plugin object dump

### DIFF
--- a/snapd.go
+++ b/snapd.go
@@ -488,7 +488,7 @@ func action(ctx *cli.Context) {
 							"_block":           "main",
 							"_module":          "snapd",
 							"autodiscoverpath": fullPath,
-							"plugin":           file,
+							"plugin-file-name": file.Name(),
 							"plugin-name":      pl.Name(),
 							"plugin-version":   pl.Version(),
 							"plugin-type":      pl.TypeName(),


### PR DESCRIPTION
Fixes #891

Summary of changes:
- When autodiscover plugins were loaded the log would print the object dump for the file object instead of the filename. Modified this output to instead print the filename.

Example output:

`INFO[0000] Loading plugin                                _block=main _module=snapd autodiscoverpath=/Users/crosebor/go/src/github.com/intelsdi-x/snap/build/plugin plugin-file-name=snap-processor-passthru plugin-name=passthru plugin-type=processor plugin-version=1`
@intelsdi-x/snap-maintainers