### PR TITLE
Update snapctl output for metric and metric catalog with metric schema changes

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -147,6 +147,7 @@ var (
 					Flags: []cli.Flag{
 						flMetricVersion,
 						flMetricNamespace,
+						flVerbose,
 					},
 				},
 				{

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -135,7 +135,7 @@ var (
 
 	// general
 	flVerbose = cli.BoolFlag{
-		Name:  "verbose, v",
+		Name:  "verbose",
 		Usage: "Verbose output",
 	}
 )


### PR DESCRIPTION
This PR updates the output of snapctl to include the latest metric schema changes for a single metric or a group of metrics returned during a metric query. 

** Note: Due to other flags using `-v` for flags, this PR also removes `-v` from the verbose flag. Use of verbose will require specifying `--verbose`

Summary of changes:
- Add Description, Unit, and Dynamic Elements for namespaces to the output of snapctl commands for returning a single metric or a list of metrics.
- Add `--verbose` flag to `metric list` command to expand out metrics to populate namespace with dynamic elements and include Unit and Description in the output.
- Remove `-v` from the verbose flag as other flags also use `-v`.

Sample output of the changes:
![screen shot 2016-05-17 at 4 02 18 pm](https://cloud.githubusercontent.com/assets/1395030/15342357/8ef9dd92-1c49-11e6-816a-d3884f2e0a6c.png)


Testing done:
- Verified outputs of snapctl for `metric list`, `metric list --verbose` and `metric get`

@intelsdi-x/snap-maintainers
