### PR TITLE
Only use version for specific tags.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-GITVERSION=`git describe --always`
+GITVERSION=`git describe --always --exact-match 2> /dev/null || echo "$(git symbolic-ref HEAD 2> /dev/null | cut -b 12-)-$(git log --pretty=format:"%h" -1)"`
 SOURCEDIR=$1
 BUILDPLUGINS=$2
 SPLUGINFOLDER=$3


### PR DESCRIPTION
Since we are interating on snap, we don't want users to think
0.14.0-sha is semantic version of 0.14.0. This ensure the build script
only label version for specific git tags and use branch-sha to
indicate development versions.