### PR TITLE
sdi-1177 make consistent behavior for RecordFailure

### DIFF
--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -318,8 +318,8 @@ func (s *schedulerWorkflow) Start(t *task) {
 	// Block until the job has been either run or skipped.
 	errors := t.manager.Work(j).Promise().Await()
 
-	if len(errors) != 0 {
-		t.RecordFailure(j.Errors())
+	if len(errors) > 0 {
+		t.RecordFailure(errors)
 		event := new(scheduler_event.MetricCollectionFailedEvent)
 		event.TaskID = t.id
 		event.Errors = errors


### PR DESCRIPTION
Fixes #858

Summary of changes:
- Send errors to RecordFailure if a job error exists
- Send promise errors to RecordFailure if errors exist

Testing done:
- unit mock test

@intelsdi-x/snap-maintainers

