### PR TITLE
Fixes #942: Return schedules in REST API response for task creation for windowed and cron schedules

### DIFF
--- a/mgmt/rest/rbody/task.go
+++ b/mgmt/rest/rbody/task.go
@@ -222,8 +222,23 @@ func assertSchedule(s schedule.Schedule, t *AddScheduledTask) {
 			Interval: v.Interval.String(),
 		}
 		return
+	case *schedule.WindowedSchedule:
+		startTime := v.StartTime.Unix()
+		stopTime := v.StopTime.Unix()
+		t.Schedule = &request.Schedule{
+			Type:           "windowed",
+			Interval:       v.Interval.String(),
+			StartTimestamp: &startTime,
+			StopTimestamp:  &stopTime,
+		}
+		return
+	case *schedule.CronSchedule:
+		t.Schedule = &request.Schedule{
+			Type:     "cron",
+			Interval: v.Entry(),
+		}
+		return
 	}
-	t.Schedule = &request.Schedule{}
 }
 
 type ScheduledTaskWatchingEnded struct {

--- a/pkg/schedule/cron_schedule.go
+++ b/pkg/schedule/cron_schedule.go
@@ -46,6 +46,11 @@ func NewCronSchedule(entry string) *CronSchedule {
 	}
 }
 
+// Entry returns the cron schedule entry
+func (c *CronSchedule) Entry() string {
+	return c.entry
+}
+
 // GetState returns state of CronSchedule
 func (c *CronSchedule) GetState() ScheduleState {
 	return c.state


### PR DESCRIPTION
Fixes #942 

Summary of changes:
- Adds returning windowed and cron schedule types on response from REST API on task creation
- Adds Entry() method to cron schedule type to return the entry that was used to create the schedule.

Testing done:
- Verified tests passed.
- Verified task creation response from REST API included the schedule for windowed and cron types.

@intelsdi-x/snap-maintainers