### PR TITLE
Fixes #971: Rechecks config option constraints after CLI flags applied

### DIFF
--- a/control/config.go
+++ b/control/config.go
@@ -67,12 +67,12 @@ type pluginConfigItem struct {
 //         UnmarshalJSON method in this same file needs to be modified to
 //         match the field mapping that is defined here
 type Config struct {
-	MaxRunningPlugins int               `json:"max_running_plugins,omitempty"yaml:"max_running_plugins,omitempty"`
-	PluginTrust       int               `json:"plugin_trust_level,omitempty"yaml:"plugin_trust_level,omitempty"`
-	AutoDiscoverPath  string            `json:"auto_discover_path,omitempty"yaml:"auto_discover_path,omitempty"`
-	KeyringPaths      string            `json:"keyring_paths,omitempty"yaml:"keyring_paths,omitempty"`
-	CacheExpiration   jsonutil.Duration `json:"cache_expiration,omitempty"yaml:"cache_expiration,omitempty"`
-	Plugins           *pluginConfig     `json:"plugins,omitempty"yaml:"plugins,omitempty"`
+	MaxRunningPlugins int               `json:"max_running_plugins"yaml:"max_running_plugins"`
+	PluginTrust       int               `json:"plugin_trust_level"yaml:"plugin_trust_level"`
+	AutoDiscoverPath  string            `json:"auto_discover_path"yaml:"auto_discover_path"`
+	KeyringPaths      string            `json:"keyring_paths"yaml:"keyring_paths"`
+	CacheExpiration   jsonutil.Duration `json:"cache_expiration"yaml:"cache_expiration"`
+	Plugins           *pluginConfig     `json:"plugins"yaml:"plugins"`
 }
 
 const (

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -72,14 +72,14 @@ var (
 //         UnmarshalJSON method in this same file needs to be modified to
 //         match the field mapping that is defined here
 type Config struct {
-	Enable           bool   `json:"enable,omitempty"yaml:"enable,omitempty"`
-	Port             int    `json:"port,omitempty"yaml:"port,omitempty"`
-	Address          string `json:"addr,omitempty"yaml:"addr,omitempty"`
-	HTTPS            bool   `json:"https,omitempty"yaml:"https,omitempty"`
-	RestCertificate  string `json:"rest_certificate,omitempty"yaml:"rest_certificate,omitempty"`
-	RestKey          string `json:"rest_key,omitempty"yaml:"rest_key,omitempty"`
-	RestAuth         bool   `json:"rest_auth,omitempty"yaml:"rest_auth,omitempty"`
-	RestAuthPassword string `json:"rest_auth_password,omitempty"yaml:"rest_auth_password,omitempty"`
+	Enable           bool   `json:"enable"yaml:"enable"`
+	Port             int    `json:"port"yaml:"port"`
+	Address          string `json:"addr"yaml:"addr"`
+	HTTPS            bool   `json:"https"yaml:"https"`
+	RestCertificate  string `json:"rest_certificate"yaml:"rest_certificate"`
+	RestKey          string `json:"rest_key"yaml:"rest_key"`
+	RestAuth         bool   `json:"rest_auth"yaml:"rest_auth"`
+	RestAuthPassword string `json:"rest_auth_password"yaml:"rest_auth_password"`
 }
 
 const (

--- a/mgmt/tribe/config.go
+++ b/mgmt/tribe/config.go
@@ -47,11 +47,11 @@ const (
 //         UnmarshalJSON method in this same file needs to be modified to
 //         match the field mapping that is defined here
 type Config struct {
-	Name                      string             `json:"name,omitempty"yaml:"name,omitempty"`
-	Enable                    bool               `json:"enable,omitempty"yaml:"enable,omitempty"`
-	BindAddr                  string             `json:"bind_addr,omitempty"yaml:"bind_addr,omitempty"`
-	BindPort                  int                `json:"bind_port,omitempty"yaml:"bind_port,omitempty"`
-	Seed                      string             `json:"seed,omitempty"yaml:"seed,omitempty"`
+	Name                      string             `json:"name"yaml:"name"`
+	Enable                    bool               `json:"enable"yaml:"enable"`
+	BindAddr                  string             `json:"bind_addr"yaml:"bind_addr"`
+	BindPort                  int                `json:"bind_port"yaml:"bind_port"`
+	Seed                      string             `json:"seed"yaml:"seed"`
 	MemberlistConfig          *memberlist.Config `json:"-"yaml:"-"`
 	RestAPIProto              string             `json:"-"yaml:"-"`
 	RestAPIPassword           string             `json:"-"yaml:"-"`

--- a/pkg/cfgfile/cfgfile.go
+++ b/pkg/cfgfile/cfgfile.go
@@ -54,14 +54,14 @@ var cfgReader reader
 // validating the schema; first, create an interface to wrap the underlying
 // method that will be used to validate the schema
 type schemaValidator interface {
-	ValidateSchema(schema, cfg string) []serror.SnapError
+	validateSchema(schema, cfg string) []serror.SnapError
 }
 
 // then, define a type (struct) that will validate the underlying schema
 type schemaValidatorType struct{}
 
 // and define an implementation for that type that performs the schema validation
-func (r *schemaValidatorType) ValidateSchema(schema, cfg string) []serror.SnapError {
+func (r *schemaValidatorType) validateSchema(schema, cfg string) []serror.SnapError {
 	schemaLoader := gojsonschema.NewStringLoader(schema)
 	testDoc := gojsonschema.NewStringLoader(cfg)
 	result, err := gojsonschema.Validate(schemaLoader, testDoc)
@@ -110,7 +110,7 @@ func Read(path string, v interface{}, schema string) []serror.SnapError {
 		return []serror.SnapError{serror.New(fmt.Errorf("error converting YAML to JSON: %v", err))}
 	}
 	// validate the resulting JSON against the input the schema
-	if errors := cfgValidator.ValidateSchema(schema, string(jb)); errors != nil {
+	if errors := cfgValidator.validateSchema(schema, string(jb)); errors != nil {
 		// if invalid, construct (and return?) a SnapError from the errors identified
 		// during schema validation
 		return errors
@@ -127,4 +127,10 @@ func Read(path string, v interface{}, schema string) []serror.SnapError {
 		return []serror.SnapError{serror.New(fmt.Errorf("Error while parsing configuration file: %v", errRet))}
 	}
 	return nil
+}
+
+// Validate an input JSON string against the input schema (and return a set of errors
+// or nil if the input JSON string matches the constraints defined in that schema)
+func ValidateSchema(schema, cfg string) []serror.SnapError {
+	return cfgValidator.validateSchema(schema, cfg)
 }

--- a/pkg/cfgfile/cfgfile_small_test.go
+++ b/pkg/cfgfile/cfgfile_small_test.go
@@ -112,8 +112,8 @@ type mockSchemaValidator struct {
 	returnError bool
 }
 
-// and redefine the ValidateSchema method to always return nil (no errors found)
-func (r *mockSchemaValidator) ValidateSchema(schema, cfg string) []serror.SnapError {
+// and redefine the validateSchema method to always return nil (no errors found)
+func (r *mockSchemaValidator) validateSchema(schema, cfg string) []serror.SnapError {
 	if r.returnError {
 		return []serror.SnapError{serror.New(errors.New("Invalid schema"))}
 	}
@@ -185,7 +185,7 @@ func TestValidateSchema(t *testing.T) {
 		config := testConfig{"Tom", "Justin"}
 		cfgValidator = &schemaValidatorType{}
 		jb, _ := json.Marshal(config)
-		errs := cfgValidator.ValidateSchema(MOCK_CONSTRAINTS, string(jb))
+		errs := ValidateSchema(MOCK_CONSTRAINTS, string(jb))
 		So(errs, ShouldBeNil)
 	})
 
@@ -193,7 +193,7 @@ func TestValidateSchema(t *testing.T) {
 		config := testConfig{"Tom", "Justin"}
 		cfgValidator = &schemaValidatorType{}
 		jb, _ := json.Marshal(config)
-		errs := cfgValidator.ValidateSchema(INVALID_MOCK_CONSTRAINTS, string(jb))
+		errs := ValidateSchema(INVALID_MOCK_CONSTRAINTS, string(jb))
 		So(errs, ShouldNotBeNil)
 	})
 
@@ -201,7 +201,7 @@ func TestValidateSchema(t *testing.T) {
 		config := testConfig{"Tom", "Justin"}
 		cfgValidator = &schemaValidatorType{}
 		yb, _ := yaml.Marshal(config)
-		errs := cfgValidator.ValidateSchema(MOCK_CONSTRAINTS, string(yb))
+		errs := ValidateSchema(MOCK_CONSTRAINTS, string(yb))
 		So(errs, ShouldNotBeNil)
 	})
 }

--- a/scheduler/config.go
+++ b/scheduler/config.go
@@ -35,8 +35,8 @@ const (
 //         UnmarshalJSON method in this same file needs to be modified to
 //         match the field mapping that is defined here
 type Config struct {
-	WorkManagerQueueSize uint `json:"work_manager_queue_size,omitempty"yaml:"work_manager_queue_size,omitempty"`
-	WorkManagerPoolSize  uint `json:"work_manager_pool_size,omitempty"yaml:"work_manager_pool_size,omitempty"`
+	WorkManagerQueueSize uint `json:"work_manager_queue_size"yaml:"work_manager_queue_size"`
+	WorkManagerPoolSize  uint `json:"work_manager_pool_size"yaml:"work_manager_pool_size"`
 }
 
 const (


### PR DESCRIPTION
Fixes #971

Summary of changes:
- Modified the `pkg/cfgfile/cfgfile.go` public interface by renaming the `ValidateSchema` method in the underlying `schemaValidator` interface to `validateSchema`, then adding a new `ValidateSchema` function that calls through to that underlying `validateSchema` method; this provides an externally visible function that can be used to check the configuration (after applying the command-line flags) against the constraints specified in the schema from within the `action()` method in the `snapd.go` file
- Modified the `small` tests that previously tested the `ValidateSchema` method from the `schemaValidator` interface so that they test the new `ValidateSchema` function instead
- Removed the `omitempty` tags from the fields in the `Config` structs defined in the `control/config.go`, `mgmt/rest/server.go`, `mgmt/tribe/config.go`, `scheduler/config.go`, and `snapd.go` files; with the `omitempty` tags included files with `zero` values were stripped out of the configuration when we marshalled the resulting configuration as JSON in order to check the configuration against the constraints in the schema (resulting in an incomplete check of the configuration since only `non-zero` fields were checked)
- Added code to check the configuration (after the command-line options had been applied) using the new `ValidateSchema` function and report any errors found; if errors are found, then `snapd` exits with a fatal error

Testing done:
- Verified that the existing small tests from the `pkg/cfgfile` package ran without error after the refactoring was complete
- Started `snapd` using a global configuration file that set the RESTful API port to `0` and verified that an error was reported (the port for the RESTful API must be greater than or equal to 1)
- Started `snapd` using a global configuration file that set the RESTful API port to `8282` and verified that the application started correctly and that the RESTful API was listening on port `8282`
- Started `snapd` with the same global configuration file used in the previous test (with the port set to `8282`) but overrode that port assignment with a CLI option of `--api-port 0`; verified that an error was reported
- Started `snapd` with the same global configuration file used in the previous test, but overrode that port assignment with a CLI option of `--api-port 8080`; verified that the application started correctly and that the RESTful API was listening on port `8080`

@intelsdi-x/snap-maintainers
