### PR TITLE
Fixes pool eligibility #910

### DIFF
--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -270,8 +270,9 @@ func (p *pool) Eligible() bool {
 		return false
 	}
 
-	should := p.SubscriptionCount() / p.concurrencyCount
-	if should > p.Count() && should <= p.max {
+	should := p.SubscriptionCount() > p.concurrencyCount*p.Count()
+	// Check if pool is eligible and number of plugins is less than maximum allowed
+	if should && p.Count() < p.max {
 		return true
 	}
 

--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -266,13 +266,12 @@ func (p *pool) Eligible() bool {
 
 	// optimization: don't even bother with concurrency
 	// count if we have already reached pool max
-	if p.Count() == p.max {
+	if p.Count() >= p.max {
 		return false
 	}
 
-	should := p.SubscriptionCount() > p.concurrencyCount*p.Count()
 	// Check if pool is eligible and number of plugins is less than maximum allowed
-	if should && p.Count() < p.max {
+	if p.SubscriptionCount() > p.concurrencyCount*p.Count() {
 		return true
 	}
 


### PR DESCRIPTION
Fixes #910 

Summary of changes:
- changed condition for eligibility

Testing done:
- unit tests

@intelsdi-x/snap-maintainers

Pool eligibility was not calculated properly for concurrency count > 1