### PR TITLE
Fixes #988 - Plugins with multiple config policy nodes may cause a panic

### DIFF
--- a/pkg/ctree/tree.go
+++ b/pkg/ctree/tree.go
@@ -161,6 +161,10 @@ func (c *ConfigTree) Get(ns []string) Node {
 		childNodes := child.get(remain)
 		*retNodes = append(*retNodes, *childNodes...)
 	}
+	if len(*retNodes) == 0 {
+		// There are no child nodes with configs so we return
+		return nil
+	}
 
 	c.log(fmt.Sprintf("nodes to merge count (%d)\n", len(*retNodes)))
 	// Call Node.Merge() sequentially on the retNodes

--- a/pkg/ctree/tree_test.go
+++ b/pkg/ctree/tree_test.go
@@ -193,7 +193,7 @@ func TestConfigTree(t *testing.T) {
 			So(g, ShouldNotBeNil)
 		})
 
-		Convey("get is inbetween two nodes in tree", func() {
+		Convey("get is in between two nodes in tree", func() {
 			d1 := newMockNode()
 			d1.data = "a"
 			d2 := newMockNode()
@@ -217,6 +217,21 @@ func TestConfigTree(t *testing.T) {
 			So(func() {
 				c.Add([]string{"mashery", "foo", "sdilabs", "joel", "dan", "nick", "justin", "sarah"}, d2)
 			}, ShouldPanic)
+		})
+
+		Convey("doesn't panic on ns where the root and ns don't have a policy", func() {
+			d1 := newMockNode()
+			d1.data = "a"
+			d2 := newMockNode()
+			d2.data = "b"
+			c := New()
+			c.Add([]string{"intel", "foo", "sdi-x", "cody"}, d1)
+			c.Add([]string{"intel", "foo", "sdi-x", "nan"}, d2)
+			c.Freeze()
+			So(func() {
+				g := c.Get([]string{"intel", "foo", "sdi-x", "emily", "tiffany", "matt"})
+				So(g, ShouldBeNil)
+			}, ShouldNotPanic)
 		})
 
 		Convey("doesn't panic on empty ns", func() {


### PR DESCRIPTION
When there are multiple config policy nodes 
**and** there exists a metric which does not fall under any of the policies
**and** the root node does not contain a policy 

The following example causes a panic since no policies apply to `/intel/abc/baz`. 
**metric types**
/intel/abc/foo
/intel/def/bar
/intel/abc/baz

**config at**
/intel/abc/foo 
/intel/def/bar 

**root**
/intel

----
- [x] @tiffanyfj to add test