### PR TITLE
Fixes #929: Corrects error in control/runner.go

### DIFF
--- a/control/runner.go
+++ b/control/runner.go
@@ -264,7 +264,7 @@ func (r *runner) HandleGomitEvent(e gomit.Event) {
 					runnerLog.WithFields(log.Fields{
 						"_block":  "handle-events",
 						"aplugin": v.String,
-					}).Error(err.Error())
+					}).Error(e.Error())
 					return
 				}
 				pool.IncRestartCount()
@@ -341,7 +341,7 @@ func (r *runner) HandleGomitEvent(e gomit.Event) {
 			if e != nil {
 				runnerLog.WithFields(log.Fields{
 					"_block": "handle-events",
-				}).Error(err.Error())
+				}).Error(e.Error())
 				return
 			}
 		}
@@ -451,7 +451,7 @@ func (r *runner) HandleGomitEvent(e gomit.Event) {
 			if e != nil {
 				runnerLog.WithFields(log.Fields{
 					"_block": "handle-events",
-				}).Error(err.Error())
+				}).Error(e.Error())
 				return
 			}
 			runnerLog.WithFields(log.Fields{


### PR DESCRIPTION
Fixes #929

Summary of changes:
- Changed err.Errors() to e.Errors() in required places

Testing done:
- Ran tests

@intelsdi-x/snap-maintainers
