### PR TITLE
Fixes #987: Adds check for metrics during unsubscribe

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -884,13 +884,16 @@ func (p *pluginControl) sendPluginSubscriptionEvent(taskID string, pl core.Plugi
 
 func (p *pluginControl) UnsubscribeDeps(taskID string, mts []core.Metric, plugins []core.Plugin) []serror.SnapError {
 	var serrs []serror.SnapError
-
-	collectors, errs := p.gatherCollectors(mts)
-	if len(errs) > 0 {
-		serrs = append(serrs, errs...)
-	}
-	for _, gc := range collectors {
-		plugins = append(plugins, gc.plugin)
+	// If no metrics to unsubscribe then skip this section. Avoids errors when
+	// workflow is distributed and each node may not have metrics.
+	if len(mts) > 0 {
+		collectors, errs := p.gatherCollectors(mts)
+		if len(errs) > 0 {
+			serrs = append(serrs, errs...)
+		}
+		for _, gc := range collectors {
+			plugins = append(plugins, gc.plugin)
+		}
 	}
 
 	for _, sub := range plugins {


### PR DESCRIPTION
Fixes #987

Summary of changes:
- Adds check for metrics during unsubscribe, if no metrics are found does not attempt to gather collectors which was resulting in an incorrect error being returned.


Testing done:
- go test
- manual testing to reproduce/fix the issue described in #987.

@intelsdi-x/snap-maintainers

Adds check for metrics during unsubscribe. This avoids an incorrect
error message about missing plugins for nodes that have no collectors
running.