### PR TITLE
Fix for issue #418

### DIFF
--- a/core/serror/serror.go
+++ b/core/serror/serror.go
@@ -19,6 +19,14 @@ limitations under the License.
 
 package serror
 
+import (
+	"errors"
+)
+
+var (
+	ErrBadAddress = errors.New("Address for binding can not contain comma")
+)
+
 type SnapError interface {
 	error
 	Fields() map[string]interface{}

--- a/core/serror/serror.go
+++ b/core/serror/serror.go
@@ -19,14 +19,6 @@ limitations under the License.
 
 package serror
 
-import (
-	"errors"
-)
-
-var (
-	ErrBadAddress = errors.New("Address for binding can not contain comma")
-)
-
 type SnapError interface {
 	error
 	Fields() map[string]interface{}

--- a/examples/configs/snap-config-sample.json
+++ b/examples/configs/snap-config-sample.json
@@ -69,7 +69,8 @@
         "rest_auth_password": "changeme",
         "rest_certificate": "/path/to/cert/file",
         "rest_key": "/path/to/private/key",
-        "port": 8282
+        "port": 8282,
+        "bind_addresses": "127.0.0.1:12345"
     },
     "tribe": {
         "enable": true,

--- a/examples/configs/snap-config-sample.json
+++ b/examples/configs/snap-config-sample.json
@@ -70,7 +70,7 @@
         "rest_certificate": "/path/to/cert/file",
         "rest_key": "/path/to/private/key",
         "port": 8282,
-        "bind_addresses": "127.0.0.1:12345"
+        "addr": "127.0.0.1:12345"
     },
     "tribe": {
         "enable": true,

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -115,8 +115,8 @@ restapi:
   # port sets the port to start the REST API server on. Default is 8181
   port: 8282
 
-  #
-  bind_addresses: 127.0.0.1:12345
+  # REST API in address[:port] format
+  addr: 127.0.0.1:12345
 
 # tribe section contains all configuration items for the tribe module
 tribe:

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -115,6 +115,9 @@ restapi:
   # port sets the port to start the REST API server on. Default is 8181
   port: 8282
 
+  #
+  bind_addresses: 127.0.0.1:12345
+
 # tribe section contains all configuration items for the tribe module
 tribe:
   # enable controls enabling tribe for the snapd instance. Default value is false.

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -91,7 +91,7 @@ func startAPI() string {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddress("127.0.0.1:0")
+	r.SetAddresses("127.0.0.1", 0)
 	r.Start()
 	time.Sleep(100 * time.Millisecond)
 	return fmt.Sprintf("http://localhost:%d", r.Port())

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -91,7 +91,7 @@ func startAPI() string {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddresses("127.0.0.1", 0)
+	r.SetAddress("127.0.0.1", 0)
 	r.Start()
 	time.Sleep(100 * time.Millisecond)
 	return fmt.Sprintf("http://localhost:%d", r.Port())

--- a/mgmt/rest/client/client_tribe_func_test.go
+++ b/mgmt/rest/client/client_tribe_func_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -201,7 +200,7 @@ func startTribes(count int) []int {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddress(":" + strconv.Itoa(mgtPort))
+		r.SetAddresses("", mgtPort)
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/mgmt/rest/client/client_tribe_func_test.go
+++ b/mgmt/rest/client/client_tribe_func_test.go
@@ -200,7 +200,7 @@ func startTribes(count int) []int {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddresses("", mgtPort)
+		r.SetAddress("", mgtPort)
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -488,7 +488,7 @@ func startAPI(cfg *mockConfig) *restAPIInstance {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddresses("127.0.0.1", 0)
+	r.SetAddress("127.0.0.1", 0)
 	r.Start()
 	time.Sleep(time.Millisecond * 100)
 	return &restAPIInstance{

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -488,7 +488,7 @@ func startAPI(cfg *mockConfig) *restAPIInstance {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddress("127.0.0.1:0")
+	r.SetAddresses("127.0.0.1", 0)
 	r.Start()
 	time.Sleep(time.Millisecond * 100)
 	return &restAPIInstance{

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -309,11 +309,11 @@ func (s *Server) Name() string {
 	return "REST"
 }
 
-func (s *Server) SetAddress(addrString string, dfltPort int) error {
+func (s *Server) SetAddress(addrString string, dfltPort int) {
 	restLogger.Info(fmt.Sprintf("Setting address to: [%v] Default port: %v", addrString, dfltPort))
 	// In the future, we could extend this to support multiple comma separated IP[:port] values
 	if strings.Index(addrString, ",") != -1 {
-		return serror.ErrBadAddress
+		restLogger.Fatal("Invalid address")
 	}
 	// If no port is specified, use default port
 	if strings.Index(addrString, ":") != -1 {
@@ -322,7 +322,6 @@ func (s *Server) SetAddress(addrString string, dfltPort int) error {
 		s.addrString = fmt.Sprintf("%s:%d", addrString, dfltPort)
 	}
 	restLogger.Info(fmt.Sprintf("Address used for binding: [%v]", s.addrString))
-	return nil
 }
 
 func (s *Server) Start() error {

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -52,6 +52,7 @@ const (
 const (
 	defaultEnable          bool   = true
 	defaultPort            int    = 8181
+	defaultBindAddresses   string = ""
 	defaultHTTPS           bool   = false
 	defaultRestCertificate string = ""
 	defaultRestKey         string = ""
@@ -73,6 +74,7 @@ var (
 type Config struct {
 	Enable           bool   `json:"enable,omitempty"yaml:"enable,omitempty"`
 	Port             int    `json:"port,omitempty"yaml:"port,omitempty"`
+	BindAddresses    string `json:"bind_addresses,omitempty"yaml:"bind_addresses,omitempty"`
 	HTTPS            bool   `json:"https,omitempty"yaml:"https,omitempty"`
 	RestCertificate  string `json:"rest_certificate,omitempty"yaml:"rest_certificate,omitempty"`
 	RestKey          string `json:"rest_key,omitempty"yaml:"rest_key,omitempty"`
@@ -107,6 +109,9 @@ const (
 						"type": "integer",
 						"minimum": 0,
 						"maximum": 65535
+					},
+					"bind_addresses" : {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false
@@ -210,6 +215,7 @@ func GetDefaultConfig() *Config {
 	return &Config{
 		Enable:           defaultEnable,
 		Port:             defaultPort,
+		BindAddresses:    defaultBindAddresses,
 		HTTPS:            defaultHTTPS,
 		RestCertificate:  defaultRestCertificate,
 		RestKey:          defaultRestKey,
@@ -239,6 +245,10 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		case "port":
 			if err := json.Unmarshal(v, &(c.Port)); err != nil {
 				return fmt.Errorf("%v (while parsing 'restapi::port')", err)
+			}
+		case "bind_addresses":
+			if err := json.Unmarshal(v, &(c.BindAddresses)); err != nil {
+				return fmt.Errorf("%v (while parsing 'restapi::bind_addresses')", err)
 			}
 		case "https":
 			if err := json.Unmarshal(v, &(c.HTTPS)); err != nil {
@@ -299,8 +309,19 @@ func (s *Server) Name() string {
 	return "REST"
 }
 
-func (s *Server) SetAddress(addrString string) {
-	s.addrString = addrString
+func (s *Server) SetAddresses(addrString string, dfltPort int) {
+	restLogger.Info(fmt.Sprintf("Setting address to: [%v] Default port: %v", addrString, dfltPort))
+	// In the future, we could extend this to support multiple comma separated IP[:port] values
+	if strings.Index(addrString, ",") != -1 {
+		panic("Not supported address value for binding")
+	}
+	// If no port is specified, use default port
+	if strings.Index(addrString, ":") != -1 {
+		s.addrString = addrString
+	} else {
+		s.addrString = fmt.Sprintf("%s:%d", addrString, dfltPort)
+	}
+	restLogger.Info(fmt.Sprintf("Address used for binding: [%v]", addrString))
 }
 
 func (s *Server) Start() error {

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -52,7 +52,7 @@ const (
 const (
 	defaultEnable          bool   = true
 	defaultPort            int    = 8181
-	defaultBindAddresses   string = ""
+	defaultAddress         string = ""
 	defaultHTTPS           bool   = false
 	defaultRestCertificate string = ""
 	defaultRestKey         string = ""
@@ -74,7 +74,7 @@ var (
 type Config struct {
 	Enable           bool   `json:"enable,omitempty"yaml:"enable,omitempty"`
 	Port             int    `json:"port,omitempty"yaml:"port,omitempty"`
-	BindAddresses    string `json:"bind_addresses,omitempty"yaml:"bind_addresses,omitempty"`
+	Address          string `json:"addr,omitempty"yaml:"addr,omitempty"`
 	HTTPS            bool   `json:"https,omitempty"yaml:"https,omitempty"`
 	RestCertificate  string `json:"rest_certificate,omitempty"yaml:"rest_certificate,omitempty"`
 	RestKey          string `json:"rest_key,omitempty"yaml:"rest_key,omitempty"`
@@ -110,7 +110,7 @@ const (
 						"minimum": 0,
 						"maximum": 65535
 					},
-					"bind_addresses" : {
+					"addr" : {
 						"type": "string"
 					}
 				},
@@ -215,7 +215,7 @@ func GetDefaultConfig() *Config {
 	return &Config{
 		Enable:           defaultEnable,
 		Port:             defaultPort,
-		BindAddresses:    defaultBindAddresses,
+		Address:          defaultAddress,
 		HTTPS:            defaultHTTPS,
 		RestCertificate:  defaultRestCertificate,
 		RestKey:          defaultRestKey,
@@ -246,9 +246,9 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(v, &(c.Port)); err != nil {
 				return fmt.Errorf("%v (while parsing 'restapi::port')", err)
 			}
-		case "bind_addresses":
-			if err := json.Unmarshal(v, &(c.BindAddresses)); err != nil {
-				return fmt.Errorf("%v (while parsing 'restapi::bind_addresses')", err)
+		case "addr":
+			if err := json.Unmarshal(v, &(c.Address)); err != nil {
+				return fmt.Errorf("%v (while parsing 'restapi::addr')", err)
 			}
 		case "https":
 			if err := json.Unmarshal(v, &(c.HTTPS)); err != nil {
@@ -309,11 +309,11 @@ func (s *Server) Name() string {
 	return "REST"
 }
 
-func (s *Server) SetAddresses(addrString string, dfltPort int) {
+func (s *Server) SetAddress(addrString string, dfltPort int) error {
 	restLogger.Info(fmt.Sprintf("Setting address to: [%v] Default port: %v", addrString, dfltPort))
 	// In the future, we could extend this to support multiple comma separated IP[:port] values
 	if strings.Index(addrString, ",") != -1 {
-		panic("Not supported address value for binding")
+		return serror.ErrBadAddress
 	}
 	// If no port is specified, use default port
 	if strings.Index(addrString, ":") != -1 {
@@ -321,7 +321,8 @@ func (s *Server) SetAddresses(addrString string, dfltPort int) {
 	} else {
 		s.addrString = fmt.Sprintf("%s:%d", addrString, dfltPort)
 	}
-	restLogger.Info(fmt.Sprintf("Address used for binding: [%v]", addrString))
+	restLogger.Info(fmt.Sprintf("Address used for binding: [%v]", s.addrString))
+	return nil
 }
 
 func (s *Server) Start() error {

--- a/mgmt/rest/server_test.go
+++ b/mgmt/rest/server_test.go
@@ -53,6 +53,9 @@ func TestRestAPIConfigJSON(t *testing.T) {
 		Convey("Port should be 8282", func() {
 			So(cfg.Port, ShouldEqual, 8282)
 		})
+		Convey("BindAddresses should equal 127.0.0.1:12345", func() {
+			So(cfg.BindAddresses, ShouldEqual, "127.0.0.1:12345")
+		})
 		Convey("RestAuth should be true", func() {
 			So(cfg.RestAuth, ShouldEqual, true)
 		})
@@ -92,6 +95,9 @@ func TestRestAPIConfigYaml(t *testing.T) {
 		Convey("Port should be 8282", func() {
 			So(cfg.Port, ShouldEqual, 8282)
 		})
+		Convey("BindAddresses should equal 127.0.0.1:12345", func() {
+			So(cfg.BindAddresses, ShouldEqual, "127.0.0.1:12345")
+		})
 		Convey("RestAuth should be true", func() {
 			So(cfg.RestAuth, ShouldEqual, true)
 		})
@@ -119,6 +125,9 @@ func TestRestAPIDefaultConfig(t *testing.T) {
 		})
 		Convey("Port should be 8181", func() {
 			So(cfg.Port, ShouldEqual, 8181)
+		})
+		Convey("BindAddresses should equal empty string", func() {
+			So(cfg.BindAddresses, ShouldEqual, "")
 		})
 		Convey("RestAuth should be false", func() {
 			So(cfg.RestAuth, ShouldEqual, false)

--- a/mgmt/rest/server_test.go
+++ b/mgmt/rest/server_test.go
@@ -53,8 +53,8 @@ func TestRestAPIConfigJSON(t *testing.T) {
 		Convey("Port should be 8282", func() {
 			So(cfg.Port, ShouldEqual, 8282)
 		})
-		Convey("BindAddresses should equal 127.0.0.1:12345", func() {
-			So(cfg.BindAddresses, ShouldEqual, "127.0.0.1:12345")
+		Convey("Address should equal 127.0.0.1:12345", func() {
+			So(cfg.Address, ShouldEqual, "127.0.0.1:12345")
 		})
 		Convey("RestAuth should be true", func() {
 			So(cfg.RestAuth, ShouldEqual, true)
@@ -95,8 +95,8 @@ func TestRestAPIConfigYaml(t *testing.T) {
 		Convey("Port should be 8282", func() {
 			So(cfg.Port, ShouldEqual, 8282)
 		})
-		Convey("BindAddresses should equal 127.0.0.1:12345", func() {
-			So(cfg.BindAddresses, ShouldEqual, "127.0.0.1:12345")
+		Convey("Address should equal 127.0.0.1:12345", func() {
+			So(cfg.Address, ShouldEqual, "127.0.0.1:12345")
 		})
 		Convey("RestAuth should be true", func() {
 			So(cfg.RestAuth, ShouldEqual, true)
@@ -126,8 +126,8 @@ func TestRestAPIDefaultConfig(t *testing.T) {
 		Convey("Port should be 8181", func() {
 			So(cfg.Port, ShouldEqual, 8181)
 		})
-		Convey("BindAddresses should equal empty string", func() {
-			So(cfg.BindAddresses, ShouldEqual, "")
+		Convey("Address should equal empty string", func() {
+			So(cfg.Address, ShouldEqual, "")
 		})
 		Convey("RestAuth should be false", func() {
 			So(cfg.RestAuth, ShouldEqual, false)

--- a/mgmt/rest/tribe_test.go
+++ b/mgmt/rest/tribe_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -701,7 +700,7 @@ func startTribes(count int, seed string) ([]int, int) {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddress(":" + strconv.Itoa(mgtPort))
+		r.SetAddresses("", mgtPort)
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/mgmt/rest/tribe_test.go
+++ b/mgmt/rest/tribe_test.go
@@ -700,7 +700,7 @@ func startTribes(count int, seed string) ([]int, int) {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddresses("", mgtPort)
+		r.SetAddress("", mgtPort)
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/snapd.go
+++ b/snapd.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -38,7 +39,6 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/vrischmann/jsonutil"
 
-	"errors"
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/serror"

--- a/snapd.go
+++ b/snapd.go
@@ -660,7 +660,7 @@ func checkCmdLineFlags(ctx *cli.Context) error {
 		addr := ctx.String("api-addr")
 		// Contains a comma
 		if strings.Index(addr, ",") != -1 {
-			return serror.ErrBadAddress
+			return errors.New("Invalid address")
 		}
 		idx := strings.Index(addr, ":")
 		// Port is specified in address string
@@ -682,7 +682,7 @@ func checkCmdLineFlags(ctx *cli.Context) error {
 func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	err := checkCmdLineFlags(ctx)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	invertBoolean := true
 	// apply any command line flags that might have been set, first for the
@@ -699,7 +699,7 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	// next for the RESTful server related flags
 	cfg.RestAPI.Enable = setBoolVal(cfg.RestAPI.Enable, ctx, "disable-api", invertBoolean)
 	cfg.RestAPI.Port = setIntVal(cfg.RestAPI.Port, ctx, "api-port")
-	cfg.RestAPI.Address = setStringVal(cfg.RestAPI.Address, ctx, "ip-addr")
+	cfg.RestAPI.Address = setStringVal(cfg.RestAPI.Address, ctx, "api-addr")
 	cfg.RestAPI.HTTPS = setBoolVal(cfg.RestAPI.HTTPS, ctx, "rest-https")
 	cfg.RestAPI.RestCertificate = setStringVal(cfg.RestAPI.RestCertificate, ctx, "rest-cert")
 	cfg.RestAPI.RestKey = setStringVal(cfg.RestAPI.RestKey, ctx, "rest-key")

--- a/snapd.go
+++ b/snapd.go
@@ -54,8 +54,14 @@ var (
 		Usage: "Disable the agent REST API",
 	}
 	flAPIPort = cli.IntFlag{
-		Name:  "api-port,  p",
+		Name:  "api-port, p",
 		Usage: "API port (Default: 8181)",
+		EnvVar: "SNAP_PORT",
+	}
+	flAPIBindAddresses = cli.StringFlag{
+		Name:   "bind-addresses, b",
+		Usage:  "Address[:port] to bind to.",
+		EnvVar: "SNAP_BIND_ADDRESSES",
 	}
 	flMaxProcs = cli.IntFlag{
 		Name:   "max-procs, c",
@@ -227,6 +233,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		flAPIDisabled,
 		flAPIPort,
+		flAPIBindAddresses,
 		flLogLevel,
 		flLogPath,
 		flMaxProcs,
@@ -354,7 +361,7 @@ func action(ctx *cli.Context) {
 			r.BindTribeManager(tr)
 		}
 		go monitorErrors(r.Err())
-		r.SetAddress(fmt.Sprintf(":%d", cfg.RestAPI.Port))
+		r.SetAddresses(cfg.RestAPI.BindAddresses, cfg.RestAPI.Port)
 		coreModules = append(coreModules, r)
 		log.Info("REST API is enabled")
 	} else {
@@ -663,6 +670,7 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 	// next for the RESTful server related flags
 	cfg.RestAPI.Enable = setBoolVal(cfg.RestAPI.Enable, ctx, "disable-api", invertBoolean)
 	cfg.RestAPI.Port = setIntVal(cfg.RestAPI.Port, ctx, "api-port")
+	cfg.RestAPI.BindAddresses = setStringVal(cfg.RestAPI.BindAddresses, ctx, "bind-addresses")
 	cfg.RestAPI.HTTPS = setBoolVal(cfg.RestAPI.HTTPS, ctx, "rest-https")
 	cfg.RestAPI.RestCertificate = setStringVal(cfg.RestAPI.RestCertificate, ctx, "rest-cert")
 	cfg.RestAPI.RestKey = setStringVal(cfg.RestAPI.RestKey, ctx, "rest-key")


### PR DESCRIPTION
Fixes #418

Summary of changes:
- added new parameter for allowing binding address+port
- added new test cases
- removed extra space in command line argument specification
- added possibility for default port to be passed as environment variable

Please note that plural was used (bind_addresses and not bind_address) because I have anticipated the fact that we might want to bind on several different addresses + port in the future.
 
Testing done:
- reran all existing tests successfully
- added tests also successful

@intelsdi-x/snap-maintainers
