### PR TITLE
Fixes #919: intermittent tribe test failure.

### DIFF
--- a/mgmt/tribe/tribe_test.go
+++ b/mgmt/tribe/tribe_test.go
@@ -942,7 +942,7 @@ func TestTribePluginAgreement(t *testing.T) {
 													}
 												}(t)
 											}
-											wg.Done()
+											wg.Wait()
 
 											Convey("Handles out-of-order remove", func() {
 												t := tribes[rand.Intn(numOfTribes)]
@@ -1038,7 +1038,7 @@ func TestTribePluginAgreement(t *testing.T) {
 																	}
 																}(t)
 															}
-															wg.Done()
+															wg.Wait()
 														})
 													})
 												})


### PR DESCRIPTION
Fixes #919

Summary of changes:
- Changes 2 waitgroup.Done() calls to be waitgroup.Wait()

Testing done:
- go test -run=TestTribeFullStateSync

@intelsdi-x/snap-maintainers

Modifies tribe_test to change 2 calls to wg.Done() to wg.Wait()