### PR TITLE
Fixed #889: Made snapd honor log level settings

### DIFF
--- a/snapd.go
+++ b/snapd.go
@@ -287,13 +287,17 @@ func action(ctx *cli.Context) {
 		log.SetOutput(file)
 	}
 
+	// Validate log level and trust level settings for snapd
+	validateLevelSettings(cfg.LogLevel, cfg.Control.PluginTrust)
+
+	// Switch log level to user defined
+	log.SetLevel(getLevel(cfg.LogLevel))
+	log.Info("setting log level to: ", l[cfg.LogLevel])
+
 	log.Info("Starting snapd (version: ", gitversion, ")")
 
 	// Set Max Processors for snapd.
 	setMaxProcs(cfg.GoMaxProcs)
-
-	// Validate log level and trust level settings for snapd
-	validateLevelSettings(cfg.LogLevel, cfg.Control.PluginTrust)
 
 	c := control.New(cfg.Control)
 
@@ -475,10 +479,6 @@ func action(ctx *cli.Context) {
 			"block":   "main",
 			"_module": "snapd",
 		}).Info("snapd started")
-
-	// Switch log level to user defined
-	log.Info("setting log level to: ", l[cfg.LogLevel])
-	log.SetLevel(getLevel(cfg.LogLevel))
 
 	select {} //run forever and ever
 }


### PR DESCRIPTION
Fixes #889

Summary of changes:
- Made snapd honor log level settings from config and command line flags for startup log messages.

Testing done:
- Before
```
❯ go run ./snapd.go -t 0 -l 1 
INFO[0000] Starting snapd (version: unknown) 
INFO[0000] setting GOMAXPROCS to: 1 core(s) 
INFO[0000] Setting work manager queue size _block=New _module=scheduler value=25
INFO[0000] Setting work manager pool size _block=New _module=scheduler value=4
INFO[0000] Configuring REST API with HTTPS set to: false _module=_mgmt-rest
INFO[0000] REST API is enabled 
INFO[0000] control started _block=start _module=control
INFO[0000] module started _module=snapd block=main snap-module=control
INFO[0000] scheduler started _block=start-scheduler _module=scheduler
INFO[0000] module started _module=snapd block=main snap-module=scheduler
INFO[0000] Starting REST API on :8181 _module=_mgmt-rest
INFO[0000] REST started _block=start _module=_mgmt-rest
INFO[0000] module started _module=snapd block=main snap-module=REST
INFO[0000] setting plugin trust level to: disabled 
INFO[0000] auto discover path is disabled 
INFO[0000] snapd started 
```

- After
```
❯ go run ./snapd.go -t 0 -l 1 
INFO[0000] setting log level to: debug
INFO[0000] Starting snapd (version: v0.13.0-beta-116-g8f373ab)
INFO[0000] setting GOMAXPROCS to: 1 core(s)
DEBU[0000] pevent controller created                     _block=new _module=control
DEBU[0000] metric catalog created                        _block=new _module=control
DEBU[0000] plugin manager created                        _block=new _module=control
DEBU[0000] signing manager created                       _block=new _module=control
DEBU[0000] runner created                                _block=new _module=control
DEBU[0000] started                                       _block=start _module=control-runner
INFO[0000] Setting work manager queue size               _block=New _module=scheduler value=25
INFO[0000] Setting work manager pool size                _block=New _module=scheduler value=4
DEBU[0000] metric manager linked                         _block=set-metric-manager _module=scheduler
INFO[0000] Configuring REST API with HTTPS set to: false  _module=_mgmt-rest
INFO[0000] Setting address to: [] Default port: 8181     _module=_mgmt-rest
INFO[0000] Address used for binding: [:8181]             _module=_mgmt-rest
INFO[0000] REST API is enabled
INFO[0000] control started                               _block=start _module=control
INFO[0000] module started                                _module=snapd block=main snap-module=control
INFO[0000] scheduler started                             _block=start-scheduler _module=scheduler
INFO[0000] module started                                _module=snapd block=main snap-module=scheduler
INFO[0000] Starting REST API on :8181                    _module=_mgmt-rest
INFO[0000] REST started                                  _block=start _module=_mgmt-rest
INFO[0000] module started                                _module=snapd block=main snap-module=REST
INFO[0000] setting plugin trust level to: disabled
INFO[0000] auto discover path is disabled
INFO[0000] snapd started                                 _module=snapd block=main
```

@intelsdi-x/snap-maintainers