### PR TITLE
Remove links from committed plugins section

### DIFF
--- a/docs/PLUGIN_CATALOG.md
+++ b/docs/PLUGIN_CATALOG.md
@@ -58,9 +58,10 @@ These plugins are in planned/active development. This list is useful if you want
 
 | Name  | Type  | Description | Link | Authors |
 | :---- | :---- | :---------- | :--- | :------ |
-| Cassandra | Collector | Collects metrics from Cassandra cluster | [snap-plugin-collector-cassandra](https://github.com/intelsdi-x/snap-plugin-collector-cassandra) | [@candysmurf](https://github.com/candysmurf) |
-| Open vSwitch | Collector | Collect Open vSwitch performance data | -| [@sandlbn](https://github.com/sandlbn) |
-| Cassandra | Publisher | Publishes snap metrics into Cassandra | [snap-plugin-publisher-cassandra](https://github.com/intelsdi-x/snap-plugin-publisher-cassandra) | [@candysmurf](https://github.com/candysmurf) |
+| Cassandra | Collector | Collects metrics from Cassandra cluster | - | [@candysmurf](https://github.com/candysmurf) |
+| Open vSwitch | Collector | Collects Open vSwitch performance data | -| [@sandlbn](https://github.com/sandlbn) |
+| Redfish | Collector | Collects metrics from Redfish API | - | [@candysmurf](https://github.com/candysmurf) |
+| Cassandra | Publisher | Publishes snap metrics into Cassandra | - | [@candysmurf](https://github.com/candysmurf) |
 
 ## Wish List
 This is a wish list of plugins for snap. If you see one here and want to start on it please let us know.


### PR DESCRIPTION
Summary of changes:
- Removes links from committed plugins section in plugin catalog

Testing done:
- HTML page testing.

@intelsdi-x/snap-maintainers

