### PR TITLE
Add support to REST API responses for metric schema changes

### DIFF
--- a/core/metric.go
+++ b/core/metric.go
@@ -121,6 +121,13 @@ func (n Namespace) AddStaticElements(values ...string) Namespace {
 	return n
 }
 
+func (n Namespace) Element(idx int) NamespaceElement {
+	if idx >= 0 && idx < len(n) {
+		return n[idx]
+	}
+	return NamespaceElement{}
+}
+
 // NamespaceElement provides meta data related to the namespace.  This is of particular importance when
 // the namespace contains data.
 type NamespaceElement struct {
@@ -157,4 +164,6 @@ type CatalogedMetric interface {
 	RequestedMetric
 	LastAdvertisedTime() time.Time
 	Policy() *cpolicy.ConfigPolicyNode
+	Description() string
+	Unit() string
 }

--- a/mgmt/rest/rbody/metric.go
+++ b/mgmt/rest/rbody/metric.go
@@ -36,11 +36,21 @@ type PolicyTable struct {
 }
 
 type Metric struct {
-	LastAdvertisedTimestamp int64         `json:"last_advertised_timestamp,omitempty"`
-	Namespace               string        `json:"namespace,omitempty"`
-	Version                 int           `json:"version,omitempty"`
-	Policy                  []PolicyTable `json:"policy,omitempty"`
-	Href                    string        `json:"href"`
+	LastAdvertisedTimestamp int64            `json:"last_advertised_timestamp,omitempty"`
+	Namespace               string           `json:"namespace,omitempty"`
+	Version                 int              `json:"version,omitempty"`
+	Dynamic                 bool             `json:"dynamic"`
+	DynamicElements         []DynamicElement `json:"dynamic_elements,omitempty"`
+	Description             string           `json:"description,omitempty"`
+	Unit                    string           `json:"unit,omitempty"`
+	Policy                  []PolicyTable    `json:"policy,omitempty"`
+	Href                    string           `json:"href"`
+}
+
+type DynamicElement struct {
+	Index       int    `json:"index,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type MetricReturned struct {


### PR DESCRIPTION
Summary of changes:
- Add Description() and Unit() methods to CatalogedMetric Interface
- Add Element() method on Namespace to return NamespaceElement for given index.
- Update rbody responses for Metric to include Description, Unit, Dynamic, and DynamicElements
- Add DynamicElement struct to rbody/Metric to hold information for dynamic elements of the metric namespace, which includes Index, Name, and Description
- Update REST API responses to include Description, Unit, Dynamic, and DynamicElements( if metric is dynamic) for returns of the entire metric catalog or specific requested metrics.

Sample API Response:
```json
--- intelsdi-x/snap ‹tb/sdi-1273* ?› » curl http://localhost:8181/v1/metrics/intel/mock/\*/baz\?ver\=2
{
  "meta": {
    "code": 200,
    "message": "Metric returned",
    "type": "metric_returned",
    "version": 1
  },
  "body": {
    "Metric": {
      "last_advertised_timestamp": 1463171136,
      "namespace": "/intel/mock/*/baz",
      "version": 2,
      "dynamic": true,
      "dynamic_elements": [
        {
          "index": 2,
          "name": "host",
          "description": "name of the host"
        }
      ],
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics/intel/mock/*/baz?ver=2"
    }
  }
}
```

Testing done:
- Verified tests pass. 

@intelsdi-x/snap-maintainers
