### PR TITLE
Fixes #901: mock2 doesn't update wildcard value

### DIFF
--- a/plugin/collector/snap-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-collector-mock2/mock/mock.go
@@ -54,11 +54,12 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 	metrics := []plugin.MetricType{}
 	for i := range mts {
 		if c, ok := mts[i].Config().Table()["panic"]; ok && c.(ctypes.ConfigValueBool).Value {
-			panic("Opps!")
+			panic("Oops!")
 		}
 		if mts[i].Namespace()[2].Value == "*" {
 			for j := 0; j < 10; j++ {
-				ns := mts[i].Namespace()
+				ns := make([]core.NamespaceElement, len(mts[i].Namespace()))
+				copy(ns, mts[i].Namespace())
 				ns[2].Value = fmt.Sprintf("host%d", j)
 				data := randInt(65, 90)
 				mt := plugin.MetricType{


### PR DESCRIPTION
Fixes #901 

Summary of changes:
- Make copy of namespace

Testing done:
- Created task with mock2 and looked at file output.
Before:
```
tail /tmp/snap_published_mock_file_orig.log    ✭
2016-05-05 16:32:31.945949686 -0700 PDT|/intel/mock/host9/baz|83
2016-05-05 16:32:31.945950847 -0700 PDT|/intel/mock/host9/baz|89
2016-05-05 16:32:31.945951236 -0700 PDT|/intel/mock/host9/baz|67
2016-05-05 16:32:31.945952907 -0700 PDT|/intel/mock/host9/baz|71
2016-05-05 16:32:31.945953295 -0700 PDT|/intel/mock/host9/baz|68
2016-05-05 16:32:31.945953668 -0700 PDT|/intel/mock/host9/baz|80
2016-05-05 16:32:31.945954072 -0700 PDT|/intel/mock/host9/baz|72
2016-05-05 16:32:31.945955032 -0700 PDT|/intel/mock/host9/baz|88
2016-05-05 16:32:31.94595542 -0700 PDT|/intel/mock/host9/baz|83
2016-05-05 16:32:31.945955808 -0700 PDT|/intel/mock/host9/baz|83
```
After:
```
tail /tmp/snap_published_mock_file.log   130 ↵ ✭
2016-05-05 16:44:53.121801654 -0700 PDT|/intel/mock/host2/baz|89
2016-05-05 16:44:53.121802752 -0700 PDT|/intel/mock/host3/baz|78
2016-05-05 16:44:53.121803272 -0700 PDT|/intel/mock/host4/baz|70
2016-05-05 16:44:53.121809668 -0700 PDT|/intel/mock/host5/baz|85
2016-05-05 16:44:53.121810209 -0700 PDT|/intel/mock/host6/baz|65
2016-05-05 16:44:53.121810687 -0700 PDT|/intel/mock/host7/baz|87
2016-05-05 16:44:53.121811158 -0700 PDT|/intel/mock/host8/baz|87
2016-05-05 16:44:53.121812339 -0700 PDT|/intel/mock/host9/baz|78
2016-05-05 16:44:53.121812867 -0700 PDT|/intel/mock/bar|88
```

@intelsdi-x/snap-maintainers
