### PR TITLE
Support specifying an instance of dynamic metric as requested metric in task manifest

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -359,6 +359,13 @@ func (ap *availablePlugins) getPool(key string) (strategy.Pool, serror.SnapError
 	return pool, nil
 }
 
+func (ap *availablePlugins) hasPool(key string) bool {
+	if pool, _ := ap.getPool(key); pool != nil {
+		return true
+	}
+	return false
+}
+
 func (ap *availablePlugins) collectMetrics(pluginKey string, metricTypes []core.Metric, taskID string) ([]core.Metric, error) {
 	var results []core.Metric
 	pool, serr := ap.getPool(pluginKey)

--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -84,6 +84,10 @@ func TestAvailablePlugins(t *testing.T) {
 
 			pool, err := aps.getPool("collector:test:1")
 			So(err, ShouldBeNil)
+
+			status := aps.hasPool("collector:test:1")
+			So(status, ShouldBeTrue)
+
 			nap, ok := pool.Plugins()[ap.id]
 			So(ok, ShouldBeTrue)
 			So(nap, ShouldEqual, ap)
@@ -98,6 +102,9 @@ func TestAvailablePlugins(t *testing.T) {
 			err := aps.insert(ap)
 
 			So(err, ShouldResemble, errors.New("bad plugin type"))
+
+			status := aps.hasPool("collector:test:1")
+			So(status, ShouldBeFalse)
 		})
 	})
 	Convey("it returns an error if client cannot be created", t, func() {

--- a/control/mttrie.go
+++ b/control/mttrie.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@ limitations under the License.
 package control
 
 import (
-	"errors"
 	"fmt"
-	"strings"
+	"sort"
 )
 
 /*
@@ -49,9 +48,6 @@ FETCH /metric/root/foo -> trie.Fetch([]string{"root", "foo"}) ->
     [a,b]
 
 */
-
-// ErrNotFound is returned when Get cannot find the given namespace
-var ErrNotFound = errors.New("metric not found")
 
 type mttNode struct {
 	children map[string]*mttNode
@@ -82,11 +78,11 @@ func (m *MTTrie) String() string {
 
 func (m *MTTrie) gatherMetricTypes() []metricType {
 	var mts []metricType
-	var children []*mttNode
+	var descendants []*mttNode
 	for _, node := range m.children {
-		children = gatherChildren(children, node)
+		descendants = gatherDescendants(descendants, node)
 	}
-	for _, c := range children {
+	for _, c := range descendants {
 		for _, mt := range c.mts {
 			mts = append(mts, *mt)
 		}
@@ -110,15 +106,14 @@ func (m *MTTrie) RemoveMetric(mt metricType) {
 	if a != nil {
 		for v, x := range a.mts {
 			if mt.Version() == x.Version() {
-				// Delete the metric from the node
+				// delete this metric from the node
 				delete(a.mts, v)
 			}
 		}
 	}
 }
 
-// Add adds a node with the given namespace with the
-// given MetricType
+// Add adds a node with the given namespace with the given MetricType
 func (mtt *mttNode) Add(mt *metricType) {
 	ns := mt.Namespace()
 	node, index := mtt.walk(ns.Strings())
@@ -145,9 +140,107 @@ func (mtt *mttNode) Add(mt *metricType) {
 // Fetch collects all children below a given namespace
 // and concatenates their metric types into a single slice
 func (mtt *mttNode) Fetch(ns []string) ([]*metricType, error) {
+	children := mtt.fetch(ns)
+	var mts []*metricType
+	for _, child := range children {
+		for _, mt := range child.mts {
+			mts = append(mts, mt)
+		}
+	}
+	if len(mts) == 0 {
+		return nil, errorFetchMetricsNotFound(ns)
+	}
+	return mts, nil
+}
+
+// Remove removes all descendants nodes below a given namespace
+func (mtt *mttNode) Remove(ns []string) error {
+	_, err := mtt.find(ns)
+	if err != nil {
+		return err
+	}
+
+	parent, err := mtt.find(ns[:len(ns)-1])
+	if err != nil {
+		return err
+	}
+
+	delete(parent.children, ns[len(ns)-1:][0])
+
+	return nil
+}
+
+// GetMetric works like fetch, but only returns the MT at the given node
+// in the queried version (or in the latest if ver < 1) and does NOT gather the node's children.
+func (mtt *mttNode) GetMetric(ns []string, ver int) (*metricType, error) {
 	node, err := mtt.find(ns)
 	if err != nil {
 		return nil, err
+	}
+
+	mt, err := getVersion(node.mts, ver)
+	if err != nil {
+		return nil, errorMetricNotFound(ns, ver)
+	}
+
+	return mt, nil
+}
+
+// GetMetrics returns all MTs at the given namespace in the queried version (or in the latest if ver < 1)
+// and does gather all the node's descendants if the namespace ends with an asterisk
+func (mtt *mttNode) GetMetrics(ns []string, ver int) ([]*metricType, error) {
+	nodes := []*mttNode{}
+	mts := []*metricType{}
+
+	// search returns all of the nodes fulfilling the 'ns'
+	// even for some of them there is no metric (empty node.mts)
+	nodes = mtt.search(nodes, ns)
+
+	for _, node := range nodes {
+		// choose the queried version of metric types (or the latest if ver < 1)
+		// and concatenate them into a single slice
+		mt, err := getVersion(node.mts, ver)
+
+		if err != nil {
+			continue
+		}
+
+		mts = append(mts, mt)
+	}
+
+	if len(mts) == 0 {
+		return nil, errorMetricNotFound(ns, ver)
+	}
+
+	return mts, nil
+}
+
+// GetVersions returns all versions of MTs below the given namespace
+func (mtt *mttNode) GetVersions(ns []string) ([]*metricType, error) {
+	var nodes []*mttNode
+	var mts []*metricType
+
+	nodes = mtt.search(nodes, ns)
+
+	for _, node := range nodes {
+		// concatenates metric types in ALL versions into a single slice
+		for _, mt := range node.mts {
+			mts = append(mts, mt)
+		}
+	}
+
+	if len(mts) == 0 {
+		return nil, errorMetricNotFound(ns)
+	}
+
+	return mts, nil
+}
+
+// fetch collects all descendants nodes below the given namespace
+func (mtt *mttNode) fetch(ns []string) []*mttNode {
+	node, err := mtt.find(ns)
+	if err != nil {
+		return nil
 	}
 
 	var children []*mttNode
@@ -155,85 +248,151 @@ func (mtt *mttNode) Fetch(ns []string) ([]*metricType, error) {
 		children = append(children, node)
 	}
 	if node.children != nil {
-		children = gatherChildren(children, node)
+		children = gatherDescendants(children, node)
 	}
 
-	var mts []*metricType
-	for _, child := range children {
-		for _, mt := range child.mts {
-			mts = append(mts, mt)
-		}
-	}
-
-	return mts, nil
+	return children
 }
 
-// Remove removes all children below a given namespace
-func (mtt *mttNode) Remove(ns []string) error {
-	_, err := mtt.find(ns)
-	if err != nil {
-		return err
-	}
-
-	//remove node from parent
-	parent, err := mtt.find(ns[:len(ns)-1])
-	if err != nil {
-		return err
-	}
-	delete(parent.children, ns[len(ns)-1:][0])
-
-	return nil
-}
-
-// Get works like fetch, but only returns the MT at the given node
-// and does not gather the node's children.
-func (mtt *mttNode) Get(ns []string) ([]*metricType, error) {
-	node, err := mtt.find(ns)
-	if err != nil {
-		return nil, err
-	}
-	if node.mts == nil {
-		return nil, errorMetricNotFound("/" + strings.Join(ns, "/"))
-	}
-	var mts []*metricType
-	for _, mt := range node.mts {
-		mts = append(mts, mt)
-	}
-	return mts, nil
-}
-
-// walk returns the last leaf / branch present
-// in the trie and the index in the namespace that the last node exists.
+// walk returns the last leaf / branch present in the trie and the index in the namespace that the last node exists.
+// It is useful e.g. to locate the right place to add new metric type into tree with the given namespace
 func (mtt *mttNode) walk(ns []string) (*mttNode, int) {
 	parent := mtt
+
 	var pp *mttNode
 	for i, n := range ns {
 		if parent.children == nil {
 			return parent, i
 		}
+
 		pp = parent
 		parent = parent.children[n]
 		if parent == nil {
 			return pp, i
 		}
 	}
+
 	return parent, len(ns)
+}
+
+// search returns leaf nodes in the trie below the given namespace
+func (mtt *mttNode) search(nodes []*mttNode, ns []string) []*mttNode {
+	parent := mtt
+	var children []*mttNode
+
+	if parent.children == nil {
+		return nodes
+	}
+
+	if len(ns) == 1 {
+		// the last element of ns is under searching process
+
+		switch ns[0] {
+		case "*":
+			// fetch all descendants when wildcard ends namespace
+			children = parent.fetch([]string{})
+
+		default:
+			children = parent.gatherChildren(ns[0])
+		}
+
+		nodes = append(nodes, children...)
+		return nodes
+	}
+
+	children = parent.gatherChildren(ns[0])
+
+	for _, child := range children {
+		nodes = child.search(nodes, ns[1:])
+	}
+
+	return nodes
 }
 
 func (mtt *mttNode) find(ns []string) (*mttNode, error) {
 	node, index := mtt.walk(ns)
 	if index != len(ns) {
-		return nil, errorMetricNotFound("/" + strings.Join(ns, "/"))
+		return nil, errorMetricNotFound(ns)
 	}
 	return node, nil
 }
 
-func gatherChildren(children []*mttNode, node *mttNode) []*mttNode {
-	for _, child := range node.children {
-		if child.children != nil {
-			children = gatherChildren(children, child)
+// gatherChildren returns child or children by the 'name' of a given node (direct descendant(s))
+// and concatenates this direct descendant(s) into a single slice
+func (mtt *mttNode) gatherChildren(name string) []*mttNode {
+	var children []*mttNode
+	switch name {
+	case "*":
+		// name of child is unspecified, so gather all children
+		for _, child := range mtt.children {
+			children = append(children, child)
 		}
-		children = append(children, child)
+	default:
+		// gather a single child with specified name
+		child := mtt.children[name]
+
+		if child == nil {
+			// child with this name not exist; it might be specific instance of dynamic metric
+			// so, take child named with an asterisk
+			child = mtt.children["*"]
+
+		}
+
+		if child != nil {
+			children = append(children, child)
+		}
+
 	}
 	return children
+}
+
+// gatherDescendants returns all descendants of a given node
+func gatherDescendants(descendants []*mttNode, node *mttNode) []*mttNode {
+	for _, child := range node.children {
+
+		if child.mts != nil {
+			descendants = append(descendants, child)
+		}
+
+		if child.children != nil {
+			descendants = gatherDescendants(descendants, child)
+		}
+
+	}
+	return descendants
+}
+
+// getVersion returns the MT in the latest version
+func getLatest(mts map[int]*metricType) *metricType {
+	versions := []int{}
+
+	// version is a key in mts map
+	for ver := range mts {
+		// concatenates all available versions to a single slice
+		versions = append(versions, ver)
+	}
+
+	// sort and take the last element (the latest version)
+	sort.Ints(versions)
+	latestVersion := versions[len(versions)-1]
+
+	return mts[latestVersion]
+}
+
+// getVersion returns the MT in the queried version (or the latest if 'ver' < 1)
+func getVersion(mts map[int]*metricType, ver int) (*metricType, error) {
+	if len(mts) == 0 {
+		return nil, errMetricNotFound
+	}
+
+	if ver > 0 {
+		// a version IS given
+		if mt, exist := mts[ver]; exist {
+			return mt, nil
+		}
+		return nil, errMetricNotFound
+	}
+
+	// ver is less than or equal to 0 get the latest
+	return getLatest(mts), nil
 }

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -64,18 +64,46 @@ The workflow is a [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) wh
 
 #### collect
 
-The collect section describes which metrics to collect. Metrics can be enumerated explicitly via:
- - a concrete _namespace_
- - a wildcard, `*`
- - a tuple, `(m1|m2|m3)`
- 
-The tuple begins and ends with brackets and items inside are separeted by vertical bar. It works like logical `or`, so it gives an error only if none of these metrics can be collected.
+The collect section describes which metrics are requested to be collected.
 
-Metrics declared in task manifest | Collected metrics
-----------|----------|-----------
-/intel/mock/\* |  /intel/mock/foo <br/> /intel/mock/bar <br/> /intel/mock/\*/baz
-/intel/mock/(foo\|bar) |  /intel/mock/foo <br/> /intel/mock/bar <br/>
-/intel/mock/\*/baz |  /intel/mock/\*/baz
+Metrics can be enumerated explicitly via using:
+
+ a) **concrete _namespace_**
+
+Declaring the same metric's name in task manifest as it is presented on metric list (see `snapctl metric list`)
+
+    Metrics declared in task manifest           | Collected metrics
+    --------------------------------------------|------------------------
+    /intel/mock/foo                             |  /intel/mock/foo
+	|
+    /intel/mock/bar                             |  /intel/mock/bar
+	|
+    /intel/mock/\*/baz <br/> _(dynamic metric)_ |  /intel/mock/host0/baz <br/> /intel/mock/host1/baz <br/> /intel/mock/host2/baz  <br/> /intel/mock/host3/baz  <br/> /intel/mock/host4 <br/> /intel/mock/host5/baz <br/> /intel/mock/host6/baz <br/> /intel/mock/host7/baz  <br/> /intel/mock/host8/baz <br/> /intel/mock/host9/baz <br/><br/> _(collect metrics for all instances of the dynamic metric)_
+
+ b) **_specified_ _instance_ of dynamic metrics**
+
+ This refers to dynamic metric which namespace contains dynamic element represented by an asterisk within the meaning of representation of dynamic value (e.g. hostname, cgroup id, etc.)
+
+ In task manifest can be declared a specific instance of dynamic metric to collect and only that specific one will be collected (if exist)
+
+ Metrics declared in task manifest  | Collected metrics
+------------------------------------|------------------------
+/intel/mock/host0/baz <br/><br/> _(specific instance of "/intel/mock/*/baz")_ |  /intel/mock/host0/baz <br/><br/> _(only this one metric will be collected)_
+
+
+ c) **dynamic _query_**
+
+ This allows to express metrics to collect by using
+ - **a wildcard `*`** - that matches with any value in the metric namespace or, if the wildcard is in the end, with all metrics with given prefix
+ - **a tuple**, `(metric1|metric2|metric3)` - that matches with all items separated by vertical bar; it works like logical _or_, so it gives an error only if none of these metrics can be collected
+
+Metrics declared in task manifest   | Collected metrics
+------------------------------------|------------------------
+/intel/mock/*                       | /intel/mock/foo <br/> /intel/mock/bar <br/> /intel/mock/host0/baz <br/> /intel/mock/host1/baz <br/> /intel/mock/host2/baz  <br/> /intel/mock/host3/baz  <br/> /intel/mock/host4/baz <br/> /intel/mock/host5/baz <br/> /intel/mock/host6/baz <br/> /intel/mock/host7/baz  <br/> /intel/mock/host8/baz <br/> /intel/mock/host9/baz <br/> <br/> _(collect all metrics with prefix "/intel/mock")_
+|
+/intel/mock/(foo\|bar)              | /intel/mock/foo <br/> /intel/mock/bar
+
+
 
 The namespaces are keys to another nested object which may contain a specific version of a plugin, e.g.:
 

--- a/examples/start_mock3.sh
+++ b/examples/start_mock3.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+snapctl plugin load ../build/plugin/snap-collector-mock1
+snapctl plugin load ../build/plugin/snap-publisher-file
+snapctl plugin load ../build/plugin/snap-processor-passthru
+
+#snapctl task create -t ./tasks/mock-file_specific.json
+snapctl task create -t ./tasks/mock-file_query.json
+#snapctl task create -t ./tasks/mock-file_query.json
+#snapctl plugin load ../build/plugin/snap-collector-mock2
+#snapctl plugin load /home/test/Pulse_telemetry/pulse/src/github.com/intelsdi-x/snap-plugin-collector-users/build/rootfs/snap-plugin-collector-users
+

--- a/examples/tasks/mock-file_nonspecific.json
+++ b/examples/tasks/mock-file_nonspecific.json
@@ -1,0 +1,29 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/*/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": null,
+	    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.log"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/examples/tasks/mock-file_query.json
+++ b/examples/tasks/mock-file_query.json
@@ -1,0 +1,29 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/*/foo": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": null,
+	    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.log"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/examples/tasks/mock-file_specific_instance.json
+++ b/examples/tasks/mock-file_specific_instance.json
@@ -1,0 +1,29 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/host0/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": null,
+	    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.log"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/examples/tasks/mock-file_specified_dynamic_metric.json
+++ b/examples/tasks/mock-file_specified_dynamic_metric.json
@@ -1,0 +1,34 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/host0/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "user": "root",
+                    "password": "secret"
+                }
+            },
+            "process": [
+                {
+                    "plugin_name": "passthru",                    
+                    "process": null,
+                    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.log"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -131,8 +131,9 @@ func TestSnapClient(t *testing.T) {
 			})
 			Convey("empty catalog", func() {
 				m := c.GetMetricCatalog()
-				So(m.Err, ShouldBeNil)
+				So(m.Err, ShouldNotBeNil)
 				So(m.Len(), ShouldEqual, 0)
+				So(m.Err.Error(), ShouldEqual, "Metric catalog is empty (no plugin loaded)")
 			})
 			Convey("load directory error", func() {
 				p := c.LoadPlugin(DIRECTORY_PATH)

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -28,17 +28,12 @@ import (
 	"github.com/intelsdi-x/snap/core/cdata"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/snap/core/serror"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 type mockCollector struct{}
 
-func (m *mockCollector) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
-	return nil, nil
-}
-
-func (m *mockCollector) ExpandWildcards(core.Namespace) ([]core.Namespace, serror.SnapError) {
+func (m *mockCollector) CollectMetrics([]core.RequestedMetric, *cdata.ConfigDataTree, time.Time, string) ([]core.Metric, []error) {
 	return nil, nil
 }
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -79,7 +79,7 @@ func (m *mockMetricManager) GetPluginContentTypes(n string, t core.PluginType, v
 	return m.acceptedContentTypes[key], m.returnedContentTypes[key], nil
 }
 
-func (m *mockMetricManager) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
+func (m *mockMetricManager) CollectMetrics([]core.RequestedMetric, *cdata.ConfigDataTree, time.Time, string) ([]core.Metric, []error) {
 	return nil, nil
 }
 
@@ -91,7 +91,7 @@ func (m *mockMetricManager) ProcessMetrics(contentType string, content []byte, p
 	return "", nil, nil
 }
 
-func (m *mockMetricManager) ValidateDeps(mts []core.Metric, prs []core.SubscribedPlugin) []serror.SnapError {
+func (m *mockMetricManager) ValidateDeps(mts []core.Metric, cdt *cdata.ConfigDataTree, prs []core.SubscribedPlugin) []serror.SnapError {
 	if m.failValidatingMetrics {
 		return []serror.SnapError{
 			serror.New(errors.New("metric validation error")),
@@ -107,14 +107,6 @@ func (m *mockMetricManager) SubscribeDeps(taskID string, mts []core.Metric, prs 
 
 func (m *mockMetricManager) UnsubscribeDeps(taskID string, mts []core.Metric, prs []core.Plugin) []serror.SnapError {
 	return nil
-}
-
-func (m *mockMetricManager) MatchQueryToNamespaces(core.Namespace) ([]core.Namespace, serror.SnapError) {
-	return nil, nil
-}
-
-func (m *mockMetricManager) ExpandWildcards(core.Namespace) ([]core.Namespace, serror.SnapError) {
-	return nil, nil
 }
 
 type mockMetricManagerError struct {

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/intelsdi-x/snap/core/control_event"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/core/scheduler_event"
-	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/pkg/promise"
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
@@ -262,11 +261,7 @@ type Mock1 struct {
 	queue      map[string]int
 }
 
-func (m *Mock1) CollectMetrics([]core.Metric, time.Time, string) ([]core.Metric, []error) {
-	return nil, nil
-}
-
-func (m *Mock1) ExpandWildcards(core.Namespace) ([]core.Namespace, serror.SnapError) {
+func (m *Mock1) CollectMetrics([]core.RequestedMetric, *cdata.ConfigDataTree, time.Time, string) ([]core.Metric, []error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes #654 and #832

### Summary of changes:
**a) support defining specific instance of dynamic metric in task manifest**

_Example:_ (mock collector plugin)
User might define in task manifest: 
- `/intel/mock/*/bar` to collect metric for all available instance
- or specific dynamic metric:
 - `/intel/mock/host0/bar` (in that case only one metric will be collected)
 - `/intel/mock/(host0|host1)/bar` (that returns two metrics)
 - `/intel/mock/host0/*` (that returns all available metrics for instance "host0" from mock collector)

In situation when there is no such instance `host0` error will be returned.

 **b) changing the way of matching dynamic query due to allowing the specifying of dynamic metrics, but there is no change from user perspective**

 **c) allow to immediately start collecting the new metrics by the running task from loaded plugin**
Read more #832

 **d) adding error message to trying Fetch() on empty metric catalog**

_Example:_
 running `snapctl metric list` when NO PLUGIN has been already loaded 
![image](https://cloud.githubusercontent.com/assets/11335874/15146876/e286218c-16bd-11e6-880f-09854a7bf123.png)


Testing done:
- unit tests (new unit tests added)
- running task with specified dynamic metric for mock plugin
- testing moving subscription to the latest available version of metric
- testing scenario described in #832 

@intelsdi-x/snap-maintainers