### PR TITLE
Move plugin auto discovery into control module

### DIFF
--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -56,10 +56,11 @@ var (
 	// Switching this turns on logging for all the REST API calls
 	LOG_LEVEL = log.WarnLevel
 
-	SNAP_PATH         = os.Getenv("SNAP_PATH")
-	MOCK_PLUGIN_PATH1 = SNAP_PATH + "/plugin/snap-collector-mock1"
-	MOCK_PLUGIN_PATH2 = SNAP_PATH + "/plugin/snap-collector-mock2"
-	FILE_PLUGIN_PATH  = SNAP_PATH + "/plugin/snap-publisher-file"
+	SNAP_PATH              = os.Getenv("SNAP_PATH")
+	SNAP_AUTODISCOVER_PATH = os.Getenv("SNAP_AUTODISCOVER_PATH")
+	MOCK_PLUGIN_PATH1      = SNAP_PATH + "/plugin/snap-collector-mock1"
+	MOCK_PLUGIN_PATH2      = SNAP_PATH + "/plugin/snap-collector-mock2"
+	FILE_PLUGIN_PATH       = SNAP_PATH + "/plugin/snap-publisher-file"
 
 	CompressedUpload = true
 	TotalUploadSize  = 0
@@ -582,6 +583,12 @@ func TestPluginRestCalls(t *testing.T) {
 				cfg := getDefaultMockConfig()
 				err := cfgfile.Read("../../examples/configs/snap-config-sample.json", &cfg, MOCK_CONSTRAINTS)
 				So(err, ShouldBeNil)
+				if len(SNAP_AUTODISCOVER_PATH) == 0 {
+					if len(SNAP_PATH) != 0 {
+						SNAP_AUTODISCOVER_PATH = fmt.Sprintf("%s/plugin", SNAP_PATH)
+					}
+				}
+				cfg.Control.AutoDiscoverPath = SNAP_AUTODISCOVER_PATH
 				r := startAPI(cfg)
 				port := r.port
 				col := core.CollectorPluginType

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -586,7 +586,10 @@ func TestPluginRestCalls(t *testing.T) {
 				if len(SNAP_AUTODISCOVER_PATH) == 0 {
 					if len(SNAP_PATH) != 0 {
 						SNAP_AUTODISCOVER_PATH = fmt.Sprintf("%s/plugin", SNAP_PATH)
+						log.Warning(fmt.Sprintf("SNAP_AUTODISCOVER_PATH has been set to SNAP_PATH/plugin (%s). This might cause test failures", SNAP_AUTODISCOVER_PATH))
 					}
+				} else {
+					log.Warning(fmt.Sprintf("SNAP_AUTODISCOVER_PATH is set to %s. This might cause test failures", SNAP_AUTODISCOVER_PATH))
 				}
 				cfg.Control.AutoDiscoverPath = SNAP_AUTODISCOVER_PATH
 				r := startAPI(cfg)


### PR DESCRIPTION
Summary of changes:
- moved code from snapd.go into control/control.go as suggested in [https://github.com/intelsdi-x/snap/issues/950]

Testing done (using GO 1.6.2):
- successfully launched with auto-discovery-path set
- all autoloaded standard plugins (mock, file, passthrough) functional
- same tests without auto-discovery-path being set and same plugins loaded via CLI
- all tests passed in legacy, small, medium and large configs

@intelsdi-x/snap-maintainers

