### PR TITLE
Fixed example psutil and mock task files

### DIFF
--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -13,7 +13,7 @@
             },
             "config": {
                 "/intel/mock": {
-                    "user": "root",
+                    "name": "root",
                     "password": "secret"
                 }
             },

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -11,7 +11,7 @@
         /intel/mock/*/baz: {}
       config: 
         /intel/mock: 
-          user: "root"
+          name: "root"
           password: "secret"
       process: 
         - 

--- a/examples/tasks/psutil-influx.json
+++ b/examples/tasks/psutil-influx.json
@@ -14,12 +14,6 @@
                 "/intel/psutil/vm/free": {},
                 "/intel/psutil/vm/used": {}
             },
-            "config": {
-                "/intel/mock": {
-                    "password": "secret",
-                    "user": "root"
-                }
-            },
             "process": null,
             "publish": [
                 {


### PR DESCRIPTION
Summary of changes:
- Removed config from psutil example since psutil doesn't have a config policy. Also it was for mock metrics
- Updated "user" to "name" to match mock plugin (however, I think it would make more sense to update mock--thoughts?)

@intelsdi-x/snap-maintainers
