### PR TITLE
Partial refactor of /plugin tests

### DIFF
--- a/plugin/collector/snap-collector-mock1/main_small_test.go
+++ b/plugin/collector/snap-collector-mock1/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/collector/snap-collector-mock1/main_test.go
+++ b/plugin/collector/snap-collector-mock1/main_test.go
@@ -60,10 +60,3 @@ func TestMockPluginLoad(t *testing.T) {
 		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
 	}
 }
-
-func TestMain(t *testing.T) {
-	Convey("ensure plugin loads and responds", t, func() {
-		os.Args = []string{"", "{\"NoDaemon\": true}"}
-		So(func() { main() }, ShouldNotPanic)
-	})
-}

--- a/plugin/collector/snap-collector-mock2/main_small_test.go
+++ b/plugin/collector/snap-collector-mock2/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/collector/snap-collector-mock2/main_test.go
+++ b/plugin/collector/snap-collector-mock2/main_test.go
@@ -60,10 +60,3 @@ func TestMockPluginLoad(t *testing.T) {
 		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
 	}
 }
-
-func TestMain(t *testing.T) {
-	Convey("ensure plugin loads and responds", t, func() {
-		os.Args = []string{"", "{\"NoDaemon\": true}"}
-		So(func() { main() }, ShouldNotPanic)
-	})
-}

--- a/plugin/processor/snap-processor-passthru/main_small_test.go
+++ b/plugin/processor/snap-processor-passthru/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/publisher/snap-publisher-file/file/file_small_test.go
+++ b/plugin/publisher/snap-publisher-file/file/file_small_test.go
@@ -1,4 +1,4 @@
-// +build legacy
+// +build small
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/plugin/publisher/snap-publisher-file/main_small_test.go
+++ b/plugin/publisher/snap-publisher-file/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/publisher/snap-publisher-file/main_test.go
+++ b/plugin/publisher/snap-publisher-file/main_test.go
@@ -61,10 +61,3 @@ func TestFilePublisherLoad(t *testing.T) {
 		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
 	}
 }
-
-func TestMain(t *testing.T) {
-	Convey("ensure plugin loads and responds", t, func() {
-		os.Args = []string{"", "{\"NoDaemon\": true}"}
-		So(func() { main() }, ShouldNotPanic)
-	})
-}


### PR DESCRIPTION
I walked through @tjmcs' tutorial to review content. Worth adding in. Summary of changes:

* Including a `main_small_test.go` in each subdirectory for the first time
* Leaving the more complex system testing in, tagged as `legacy` since it depends on `control` and `core` packages that @geauxvirtual is working on separately. Will leave these until we decide on whether it's a medium test or throw away for other testing options.

Testing done:
- After each file change, went to subdirectory of the change and ran: 
```
o test -tags=small -coverprofile=/tmp/coverage.out . && go tool cover -func=/tmp/coverage.out | grep -v '\t0.0%$'
```

Example: 

```
$ cd collector/snap-collector-mock1
$ go test -tags=small -coverprofile=/tmp/coverage.out . && go tool cover -func=/tmp/coverage.out | grep -v '\t0.0%$'
ok  	github.com/intelsdi-x/snap/plugin/collector/snap-collector-mock1	0.013s	coverage: 100.0% of statements
github.com/intelsdi-x/snap/plugin/collector/snap-collector-mock1/main.go:31:	main		100.0%
total:										(statements)	100.0%
```

@intelsdi-x/snap-maintainers