### PR TITLE
Display tags in watch output for a task.

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -80,6 +80,9 @@ var (
 					Name:   "watch",
 					Usage:  "watch <task_id>",
 					Action: watchTask,
+					Flags: []cli.Flag{
+						flVerbose,
+					},
 				},
 				{
 					Name:   "enable",


### PR DESCRIPTION
Summary of changes:
- Add support for displaying tags during watch by passing a `-v` or `--verbose` to the watch command
- Displays three tags per line, and groups tags together in the `TAGS` column of the display

Testing done:
- Verified `watch` command continues to function without passing `-v` and displays tags when `-v` is passed.

Example output when `-v` is passed to `watch`

![screen shot 2016-05-11 at 2 23 59 pm](https://cloud.githubusercontent.com/assets/1395030/15197128/99d290f2-1784-11e6-9006-3124aa886660.png)


@intelsdi-x/snap-maintainers

