### PR TITLE
Fixes #799: Exposes collector plugin defaults to the framework

### DIFF
--- a/control/plugin/client/httpjsonrpc_test.go
+++ b/control/plugin/client/httpjsonrpc_test.go
@@ -240,7 +240,7 @@ func TestHTTPJSONRPC(t *testing.T) {
 				cpn, cserrs := node.Process(mts[0].Config().Table())
 				So(cpn, ShouldNotBeNil)
 				So((*cpn)["somefloat"].Type(), ShouldResemble, "float")
-				So((*cpn)["somefloat"].(*ctypes.ConfigValueFloat).Value, ShouldResemble, 3.14)
+				So((*cpn)["somefloat"].(ctypes.ConfigValueFloat).Value, ShouldResemble, 3.14)
 				So(cserrs.Errors(), ShouldBeEmpty)
 			})
 		})

--- a/control/plugin/cpolicy/bool.go
+++ b/control/plugin/cpolicy/bool.go
@@ -129,7 +129,7 @@ func (b *BoolRule) Validate(cv ctypes.ConfigValue) error {
 // Default returns a default value is it exists.
 func (b *BoolRule) Default() ctypes.ConfigValue {
 	if b.default_ != nil {
-		return &ctypes.ConfigValueBool{Value: *b.default_}
+		return ctypes.ConfigValueBool{Value: *b.default_}
 	}
 	return nil
 }

--- a/control/plugin/cpolicy/bool_test.go
+++ b/control/plugin/cpolicy/bool_test.go
@@ -54,7 +54,7 @@ func TestConfigPolicyRuleBool(t *testing.T) {
 			r, e := NewBoolRule("thekey", true, true)
 			So(r.Default(), ShouldNotBeNil)
 			So(r.Default().Type(), ShouldEqual, "bool")
-			So(r.Default().(*ctypes.ConfigValueBool).Value, ShouldEqual, true)
+			So(r.Default().(ctypes.ConfigValueBool).Value, ShouldEqual, true)
 			So(e, ShouldBeNil)
 		})
 
@@ -69,7 +69,7 @@ func TestConfigPolicyRuleBool(t *testing.T) {
 			Convey("passes with string config value", func() {
 				r, e := NewBoolRule("thekey", true, true)
 				So(r.Default().Type(), ShouldEqual, "bool")
-				So(r.Default().(*ctypes.ConfigValueBool).Value, ShouldEqual, true)
+				So(r.Default().(ctypes.ConfigValueBool).Value, ShouldEqual, true)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueBool{Value: true}
@@ -81,7 +81,7 @@ func TestConfigPolicyRuleBool(t *testing.T) {
 			Convey("errors with non-string config value", func() {
 				r, e := NewBoolRule("thekey", true, true)
 				So(r.Default().Type(), ShouldEqual, "bool")
-				So(r.Default().(*ctypes.ConfigValueBool).Value, ShouldEqual, true)
+				So(r.Default().(ctypes.ConfigValueBool).Value, ShouldEqual, true)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueInt{Value: 1}

--- a/control/plugin/cpolicy/float.go
+++ b/control/plugin/cpolicy/float.go
@@ -176,7 +176,7 @@ func (f *FloatRule) Validate(cv ctypes.ConfigValue) error {
 // Default returns the rule's default value
 func (f *FloatRule) Default() ctypes.ConfigValue {
 	if f.default_ != nil {
-		return &ctypes.ConfigValueFloat{Value: *f.default_}
+		return ctypes.ConfigValueFloat{Value: *f.default_}
 	}
 	return nil
 }
@@ -198,14 +198,14 @@ func (f *FloatRule) SetMaximum(m float64) {
 
 func (i *FloatRule) Minimum() ctypes.ConfigValue {
 	if i.minimum != nil {
-		return &ctypes.ConfigValueFloat{Value: *i.minimum}
+		return ctypes.ConfigValueFloat{Value: *i.minimum}
 	}
 	return nil
 }
 
 func (i *FloatRule) Maximum() ctypes.ConfigValue {
 	if i.maximum != nil {
-		return &ctypes.ConfigValueFloat{Value: *i.maximum}
+		return ctypes.ConfigValueFloat{Value: *i.maximum}
 	}
 	return nil
 }

--- a/control/plugin/cpolicy/float_test.go
+++ b/control/plugin/cpolicy/float_test.go
@@ -54,7 +54,7 @@ func TestConfigPolicyRuleFloat(t *testing.T) {
 			r, e := NewFloatRule("thekey", true, 7)
 			So(r.Default(), ShouldNotBeNil)
 			So(r.Default().Type(), ShouldEqual, "float")
-			So(r.Default().(*ctypes.ConfigValueFloat).Value, ShouldEqual, 7)
+			So(r.Default().(ctypes.ConfigValueFloat).Value, ShouldEqual, 7)
 			So(e, ShouldBeNil)
 		})
 
@@ -84,7 +84,7 @@ func TestConfigPolicyRuleFloat(t *testing.T) {
 				r, e := NewFloatRule("thekey", true, 7)
 				So(r.Default(), ShouldNotBeNil)
 				So(r.Default().Type(), ShouldEqual, "float")
-				So(r.Default().(*ctypes.ConfigValueFloat).Value, ShouldEqual, 7)
+				So(r.Default().(ctypes.ConfigValueFloat).Value, ShouldEqual, 7)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueFloat{Value: 1}
@@ -105,7 +105,7 @@ func TestConfigPolicyRuleFloat(t *testing.T) {
 				r, e := NewFloatRule("thekey", true, 2)
 				So(r.Default(), ShouldNotBeNil)
 				So(r.Default().Type(), ShouldEqual, "float")
-				So(r.Default().(*ctypes.ConfigValueFloat).Value, ShouldEqual, 2)
+				So(r.Default().(ctypes.ConfigValueFloat).Value, ShouldEqual, 2)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueStr{Value: "wat"}

--- a/control/plugin/cpolicy/integer.go
+++ b/control/plugin/cpolicy/integer.go
@@ -179,7 +179,7 @@ func (i *IntRule) Validate(cv ctypes.ConfigValue) error {
 // Default return this rules default value
 func (i *IntRule) Default() ctypes.ConfigValue {
 	if i.default_ != nil {
-		return &ctypes.ConfigValueInt{Value: *i.default_}
+		return ctypes.ConfigValueInt{Value: *i.default_}
 	}
 	return nil
 }
@@ -201,14 +201,14 @@ func (i *IntRule) SetMaximum(m int) {
 
 func (i *IntRule) Minimum() ctypes.ConfigValue {
 	if i.minimum != nil {
-		return &ctypes.ConfigValueInt{Value: *i.minimum}
+		return ctypes.ConfigValueInt{Value: *i.minimum}
 	}
 	return nil
 }
 
 func (i *IntRule) Maximum() ctypes.ConfigValue {
 	if i.maximum != nil {
-		return &ctypes.ConfigValueInt{Value: *i.maximum}
+		return ctypes.ConfigValueInt{Value: *i.maximum}
 	}
 	return nil
 }

--- a/control/plugin/cpolicy/integer_test.go
+++ b/control/plugin/cpolicy/integer_test.go
@@ -54,7 +54,7 @@ func TestConfigPolicyRuleInteger(t *testing.T) {
 			r, e := NewIntegerRule("thekey", true, 7)
 			So(r.Default(), ShouldNotBeNil)
 			So(r.Default().Type(), ShouldEqual, "integer")
-			So(r.Default().(*ctypes.ConfigValueInt).Value, ShouldEqual, 7)
+			So(r.Default().(ctypes.ConfigValueInt).Value, ShouldEqual, 7)
 			So(e, ShouldBeNil)
 		})
 
@@ -84,7 +84,7 @@ func TestConfigPolicyRuleInteger(t *testing.T) {
 				r, e := NewIntegerRule("thekey", true, 7)
 				So(r.Default(), ShouldNotBeNil)
 				So(r.Default().Type(), ShouldEqual, "integer")
-				So(r.Default().(*ctypes.ConfigValueInt).Value, ShouldEqual, 7)
+				So(r.Default().(ctypes.ConfigValueInt).Value, ShouldEqual, 7)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueInt{Value: 1}
@@ -105,7 +105,7 @@ func TestConfigPolicyRuleInteger(t *testing.T) {
 				r, e := NewIntegerRule("thekey", true, 2)
 				So(r.Default(), ShouldNotBeNil)
 				So(r.Default().Type(), ShouldEqual, "integer")
-				So(r.Default().(*ctypes.ConfigValueInt).Value, ShouldEqual, 2)
+				So(r.Default().(ctypes.ConfigValueInt).Value, ShouldEqual, 2)
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueStr{Value: "wat"}

--- a/control/plugin/cpolicy/node_test.go
+++ b/control/plugin/cpolicy/node_test.go
@@ -122,9 +122,9 @@ func TestConfigPolicyNode(t *testing.T) {
 		m2, pe := n.Process(m)
 
 		So(len(pe.Errors()), ShouldEqual, 0)
-		So((*m2)["username"].(*ctypes.ConfigValueStr).Value, ShouldEqual, "root")
-		So((*m2)["port"].(*ctypes.ConfigValueInt).Value, ShouldEqual, 8080)
-		So((*m2)["nova"].(*ctypes.ConfigValueBool).Value, ShouldEqual, true)
+		So((*m2)["username"].(ctypes.ConfigValueStr).Value, ShouldEqual, "root")
+		So((*m2)["port"].(ctypes.ConfigValueInt).Value, ShouldEqual, 8080)
+		So((*m2)["nova"].(ctypes.ConfigValueBool).Value, ShouldEqual, true)
 	})
 
 	Convey("defaults don't fix missing values on required", t, func() {

--- a/control/plugin/cpolicy/string.go
+++ b/control/plugin/cpolicy/string.go
@@ -130,7 +130,7 @@ func (s *StringRule) Validate(cv ctypes.ConfigValue) error {
 // Returns a default value is it exists.
 func (s *StringRule) Default() ctypes.ConfigValue {
 	if s.default_ != nil {
-		return &ctypes.ConfigValueStr{Value: *s.default_}
+		return ctypes.ConfigValueStr{Value: *s.default_}
 	}
 	return nil
 }

--- a/control/plugin/cpolicy/string_test.go
+++ b/control/plugin/cpolicy/string_test.go
@@ -54,7 +54,7 @@ func TestConfigPolicyRuleString(t *testing.T) {
 			r, e := NewStringRule("thekey", true, "wat")
 			So(r.Default(), ShouldNotBeNil)
 			So(r.Default().Type(), ShouldEqual, "string")
-			So(r.Default().(*ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
+			So(r.Default().(ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
 			So(e, ShouldBeNil)
 		})
 
@@ -69,7 +69,7 @@ func TestConfigPolicyRuleString(t *testing.T) {
 			Convey("passes with string config value", func() {
 				r, e := NewStringRule("thekey", true, "wat")
 				So(r.Default().Type(), ShouldEqual, "string")
-				So(r.Default().(*ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
+				So(r.Default().(ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueStr{Value: "foo"}
@@ -81,7 +81,7 @@ func TestConfigPolicyRuleString(t *testing.T) {
 			Convey("errors with non-string config value", func() {
 				r, e := NewStringRule("thekey", true, "wat")
 				So(r.Default().Type(), ShouldEqual, "string")
-				So(r.Default().(*ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
+				So(r.Default().(ctypes.ConfigValueStr).Value, ShouldEqual, "wat")
 				So(e, ShouldBeNil)
 
 				v := ctypes.ConfigValueInt{Value: 1}

--- a/control/plugin/cpolicy/tree.go
+++ b/control/plugin/cpolicy/tree.go
@@ -144,6 +144,22 @@ func (c *ConfigPolicy) Get(ns []string) *ConfigPolicyNode {
 	}
 }
 
+func (c *ConfigPolicy) GetAll() map[string]*ConfigPolicyNode {
+	// Automatically freeze on first Get
+	if !c.config.Frozen() {
+		c.config.Freeze()
+	}
+
+	ret := map[string]*ConfigPolicyNode{}
+	for key, node := range c.config.GetAll() {
+		switch t := node.(type) {
+		case *ConfigPolicyNode:
+			ret[key] = t
+		}
+	}
+	return ret
+}
+
 // Freezes the ConfigPolicy from future writes (adds) and triggers compression
 // of tree into read-performant version.
 func (c *ConfigPolicy) Freeze() {

--- a/control/plugin/cpolicy/tree_test.go
+++ b/control/plugin/cpolicy/tree_test.go
@@ -49,7 +49,7 @@ func TestConfigPolicy(t *testing.T) {
 			Convey("retrieves store policy", func() {
 				gc := cp.Get(ns)
 				So(gc.rules["username"].Required(), ShouldEqual, false)
-				So(gc.rules["username"].Default().(*ctypes.ConfigValueStr).Value, ShouldEqual, "root")
+				So(gc.rules["username"].Default().(ctypes.ConfigValueStr).Value, ShouldEqual, "root")
 				So(gc.rules["password"].Required(), ShouldEqual, true)
 			})
 			Convey("encode & decode", func() {
@@ -69,7 +69,7 @@ func TestConfigPolicy(t *testing.T) {
 				So(gc.rules["password"].Required(), ShouldEqual, true)
 				So(gc.rules["username"].Default(), ShouldNotBeNil)
 				So(gc.rules["password"].Default(), ShouldBeNil)
-				So(gc.rules["username"].Default().(*ctypes.ConfigValueStr).Value, ShouldEqual, "root")
+				So(gc.rules["username"].Default().(ctypes.ConfigValueStr).Value, ShouldEqual, "root")
 			})
 
 		})

--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -95,20 +95,22 @@ github.com/intelsdi-x/snap/control/plugin/cpolicy
 github.com/intelsdi-x/snap/core/ctypes  
 ```
 ### Writing a collector plugin
-A Snap collector plugin collects telemetry data by communicating with the Snap daemon. To confine to collector plugin interfaces and metric types defined in Snap,  a collector plugin must implement the following methods:
+A Snap collector plugin collects telemetry data by communicating with the Snap daemon. To confine to collector plugin interfaces and metric types defined in Snap, a collector plugin must implement the following methods:
 ```
 GetConfigPolicy() (*cpolicy.ConfigPolicy, error)
 CollectMetrics([]MetricType) ([]MetricType, error)
 GetMetricTypes(ConfigType) ([]MetricType, error)
 ```
+The plugin uses the default values given in the ConfigPolicy so a config file doesn't need to be passed in for these rules. An example use case would be for the URL the Apache Collector collects from. Disclaimer: Two namespaces can't have rules with the same key name. E.g. you can't have the key "username" for /intel/foo/bar and a different "username" for /intel/foo/mock. They would need unique keys.
+
 ### Writing a processor plugin
-A Snap processor plugin allows filtering, aggregation, transformation, etc of collected telemetry data. To complaint with processor plugin interfaces defined in Snap,  a processor plugin must implement the following methods:
+A Snap processor plugin allows filtering, aggregation, transformation, etc of collected telemetry data. To complaint with processor plugin interfaces defined in Snap, a processor plugin must implement the following methods:
 ```
 GetConfigPolicy() (*cpolicy.ConfigPolicy, error)
 Process(contentType string, content []byte, config map[string]ctypes.ConfigValue) (string, []byte, error)
 ```
 ### Writing a publisher plugin
-A Snap publisher plugin allows publishing processed telemetry data into a variety of systems, databases, and monitors through Snap metrics. To compliant with metric types and plugin interfaces defined in Snap,  a publisher plugin must implement the following methods:
+A Snap publisher plugin allows publishing processed telemetry data into a variety of systems, databases, and monitors through Snap metrics. To compliant with metric types and plugin interfaces defined in Snap, a publisher plugin must implement the following methods:
 ```
 GetConfigPolicy() (*cpolicy.ConfigPolicy, error)
 Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error

--- a/pkg/ctree/tree.go
+++ b/pkg/ctree/tree.go
@@ -24,6 +24,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -117,6 +118,35 @@ func (c *ConfigTree) Add(ns []string, inNode Node) {
 	}
 	c.root.add(remain, inNode)
 
+}
+
+func (c *ConfigTree) GetAll() map[string]Node {
+	ret := map[string]Node{}
+	if !c.Frozen() {
+		panic("must freeze before getting")
+	}
+	if c.root == nil {
+		c.log(fmt.Sprintln("ctree: no root - returning nil"))
+		return nil
+	}
+	return c.getAll(c.root, "", ret)
+}
+
+func (c *ConfigTree) getAll(node *node, base string, results map[string]Node) map[string]Node {
+	if len(node.keys) > 0 {
+		if base != "" {
+			base = base + "." + strings.Join(node.keys, ".")
+		} else {
+			base = strings.Join(node.keys, ".")
+		}
+		if node.Node != nil {
+			results[base] = node.Node
+		}
+	}
+	for _, child := range node.nodes {
+		c.getAll(child, base, results)
+	}
+	return results
 }
 
 // Get returns a tree node given the namespace

--- a/plugin/collector/snap-collector-mock1/mock/mock.go
+++ b/plugin/collector/snap-collector-mock1/mock/mock.go
@@ -67,9 +67,9 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 			}
 		} else {
 			if cv, ok := p.Config().Table()["test"]; ok {
-				p.Data_ = fmt.Sprintf("The mock collected data! config data: user=%s password=%s test=%v", p.Config().Table()["user"], p.Config().Table()["password"], cv.(ctypes.ConfigValueBool).Value)
+				p.Data_ = fmt.Sprintf("The mock collected data! config data: name=%s password=%s test=%v", p.Config().Table()["name"], p.Config().Table()["password"], cv.(ctypes.ConfigValueBool).Value)
 			} else {
-				p.Data_ = fmt.Sprintf("The mock collected data! config data: user=%s password=%s", p.Config().Table()["user"], p.Config().Table()["password"])
+				p.Data_ = fmt.Sprintf("The mock collected data! config data: name=%s password=%s", p.Config().Table()["name"], p.Config().Table()["password"])
 			}
 			p.Timestamp_ = time.Now()
 			metrics = append(metrics, p)


### PR DESCRIPTION
Fixes #799 

Summary of changes:
- Switched ctypes.ConfigValueX to pass by value instead of reference
- Updated mock1 so the required password doesn't fail all tests since I moved the rules to the root
- Added defaults to GetMetricTypes call and the plugin config

Testing done:
- Ran tests
- Added testing
- Removed check from Apache plugin and it loaded correctly
- Loaded plugins with print statements
     - For mock1 the config passed into GetMetricTypes is cfg : map[name:{bob}]
     - For CollectMetrics name is only being set in the config policy and for "test" it gives "The mock collected data! config data: name={bob} password={testval} test=true"

@intelsdi-x/snap-maintainers