### PR TITLE
Improves error handling when parsing the global config file

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -6,6 +6,18 @@
 	],
 	"Deps": [
 		{
+			"ImportPath": "github.com/xeipuuv/gojsonpointer",
+			"Rev": "e0fe6f68307607d540ed8eac07a342c33fa1b54a"
+		},
+		{
+			"ImportPath": "github.com/xeipuuv/gojsonreference",
+			"Rev": "e02fc20de94c78484cd5ffb007f8af96be030a45"
+		},
+		{
+			"ImportPath": "github.com/xeipuuv/gojsonschema",
+			"Rev": "d3178baac32433047aa76f07317f84fbe2be6cda"
+		},
+		{
 			"ImportPath": "github.com/Sirupsen/logrus",
 			"Comment": "v0.7.3",
 			"Rev": "55eb11d21d2a31a3cc93838241d04800f52e823d"

--- a/control/config.go
+++ b/control/config.go
@@ -103,23 +103,23 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "max_running_plugins":
 			if err := json.Unmarshal(v, &(c.MaxRunningPlugins)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'control::max_running_plugins')", err)
 			}
 		case "plugin_trust_level":
 			if err := json.Unmarshal(v, &(c.PluginTrust)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'control::plugin_trust_level')", err)
 			}
 		case "auto_discover_path":
 			if err := json.Unmarshal(v, &(c.AutoDiscoverPath)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'control::auto_discover_path')", err)
 			}
 		case "keyring_paths":
 			if err := json.Unmarshal(v, &(c.KeyringPaths)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'control::keyring_paths')", err)
 			}
 		case "cache_expiration":
 			if err := json.Unmarshal(v, &(c.CacheExpiration)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'control::cache_expiration')", err)
 			}
 		case "plugins":
 			if err := json.Unmarshal(v, c.Plugins); err != nil {

--- a/control/config.go
+++ b/control/config.go
@@ -75,6 +75,40 @@ type Config struct {
 	Plugins           *pluginConfig     `json:"plugins,omitempty"yaml:"plugins,omitempty"`
 }
 
+const (
+	CONFIG_CONSTRAINTS = `
+			"control" : {
+				"type": ["object", "null"],
+				"properties": {
+					"plugin_trust_level": {
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 2
+					},
+					"auto_discover_path": {
+						"type": "string"
+					},
+					"cache_expiration": {
+						"type": "string"
+					},
+					"max_running_plugins": {
+						"type": "integer",
+						"minimum": 1
+					},
+					"keyring_paths" : {
+						"type": "string"
+					},
+					"plugins": {
+						"type": ["object", "null"],
+						"properties" : {},
+						"additionalProperties": true
+					}
+				},
+				"additionalProperties": false
+			}
+	`
+)
+
 // get the default snapd configuration
 func GetDefaultConfig() *Config {
 	return &Config{

--- a/control/config.go
+++ b/control/config.go
@@ -125,6 +125,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, c.Plugins); err != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("Unrecognized key '%v' in global config file while parsing 'control'", k)
 		}
 	}
 	return nil

--- a/control/config_test.go
+++ b/control/config_test.go
@@ -30,6 +30,24 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	MOCK_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "snapd global config schema",
+		"type": ["object", "null"],
+		"properties": {
+			"control": { "$ref": "#/definitions/control" },
+			"scheduler": { "$ref": "#/definitions/scheduler"},
+			"restapi" : { "$ref": "#/definitions/restapi"},
+			"tribe": { "$ref": "#/definitions/tribe"}
+		},
+		"additionalProperties": true,
+		"definitions": { ` +
+		CONFIG_CONSTRAINTS + `,` + `"scheduler": {}, "restapi": {}, "tribe":{}` +
+		`}` +
+		`}`
+)
+
 type mockConfig struct {
 	Control *Config
 }
@@ -68,7 +86,7 @@ func TestPluginConfig(t *testing.T) {
 			Control: GetDefaultConfig(),
 		}
 		path := "../examples/configs/snap-config-sample.json"
-		err := cfgfile.Read(path, &config)
+		err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 		So(err, ShouldBeNil)
 		cfg := config.Control
 		So(cfg.Plugins, ShouldNotBeNil)
@@ -124,7 +142,7 @@ func TestControlConfigJSON(t *testing.T) {
 		Control: GetDefaultConfig(),
 	}
 	path := "../examples/configs/snap-config-sample.json"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Control
@@ -187,7 +205,7 @@ func TestControlConfigYaml(t *testing.T) {
 		Control: GetDefaultConfig(),
 	}
 	path := "../examples/configs/snap-config-sample.yaml"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Control

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -64,6 +64,24 @@ var (
 	UploadCount      = 0
 )
 
+const (
+	MOCK_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "snapd global config schema",
+		"type": ["object", "null"],
+		"properties": {
+			"control": { "$ref": "#/definitions/control" },
+			"scheduler": { "$ref": "#/definitions/scheduler"},
+			"restapi" : { "$ref": "#/definitions/restapi"},
+			"tribe": { "$ref": "#/definitions/tribe"}
+		},
+		"additionalProperties": true,
+		"definitions": { ` +
+		`"control": {}, "scheduler": {}, ` + CONFIG_CONSTRAINTS + `, "tribe":{}` +
+		`}` +
+		`}`
+)
+
 type restAPIInstance struct {
 	port   int
 	server *Server
@@ -560,7 +578,7 @@ func TestPluginRestCalls(t *testing.T) {
 			})
 			Convey("Plugin config is set at startup", func() {
 				cfg := getDefaultMockConfig()
-				err := cfgfile.Read("../../examples/configs/snap-config-sample.json", &cfg)
+				err := cfgfile.Read("../../examples/configs/snap-config-sample.json", &cfg, MOCK_CONSTRAINTS)
 				So(err, ShouldBeNil)
 				r := startAPI(cfg)
 				port := r.port

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -200,31 +200,31 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "enable":
 			if err := json.Unmarshal(v, &(c.Enable)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::enable')", err)
 			}
 		case "port":
 			if err := json.Unmarshal(v, &(c.Port)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::port')", err)
 			}
 		case "https":
 			if err := json.Unmarshal(v, &(c.HTTPS)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::https')", err)
 			}
 		case "rest_certificate":
 			if err := json.Unmarshal(v, &(c.RestCertificate)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::rest_certificate')", err)
 			}
 		case "rest_key":
 			if err := json.Unmarshal(v, &(c.RestKey)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::rest_key')", err)
 			}
 		case "rest_auth":
 			if err := json.Unmarshal(v, &(c.RestAuth)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::rest_auth')", err)
 			}
 		case "rest_auth_password":
 			if err := json.Unmarshal(v, &(c.RestAuthPassword)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'restapi::rest_auth_password')", err)
 			}
 		}
 	}

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -80,6 +80,40 @@ type Config struct {
 	RestAuthPassword string `json:"rest_auth_password,omitempty"yaml:"rest_auth_password,omitempty"`
 }
 
+const (
+	CONFIG_CONSTRAINTS = `
+			"restapi" : {
+				"type": ["object", "null"],
+				"properties" : {
+					"enable": {
+						"type": "boolean"
+					},
+					"https" : {
+						"type": "boolean"
+					},
+					"rest_auth": {
+						"type": "boolean"
+					},
+					"rest_auth_password": {
+						"type": "string"
+					},
+					"rest_certificate": {
+						"type": "string"
+					},
+					"rest_key" : {
+						"type": "string"
+					},
+					"port" : {
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 65535
+					}
+				},
+				"additionalProperties": false
+			}
+	`
+)
+
 type managesMetrics interface {
 	MetricCatalog() ([]core.CatalogedMetric, error)
 	FetchMetrics(core.Namespace, int) ([]core.CatalogedMetric, error)

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -226,6 +226,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, &(c.RestAuthPassword)); err != nil {
 				return fmt.Errorf("%v (while parsing 'restapi::rest_auth_password')", err)
 			}
+		default:
+			return fmt.Errorf("Unrecognized key '%v' in global config file while parsing 'restapi'", k)
 		}
 	}
 	return nil

--- a/mgmt/rest/server_test.go
+++ b/mgmt/rest/server_test.go
@@ -35,7 +35,7 @@ func TestRestAPIConfigJSON(t *testing.T) {
 		RestAPI: GetDefaultConfig(),
 	}
 	path := "../../examples/configs/snap-config-sample.json"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.RestAPI
@@ -74,7 +74,7 @@ func TestRestAPIConfigYaml(t *testing.T) {
 		RestAPI: GetDefaultConfig(),
 	}
 	path := "../../examples/configs/snap-config-sample.yaml"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.RestAPI

--- a/mgmt/tribe/config.go
+++ b/mgmt/tribe/config.go
@@ -21,6 +21,7 @@ package tribe
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"time"
@@ -93,23 +94,23 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "name":
 			if err := json.Unmarshal(v, &(c.Name)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'tribe::name')", err)
 			}
 		case "enable":
 			if err := json.Unmarshal(v, &(c.Enable)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'tribe::enable')", err)
 			}
 		case "bind_addr":
 			if err := json.Unmarshal(v, &(c.BindAddr)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'tribe::bind_addr')", err)
 			}
 		case "bind_port":
 			if err := json.Unmarshal(v, &(c.BindPort)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'tribe::bind_port')", err)
 			}
 		case "seed":
 			if err := json.Unmarshal(v, &(c.Seed)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'tribe::seed')", err)
 			}
 		}
 	}

--- a/mgmt/tribe/config.go
+++ b/mgmt/tribe/config.go
@@ -112,6 +112,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, &(c.Seed)); err != nil {
 				return fmt.Errorf("%v (while parsing 'tribe::seed')", err)
 			}
+		default:
+			return fmt.Errorf("Unrecognized key '%v' in global config file while parsing 'tribe'", k)
 		}
 	}
 	return nil

--- a/mgmt/tribe/config.go
+++ b/mgmt/tribe/config.go
@@ -59,6 +59,34 @@ type Config struct {
 	RestAPIInsecureSkipVerify string             `json:"-"yaml:"-"`
 }
 
+const (
+	CONFIG_CONSTRAINTS = `
+			"tribe": {
+				"type": ["object", "null"],
+				"properties": {
+					"enable" : {
+						"type": "boolean"
+					},
+					"bind_addr": {
+						"type": "string"
+					},
+					"bind_port": {
+						"type": "integer",
+						"minimum": 0,
+						"maximum": 65535
+					},
+					"name": {
+						"type": "string"
+					},
+					"seed": {
+						"type" : "string"
+					}
+				},
+				"additionalProperties": false
+			}
+	`
+)
+
 // get the default snapd configuration
 func GetDefaultConfig() *Config {
 	mlCfg := memberlist.DefaultLANConfig()

--- a/mgmt/tribe/config_test.go
+++ b/mgmt/tribe/config_test.go
@@ -27,6 +27,24 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	MOCK_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "snapd global config schema",
+		"type": ["object", "null"],
+		"properties": {
+			"control": { "$ref": "#/definitions/control" },
+			"scheduler": { "$ref": "#/definitions/scheduler"},
+			"restapi" : { "$ref": "#/definitions/restapi"},
+			"tribe": { "$ref": "#/definitions/tribe"}
+		},
+		"additionalProperties": true,
+		"definitions": { ` +
+		`"control": {}, "scheduler": {}, "restapi":{}, ` + CONFIG_CONSTRAINTS +
+		`}` +
+		`}`
+)
+
 type mockConfig struct {
 	Tribe *Config
 }
@@ -36,7 +54,7 @@ func TestTribeConfigJSON(t *testing.T) {
 		Tribe: GetDefaultConfig(),
 	}
 	path := "../../examples/configs/snap-config-sample.json"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Tribe
@@ -69,7 +87,7 @@ func TestTribeConfigYaml(t *testing.T) {
 		Tribe: GetDefaultConfig(),
 	}
 	path := "../../examples/configs/snap-config-sample.yaml"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Tribe

--- a/pkg/cfgfile/cfgfile.go
+++ b/pkg/cfgfile/cfgfile.go
@@ -20,28 +20,33 @@ limitations under the License.
 package cfgfile
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/ghodss/yaml"
 )
 
-//
+// Read an input configuration file, parsing it (as YAML or JSON)
+// into the input 'interface{}'', v
 func Read(path string, v interface{}) error {
 	// read bytes from file
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
-
-	// Try to unmarshal the byte array, first in YAML, then JSON. If both
-	// fail to unmarshal the blob read above, then return an error.
-	if err := yaml.Unmarshal(b, v); err == nil {
-		return nil
+	// parse the byte-stream read (above); Note that we can parse both JSON
+	// and YAML using the same yaml.Unmarshal() method since a JSON string is
+	// a valid YAML string (but the converse is not true)
+	if parseErr := yaml.Unmarshal(b, v); parseErr != nil {
+		// remove any YAML-specific prefix that might have been added by then
+		// yaml.Unmarshal() method or JSON-specific prefix that might have been
+		// added if the resulting JSON string could not be marshalled into our
+		// input interface correctly (note, if there is no match to either of
+		// these prefixes then the error message will be passed through unchanged)
+		tmpErr := strings.TrimPrefix(parseErr.Error(), "error converting YAML to JSON: yaml: ")
+		errRet := strings.TrimPrefix(tmpErr, "error unmarshaling JSON: json: ")
+		return fmt.Errorf("Error while parsing configuration file: %v", errRet)
 	}
-	if err := json.Unmarshal(b, v); err == nil {
-		return nil
-	}
-	return fmt.Errorf("Unknown file type")
+	return nil
 }

--- a/pkg/cfgfile/cfgfile_test.go
+++ b/pkg/cfgfile/cfgfile_test.go
@@ -29,6 +29,23 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	MOCK_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "test schema",
+		"type": ["object", "null"],
+		"properties": {
+			"Foo": {
+				"type": "string"
+			},
+			"Bar": {
+				"type": "string"
+			}
+		}
+	}
+	`
+)
+
 type testConfig struct {
 	Foo string
 	Bar string
@@ -85,7 +102,7 @@ func TestReadConfig(t *testing.T) {
 
 	Convey("Unmarshal yaml file", t, func() {
 		config := testConfig{}
-		err := Read(yamlFile, &config)
+		err := Read(yamlFile, &config, MOCK_CONSTRAINTS)
 		So(err, ShouldBeNil)
 		So(config.Foo, ShouldResemble, "Tom")
 		So(config.Bar, ShouldResemble, "Justin")
@@ -93,7 +110,7 @@ func TestReadConfig(t *testing.T) {
 
 	Convey("Unmarshal json file", t, func() {
 		config := testConfig{}
-		err := Read(jsonFile, &config)
+		err := Read(jsonFile, &config, MOCK_CONSTRAINTS)
 		So(err, ShouldBeNil)
 		So(config.Foo, ShouldResemble, "Tom")
 		So(config.Bar, ShouldResemble, "Justin")

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -19,7 +19,10 @@ limitations under the License.
 
 package scheduler
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // default configuration values
 const (
@@ -60,11 +63,11 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "work_manager_queue_size":
 			if err := json.Unmarshal(v, &(c.WorkManagerQueueSize)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'scheduler::work_manager_queue_size')", err)
 			}
 		case "work_manager_pool_size":
 			if err := json.Unmarshal(v, &(c.WorkManagerPoolSize)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'scheduler::work_manager_pool_size')", err)
 			}
 		}
 	}

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -69,6 +69,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, &(c.WorkManagerPoolSize)); err != nil {
 				return fmt.Errorf("%v (while parsing 'scheduler::work_manager_pool_size')", err)
 			}
+		default:
+			return fmt.Errorf("Unrecognized key '%v' in global config file while parsing 'scheduler'", k)
 		}
 	}
 	return nil

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -39,6 +39,25 @@ type Config struct {
 	WorkManagerPoolSize  uint `json:"work_manager_pool_size,omitempty"yaml:"work_manager_pool_size,omitempty"`
 }
 
+const (
+	CONFIG_CONSTRAINTS = `
+			"scheduler": {
+				"type": ["object", "null"],
+				"properties" : {
+					"work_manager_queue_size" : {
+						"type": "integer",
+						"minimum": 1
+					},
+					"work_manager_pool_size" : {
+						"type": "integer",
+						"minimum": 1
+					}
+				},
+				"additionalProperties": false
+			}
+	`
+)
+
 // get the default snapd configuration
 func GetDefaultConfig() *Config {
 	return &Config{

--- a/scheduler/config_test.go
+++ b/scheduler/config_test.go
@@ -26,6 +26,24 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const (
+	MOCK_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "snapd global config schema",
+		"type": ["object", "null"],
+		"properties": {
+			"control": { "$ref": "#/definitions/control" },
+			"scheduler": { "$ref": "#/definitions/scheduler"},
+			"restapi" : { "$ref": "#/definitions/restapi"},
+			"tribe": { "$ref": "#/definitions/tribe"}
+		},
+		"additionalProperties": true,
+		"definitions": { ` +
+		`"control": {}, ` + CONFIG_CONSTRAINTS + `, "restapi": {}, "tribe":{}` +
+		`}` +
+		`}`
+)
+
 type mockConfig struct {
 	Scheduler *Config
 }
@@ -35,7 +53,7 @@ func TestSchedulerConfigJSON(t *testing.T) {
 		Scheduler: GetDefaultConfig(),
 	}
 	path := "../examples/configs/snap-config-sample.json"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Scheduler
@@ -59,7 +77,7 @@ func TestSchedulerConfigYaml(t *testing.T) {
 		Scheduler: GetDefaultConfig(),
 	}
 	path := "../examples/configs/snap-config-sample.yaml"
-	err := cfgfile.Read(path, &config)
+	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config
 	if err == nil {
 		cfg = config.Scheduler

--- a/snapd.go
+++ b/snapd.go
@@ -722,15 +722,15 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		switch k {
 		case "log_level":
 			if err := json.Unmarshal(v, &(c.LogLevel)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'log_level')", err)
 			}
 		case "gomaxprocs":
 			if err := json.Unmarshal(v, &(c.GoMaxProcs)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'gomaxprocs')", err)
 			}
 		case "log_path":
 			if err := json.Unmarshal(v, &(c.LogPath)); err != nil {
-				return err
+				return fmt.Errorf("%v (while parsing 'log_path')", err)
 			}
 		case "control":
 			if err := json.Unmarshal(v, c.Control); err != nil {

--- a/snapd.go
+++ b/snapd.go
@@ -161,6 +161,42 @@ type Config struct {
 	Tribe      *tribe.Config     `json:"tribe,omitempty"yaml:"tribe,omitempty"`
 }
 
+const (
+	CONFIG_CONSTRAINTS = `{
+		"$schema": "http://json-schema.org/draft-04/schema#",
+		"title": "snapd global config schema",
+		"type": ["object", "null"],
+		"properties": {
+			"log_level": {
+				"description": "log verbosity level for snapd. Range between 1: debug, 2: info, 3: warning, 4: error, 5: fatal",
+				"type": "integer",
+				"minimum": 1,
+				"maximum": 5
+			},
+			"log_path": {
+				"description": "path to log file for snapd to use",
+				"type": "string"
+			},
+			"gomaxprocs": {
+				"description": "value to be used for gomaxprocs",
+				"type": "integer",
+				"minimum": 1
+			},
+			"control": { "$ref": "#/definitions/control" },
+			"scheduler": { "$ref": "#/definitions/scheduler"},
+			"restapi" : { "$ref": "#/definitions/restapi"},
+			"tribe": { "$ref": "#/definitions/tribe"}
+		},
+		"additionalProperties": false,
+		"definitions": { ` +
+		control.CONFIG_CONSTRAINTS + `,` +
+		scheduler.CONFIG_CONSTRAINTS + `,` +
+		rest.CONFIG_CONSTRAINTS + `,` +
+		tribe.CONFIG_CONSTRAINTS +
+		`}` +
+		`}`
+)
+
 type coreModule interface {
 	Start() error
 	Stop()
@@ -551,9 +587,12 @@ func readConfig(cfg *Config, fpath string) {
 		path = fpath
 	}
 
-	err := cfgfile.Read(path, &cfg)
-	if err != nil {
-		log.Fatal(err)
+	serrs := cfgfile.Read(path, &cfg, CONFIG_CONSTRAINTS)
+	if serrs != nil {
+		for _, serr := range serrs {
+			log.WithFields(serr.Fields()).Error(serr.Error())
+		}
+		log.Fatal("Errors found while parsing global configuration file")
 	}
 }
 

--- a/snapd.go
+++ b/snapd.go
@@ -748,6 +748,8 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, c.Tribe); err != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("Unrecognized key '%v' in global config file", k)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #897 and #898

Summary of changes:
- Improves error handling for both malformed YAML/JSON files and YAML/JSON files that cannot be parsed into our global configuration struct for some other reason (incorrect value types, for example)
- Adds error handling that catches and reports errors when unrecognized keys are detected while parsing the global configuration file

Testing done:
- Tested with a number of malformed YAML and JSON configuration files, configuration files with unrecognized keys, and configuration files that contain incorrect value types (a boolean where an integer is expected, for example) to ensure that all of these types of errors are caught and reported correctly.

With these changes in place, I believe that both of these issues can be considered resolved. We have discussed adding the ability to validate a global configuration file against an externally defined schema as part of Issue #898, but I think this feature would best be done by adding an additional option to the `snapctl` command (and the `snapd` RESTful API) that can be used to check the configuration file (rather than attempting to validate the global configuration file using an externally defined schema), but I could be convinced otherwise if others feel strongly that such validation needs to be added to this pull request before it can be merged.

It should also be noted that the parsing of the section of the global configuration file containing the options for the various plugins (in the `plugins` section under the `control` section of the global configuration file) remains unchanged by this pull request. The dynamic nature of that part of the configuration file makes the sort of error checking we've been adding here (and in the previous pull requests we've done around this global configuration file) a difficult task.

@intelsdi-x/snap-maintainers
