### PR TITLE
Fixes #900: Removes '0' from the list of valid ports

### DIFF
--- a/control/flags.go
+++ b/control/flags.go
@@ -1,0 +1,56 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package control
+
+import "github.com/codegangsta/cli"
+
+var (
+	flNumberOfPLs = cli.IntFlag{
+		Name:   "max-running-plugins, m",
+		Value:  defaultMaxRunningPlugins,
+		Usage:  "The maximum number of instances of a loaded plugin to run",
+		EnvVar: "SNAP_MAX_PLUGINS",
+	}
+	flPluginTrust = cli.IntFlag{
+		Name:   "plugin-trust, t",
+		Usage:  "0-2 (Disabled, Enabled, Warning)",
+		Value:  defaultPluginTrust,
+		EnvVar: "SNAP_TRUST_LEVEL",
+	}
+	flAutoDiscover = cli.StringFlag{
+		Name:   "auto-discover, a",
+		Usage:  "Auto discover paths separated by colons.",
+		EnvVar: "SNAP_AUTODISCOVER_PATH",
+	}
+	flKeyringPaths = cli.StringFlag{
+		Name:   "keyring-paths, k",
+		Usage:  "Keyring paths for signing verification separated by colons",
+		EnvVar: "SNAP_KEYRING_PATHS",
+	}
+	flCache = cli.DurationFlag{
+		Name:   "cache-expiration",
+		Usage:  "The time limit for which a metric cache entry is valid",
+		Value:  defaultCacheExpiration,
+		EnvVar: "SNAP_CACHE_EXPIRATION",
+	}
+
+	// Flags consumed by snapd
+	Flags = []cli.Flag{flNumberOfPLs, flPluginTrust, flAutoDiscover, flKeyringPaths, flCache}
+)

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -1,0 +1,63 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+)
+
+var (
+	flAPIDisabled = cli.BoolFlag{
+		Name:  "disable-api, d",
+		Usage: "Disable the agent REST API",
+	}
+	flAPIAddr = cli.StringFlag{
+		Name:   "api-addr, b",
+		Usage:  "API Address[:port] to bind to/listen on. Default: empty string => listen on all interfaces",
+		EnvVar: "SNAP_ADDR",
+	}
+	flAPIPort = cli.IntFlag{
+		Name:   "api-port, p",
+		Usage:  fmt.Sprintf("API port (Default: %d)", defaultPort),
+		Value:  defaultPort,
+		EnvVar: "SNAP_PORT",
+	}
+	flRestHTTPS = cli.BoolFlag{
+		Name:  "rest-https",
+		Usage: "start snap's API as https",
+	}
+	flRestCert = cli.StringFlag{
+		Name:  "rest-cert",
+		Usage: "A path to a certificate to use for HTTPS deployment of snap's REST API",
+	}
+	flRestKey = cli.StringFlag{
+		Name:  "rest-key",
+		Usage: "A path to a key file to use for HTTPS deployment of snap's REST API",
+	}
+	flRestAuth = cli.BoolFlag{
+		Name:  "rest-auth",
+		Usage: "Enables snap's REST API authentication",
+	}
+
+	// Flags consumed by snapd
+	Flags = []cli.Flag{flAPIDisabled, flAPIAddr, flAPIPort, flRestHTTPS, flRestCert, flRestKey, flRestAuth}
+)

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -107,7 +107,7 @@ const (
 					},
 					"port" : {
 						"type": "integer",
-						"minimum": 0,
+						"minimum": 1,
 						"maximum": 65535
 					},
 					"addr" : {

--- a/mgmt/tribe/flags.go
+++ b/mgmt/tribe/flags.go
@@ -43,6 +43,7 @@ var (
 	flTribeAdvertisePort = cli.IntFlag{
 		Name:   "tribe-port",
 		Usage:  "Port tribe gossips over to maintain membership",
+		Value:  defaultBindPort,
 		EnvVar: "SNAP_TRIBE_PORT",
 	}
 

--- a/scheduler/flags.go
+++ b/scheduler/flags.go
@@ -19,18 +19,24 @@ limitations under the License.
 
 package scheduler
 
-import "github.com/codegangsta/cli"
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+)
 
 var (
 	flSchedulerQueueSize = cli.IntFlag{
 		Name:   "work-manager-queue-size",
-		Usage:  "Size of the work manager queue (default: 25)",
+		Usage:  fmt.Sprintf("Size of the work manager queue (default: %d)", defaultWorkManagerQueueSize),
+		Value:  int(defaultWorkManagerQueueSize),
 		EnvVar: "WORK_MANAGER_QUEUE_SIZE",
 	}
 
 	flSchedulerPoolSize = cli.IntFlag{
 		Name:   "work-manager-pool-size",
-		Usage:  "Size of the work manager pool (default 4)",
+		Usage:  fmt.Sprintf("Size of the work manager pool (default %d)", defaultWorkManagerPoolSize),
+		Value:  int(defaultWorkManagerPoolSize),
 		EnvVar: "WORK_MANAGER_POOL_SIZE",
 	}
 

--- a/snapd.go
+++ b/snapd.go
@@ -48,29 +48,11 @@ import (
 )
 
 var (
-	flAPIDisabled = cli.BoolFlag{
-		Name:  "disable-api, d",
-		Usage: "Disable the agent REST API",
-	}
-	flAPIPort = cli.IntFlag{
-		Name:   "api-port, p",
-		Usage:  "API port (Default: 8181)",
-		EnvVar: "SNAP_PORT",
-	}
-	flAPIAddr = cli.StringFlag{
-		Name:   "api-addr, b",
-		Usage:  "API Address[:port] to bind to/listen on. Default: empty string => listen on all interfaces",
-		EnvVar: "SNAP_ADDR",
-	}
 	flMaxProcs = cli.IntFlag{
 		Name:   "max-procs, c",
-		Usage:  "Set max cores to use for snap Agent. Default is 1 core.",
+		Usage:  fmt.Sprintf("Set max cores to use for snap Agent. Default is %d core.", defaultGoMaxProcs),
+		Value:  defaultGoMaxProcs,
 		EnvVar: "GOMAXPROCS",
-	}
-	flNumberOfPLs = cli.IntFlag{
-		Name:   "max-running-plugins, m",
-		Usage:  "The maximum number of instances of a loaded plugin to run",
-		EnvVar: "SNAP_MAX_PLUGINS",
 	}
 	// plugin
 	flLogPath = cli.StringFlag{
@@ -81,48 +63,13 @@ var (
 	flLogLevel = cli.IntFlag{
 		Name:   "log-level, l",
 		Usage:  "1-5 (Debug, Info, Warning, Error, Fatal)",
+		Value:  defaultLogLevel,
 		EnvVar: "SNAP_LOG_LEVEL",
-	}
-	flAutoDiscover = cli.StringFlag{
-		Name:   "auto-discover, a",
-		Usage:  "Auto discover paths separated by colons.",
-		EnvVar: "SNAP_AUTODISCOVER_PATH",
-	}
-	flPluginTrust = cli.IntFlag{
-		Name:   "plugin-trust, t",
-		Usage:  "0-2 (Disabled, Enabled, Warning)",
-		EnvVar: "SNAP_TRUST_LEVEL",
-	}
-	flKeyringPaths = cli.StringFlag{
-		Name:   "keyring-paths, k",
-		Usage:  "Keyring paths for signing verification separated by colons",
-		EnvVar: "SNAP_KEYRING_PATHS",
-	}
-	flCache = cli.DurationFlag{
-		Name:   "cache-expiration",
-		Usage:  "The time limit for which a metric cache entry is valid",
-		EnvVar: "SNAP_CACHE_EXPIRATION",
 	}
 	flConfig = cli.StringFlag{
 		Name:   "config",
 		Usage:  "A path to a config file",
 		EnvVar: "SNAP_CONFIG_PATH",
-	}
-	flRestHTTPS = cli.BoolFlag{
-		Name:  "rest-https",
-		Usage: "start snap's API as https",
-	}
-	flRestCert = cli.StringFlag{
-		Name:  "rest-cert",
-		Usage: "A path to a certificate to use for HTTPS deployment of snap's REST API",
-	}
-	flRestKey = cli.StringFlag{
-		Name:  "rest-key",
-		Usage: "A path to a key file to use for HTTPS deployment of snap's REST API",
-	}
-	flRestAuth = cli.BoolFlag{
-		Name:  "rest-auth",
-		Usage: "Enables snap's REST API authentication",
 	}
 
 	gitversion  string
@@ -230,24 +177,14 @@ func main() {
 	app.Version = gitversion
 	app.Usage = "A powerful telemetry framework"
 	app.Flags = []cli.Flag{
-		flAPIDisabled,
-		flAPIPort,
-		flAPIAddr,
 		flLogLevel,
 		flLogPath,
 		flMaxProcs,
-		flAutoDiscover,
-		flNumberOfPLs,
-		flCache,
-		flPluginTrust,
-		flKeyringPaths,
-		flRestCert,
 		flConfig,
-		flRestHTTPS,
-		flRestKey,
-		flRestAuth,
 	}
 	app.Flags = append(app.Flags, scheduler.Flags...)
+	app.Flags = append(app.Flags, control.Flags...)
+	app.Flags = append(app.Flags, rest.Flags...)
 	app.Flags = append(app.Flags, tribe.Flags...)
 
 	app.Action = action


### PR DESCRIPTION
Fixes #900

Summary of changes:
- Removes '0' from the list of valid ports that the RESTful API can be started on (as such, since a non-zero port must be specified or the default port used, the RESTful API will not have a port dynamically assigned when `snapd` starts up so there is no need to display the port that was chosen in the log file)
- Refactored how the command-line flags are set so that the command-line flags for each package are set locally in a `flags.go` file for that package rather than having the command-line flags for the options from some packages set in a package-level `flags.go` file and while the command-line flags for the options for other packages are set in the `snapd.go` file
- Modified the code that sets the command-line flags so that those that are displaying an example value display the default value for that option in the `--help` output for `snapd` (rather than displaying values like '0' for command-line options like the `--api-port`)

Testing done:
- Tested by attempting to start `snapd` with the `port` set to zero in the global configuration file and observing the error that results, then by starting it with a non-zero port in that same configuration file and observing the successful startup. Also ensured that the `--help` output for `snapd` could be generated successfully with the refactored command-line option code in this PR.

@intelsdi-x/snap-maintainers
