### PR TITLE
Fix immediately start collecting the new metrics after new plugin which shares the same namespace is loaded

### DIFF
--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -53,6 +53,7 @@ func TestAvailablePlugin(t *testing.T) {
 	Convey("Stop()", t, func() {
 		Convey("returns nil if plugin successfully stopped", func() {
 			r := newRunner()
+			r.SetEmitter(new(MockEmitter))
 			a := plugin.Arg{
 				PluginLogPath: "/tmp/snap-test-plugin-stop.log",
 			}

--- a/control/control.go
+++ b/control/control.go
@@ -224,9 +224,6 @@ func New(cfg *Config) *pluginControl {
 	c.pluginRunner.SetMetricCatalog(c.metricCatalog)
 	c.pluginRunner.SetPluginManager(c.pluginManager)
 
-	// Pass runner events to control main module
-	c.eventManager.RegisterHandler(c.Name(), c)
-
 	c.tasks = &taskDataMap{data: make(map[string]*taskData)}
 
 	// Start stuff
@@ -244,83 +241,6 @@ func New(cfg *Config) *pluginControl {
 	}
 
 	return c
-}
-
-func (p *pluginControl) HandleGomitEvent(e gomit.Event) {
-	switch v := e.Body.(type) {
-	case *control_event.LoadPluginEvent:
-		// Ignore plugins with type other than collector
-		if core.PluginType(v.Type).String() != "collector" {
-			return
-		}
-
-		// Get all known tasks data
-		for taskID, taskData := range p.tasks.data {
-			// Expand every task metric namespaces (with "*") to corresponding metric calalog namespaces
-			for _, tm := range taskData.metrics {
-
-				matchedNss, err := p.metricCatalog.MatchNamespaces(tm.Namespace())
-
-				if err != nil {
-					log.WithFields(log.Fields{
-						"_block":         "control",
-						"event":          v.Namespace(),
-						"plugin-name":    v.Name,
-						"plugin-version": v.Version,
-						"plugin-type":    core.PluginType(v.Type).String(),
-					}).Error("error matching task namespace with metric catalog")
-					continue
-				}
-
-				if len(matchedNss) > 0 {
-					depMts := []core.Metric{}
-					for _, ns := range matchedNss {
-
-						// Get expanded namespace data from metric catalog
-						if m, err := p.metricCatalog.Get(ns, tm.Version()); err == nil {
-							// Check if expanded namespace belongs to currently loaded plugin
-							if m.Plugin.TypeName() == core.PluginType(v.Type).String() && m.Plugin.Name() == v.Name {
-								depMts = append(depMts, &metric{
-									namespace: ns,
-									version:   tm.Version(),
-									config:    taskData.configTree.Get(ns.Strings()),
-								})
-							}
-						}
-					}
-
-					// Validate and subscribe deps for loaded plugin
-					errs := p.ValidateDeps(depMts, taskData.plugins)
-					if len(errs) > 0 {
-						log.WithFields(log.Fields{
-							"_block":         "control",
-							"event":          v.Namespace(),
-							"plugin-name":    v.Name,
-							"plugin-version": v.Version,
-							"plugin-type":    core.PluginType(v.Type).String(),
-						}).Error("error validating dependencies")
-						continue
-					}
-
-					cps := returnCorePlugin(taskData.plugins)
-					errs = p.SubscribeDeps(taskID, depMts, cps)
-					if len(errs) > 0 {
-						log.WithFields(log.Fields{
-							"_block":         "control",
-							"event":          v.Namespace(),
-							"plugin-name":    v.Name,
-							"plugin-version": v.Version,
-							"plugin-type":    core.PluginType(v.Type).String(),
-						}).Error("error subscribing dependencies")
-						p.UnsubscribeDeps(taskID, depMts, cps)
-						continue
-					}
-
-					p.metricCatalog.UpdateQueriedNamespaces(tm.Namespace())
-				}
-			}
-		}
-	}
 }
 
 func (p *pluginControl) AddTaskIDData(taskID string, metrics []core.RequestedMetric, configTree *cdata.ConfigDataTree, plugins []core.SubscribedPlugin) {
@@ -536,6 +456,8 @@ func (p *pluginControl) Load(rp *core.RequestedPlugin) (core.CatalogedPlugin, se
 		pl.Details.ExecPath = ""
 	}
 
+	p.refreshPluginSubscriptions(pl.Meta)
+
 	// defer sending event
 	event := &control_event.LoadPluginEvent{
 		Name:    pl.Meta.Name,
@@ -545,6 +467,66 @@ func (p *pluginControl) Load(rp *core.RequestedPlugin) (core.CatalogedPlugin, se
 	}
 	defer p.eventManager.Emit(event)
 	return pl, nil
+}
+
+func (p *pluginControl) refreshPluginSubscriptions(meta plugin.PluginMeta) {
+	f := map[string]interface{}{
+		"_block": "refresh-plugin-subscriptions",
+	}
+
+	// Ignore plugins with type other than collector
+	if core.PluginType(meta.Type).String() != "collector" {
+		return
+	}
+
+	// Get all known tasks data
+	for taskID, taskData := range p.tasks.data {
+		// Expand every task metric namespaces (with "*") to corresponding metric calalog namespaces
+		for _, tm := range taskData.metrics {
+
+			matchedNss, err := p.metricCatalog.MatchNamespaces(tm.Namespace())
+
+			if err != nil {
+				log.WithFields(f).Error("error matching task namespace with metric catalog")
+				continue
+			}
+
+			if len(matchedNss) > 0 {
+				depMts := []core.Metric{}
+				for _, ns := range matchedNss {
+
+					// Get expanded namespace data from metric catalog
+					if m, err := p.metricCatalog.Get(ns, tm.Version()); err == nil {
+						// Check if expanded namespace belongs to currently loaded plugin
+						if m.Plugin.TypeName() == core.PluginType(meta.Type).String() && m.Plugin.Name() == meta.Name {
+							depMts = append(depMts, &metric{
+								namespace: ns,
+								version:   tm.Version(),
+								config:    taskData.configTree.Get(ns.Strings()),
+							})
+						}
+					}
+				}
+
+				// Validate and subscribe deps for loaded plugin
+				errs := p.ValidateDeps(depMts, taskData.plugins)
+				if len(errs) > 0 {
+					log.WithFields(f).Error("error validating dependencies")
+					continue
+				}
+
+				cps := returnCorePlugin(taskData.plugins)
+				errs = p.SubscribeDeps(taskID, depMts, cps)
+				if len(errs) > 0 {
+					log.WithFields(f).Error("error subscribing dependencies")
+					p.UnsubscribeDeps(taskID, depMts, cps)
+					continue
+				}
+
+				p.metricCatalog.UpdateQueriedNamespaces(tm.Namespace())
+			}
+		}
+	}
 }
 
 func (p *pluginControl) verifySignature(rp *core.RequestedPlugin) (bool, serror.SnapError) {

--- a/control/control.go
+++ b/control/control.go
@@ -244,6 +244,11 @@ func New(cfg *Config) *pluginControl {
 func (p *pluginControl) HandleGomitEvent(e gomit.Event) {
 	switch v := e.Body.(type) {
 	case *control_event.LoadPluginEvent:
+		// Ignore plugins with type other than collector
+		if core.PluginType(v.Type).String() != "collector" {
+			return
+		}
+
 		// Get all known tasks data
 		for taskID, taskData := range p.taskIDData {
 			// Expand every task metric namespaces (with "*") to corresponding metric calalog namespaces

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -271,13 +271,16 @@ type mockPluginEvent struct {
 }
 
 type listenToPluginEvent struct {
-	plugin *mockPluginEvent
-	done   chan struct{}
+	plugin                          *mockPluginEvent
+	pluginRestartsExceededDoneChan  chan struct{}
+	pluginRestartsExceededNamespace string
+	done                            chan struct{}
 }
 
 func newListenToPluginEvent() *listenToPluginEvent {
 	return &listenToPluginEvent{
-		done:   make(chan struct{}),
+		done: make(chan struct{}),
+		pluginRestartsExceededDoneChan: make(chan struct{}),
 		plugin: &mockPluginEvent{},
 	}
 }
@@ -288,8 +291,8 @@ func (l *listenToPluginEvent) HandleGomitEvent(e gomit.Event) {
 		l.plugin.EventNamespace = v.Namespace()
 		l.done <- struct{}{}
 	case *control_event.MaxPluginRestartsExceededEvent:
-		l.plugin.EventNamespace = v.Namespace()
-		l.done <- struct{}{}
+		l.pluginRestartsExceededNamespace = v.Namespace()
+		l.pluginRestartsExceededDoneChan <- struct{}{}
 	case *control_event.DeadAvailablePluginEvent:
 		l.plugin.EventNamespace = v.Namespace()
 		l.done <- struct{}{}
@@ -1215,8 +1218,8 @@ func TestFailedPlugin(t *testing.T) {
 						So(lpe.plugin.EventNamespace, ShouldEqual, control_event.AvailablePluginRestarted)
 					}
 				}
-				<-lpe.done
-				So(lpe.plugin.EventNamespace, ShouldEqual, control_event.PluginRestartsExceeded)
+				<-lpe.pluginRestartsExceededDoneChan
+				So(lpe.pluginRestartsExceededNamespace, ShouldEqual, control_event.PluginRestartsExceeded)
 				So(eventMap[control_event.AvailablePluginRestarted], ShouldEqual, MaxPluginRestartCount)
 				So(len(pool.Plugins()), ShouldEqual, 0)
 				So(pool.RestartCount(), ShouldEqual, MaxPluginRestartCount)

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -707,7 +707,10 @@ func (m *mc) GetQueriedNamespaces(ns core.Namespace) ([]core.Namespace, error) {
 	return []core.Namespace{ns}, nil
 }
 
-func (m *mc) MatchQuery(ns core.Namespace) ([]core.Namespace, error) {
+func (m *mc) UpdateQueriedNamespaces(ns core.Namespace) {
+}
+
+func (m *mc) MatchNamespaces(ns core.Namespace) ([]core.Namespace, error) {
 	return []core.Namespace{ns}, nil
 }
 

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -131,6 +131,31 @@ type metricType struct {
 	unit               string
 }
 
+type metric struct {
+	namespace core.Namespace
+	version   int
+	config    *cdata.ConfigDataNode
+}
+
+func (m *metric) Namespace() core.Namespace {
+	return m.namespace
+}
+
+func (m *metric) Config() *cdata.ConfigDataNode {
+	return m.config
+}
+
+func (m *metric) Version() int {
+	return m.version
+}
+
+func (m *metric) Data() interface{}             { return nil }
+func (m *metric) Description() string           { return "" }
+func (m *metric) Unit() string                  { return "" }
+func (m *metric) Tags() map[string]string       { return nil }
+func (m *metric) LastAdvertisedTime() time.Time { return time.Unix(0, 0) }
+func (m *metric) Timestamp() time.Time          { return time.Unix(0, 0) }
+
 type processesConfigData interface {
 	Process(map[string]ctypes.ConfigValue) (*map[string]ctypes.ConfigValue, *cpolicy.ProcessingErrors)
 	HasRules() bool
@@ -260,9 +285,8 @@ func (mc *metricCatalog) GetQueriedNamespaces(ns core.Namespace) ([]core.Namespa
 	return mc.matchedNamespaces(wkey)
 }
 
-// MatchQuery matches given 'ns' which could contain an asterisk or a tuple and add them to matching map under key 'ns'
-// The matched metrics namespaces are also returned (as a []core.Namespace)
-func (mc *metricCatalog) MatchQuery(ns core.Namespace) ([]core.Namespace, error) {
+// UpdateQueriedNamespaces matches given 'ns' which could contain an asterisk or a tuple and add them to matching map under key 'ns'
+func (mc *metricCatalog) UpdateQueriedNamespaces(ns core.Namespace) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
 
@@ -271,8 +295,6 @@ func (mc *metricCatalog) MatchQuery(ns core.Namespace) ([]core.Namespace, error)
 
 	// adding matched namespaces to map
 	mc.addItemToMatchingMap(wkey)
-
-	return mc.matchedNamespaces(wkey)
 }
 
 func convertKeysToNamespaces(keys []string) []core.Namespace {
@@ -290,6 +312,16 @@ func convertKeysToNamespaces(keys []string) []core.Namespace {
 // addItemToMatchingMap adds `wkey` to matching map (or updates if `wkey` exists) with corresponding cataloged keys as a content;
 // if this 'wkey' does not match to any cataloged keys, it will be removed from matching map
 func (mc *metricCatalog) addItemToMatchingMap(wkey string) {
+	matchedKeys := mc.matchKeys(wkey)
+	if len(matchedKeys) == 0 {
+		mc.removeItemFromMatchingMap(wkey)
+	} else {
+		mc.mKeys[wkey] = matchedKeys
+	}
+}
+
+// matchKeys returns all keys matching with provided key
+func (mc *metricCatalog) matchKeys(wkey string) []string {
 	matchedKeys := []string{}
 
 	// wkey contains `.` which should not be interpreted as regexp tokens, but as a single character
@@ -306,11 +338,18 @@ func (mc *metricCatalog) addItemToMatchingMap(wkey string) {
 		}
 		matchedKeys = appendIfMissing(matchedKeys, key)
 	}
+	return matchedKeys
+}
+
+// MatchNamespaces returns all namespaces matching with provided ns query
+func (mc *metricCatalog) MatchNamespaces(ns core.Namespace) ([]core.Namespace, error) {
+	matchedKeys := mc.matchKeys(ns.Key())
+
 	if len(matchedKeys) == 0 {
-		mc.removeItemFromMatchingMap(wkey)
-	} else {
-		mc.mKeys[wkey] = matchedKeys
+		return nil, errorMetricNotFound(ns.String())
 	}
+
+	return convertKeysToNamespaces(matchedKeys), nil
 }
 
 // removeItemFromMatchingMap removes `wkey` from matching map

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -453,6 +453,14 @@ func (mc *metricCatalog) RmUnloadedPluginMetrics(lp *loadedPlugin) {
 	mc.mutex.Lock()
 	defer mc.mutex.Unlock()
 	mc.tree.DeleteByPlugin(lp)
+
+	// Update metric catalog keys
+	mc.keys = []string{}
+	mts := mc.tree.gatherMetricTypes()
+	for _, m := range mts {
+		mc.keys = append(mc.keys, m.Namespace().Key())
+	}
+
 	// update the contents of matching map (mKeys)
 	mc.updateMatchingMap()
 }

--- a/control/metrics_test.go
+++ b/control/metrics_test.go
@@ -82,7 +82,7 @@ func TestMetricType(t *testing.T) {
 }
 
 func TestMetricMatching(t *testing.T) {
-	Convey("metricCatalog.MatchQuery()", t, func() {
+	Convey("metricCatalog.GetQueriedNamespaces()", t, func() {
 		Convey("verify query support for static metrics", func() {
 			mc := newMetricCatalog()
 			ns := []core.Namespace{
@@ -111,8 +111,10 @@ func TestMetricMatching(t *testing.T) {
 			for _, v := range mt {
 				mc.Add(v)
 			}
+
 			Convey("match /mock/foo/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "foo", "*"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "foo", "*"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "foo", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -122,7 +124,8 @@ func TestMetricMatching(t *testing.T) {
 
 			})
 			Convey("match /mock/test/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "test", "*"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "test", "*"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "test", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 4)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -133,7 +136,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/*/bar", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "*", "bar"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "*", "bar"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "*", "bar"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -142,13 +146,15 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "*"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "*"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, len(ns))
 				So(nss, ShouldResemble, ns)
 			})
 			Convey("match /mock/(foo|asdf)/baz", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "(foo|asdf)", "baz"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "(foo|asdf)", "baz"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "(foo|asdf)", "baz"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -157,7 +163,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/test/(1|2|3)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "test", "(1|2|3)"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "test", "(1|2|3)"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "test", "(1|2|3)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 3)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -167,7 +174,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("invalid matching", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "not", "exist", "metric"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "not", "exist", "metric"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "not", "exist", "metric"))
 				So(err, ShouldNotBeNil)
 				So(nss, ShouldBeEmpty)
 				So(err.Error(), ShouldContainSubstring, "Metric not found:")
@@ -205,13 +213,15 @@ func TestMetricMatching(t *testing.T) {
 			So(len(mc.Keys()), ShouldEqual, len(ns))
 
 			Convey("match /mock/cgroups/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, len(ns))
 				So(nss, ShouldResemble, ns)
 			})
 			Convey("match /mock/cgroups/*/bar", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "bar"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "bar"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "bar"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 1)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -219,7 +229,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/cgroups/*/(bar|baz)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "(bar|baz)"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "(bar|baz)"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "(bar|baz)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 2)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -228,7 +239,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/cgroups/*/test/*", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "test", "*"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "test", "*"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "test", "*"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 4)
 				So(nss, ShouldResemble, []core.Namespace{
@@ -239,7 +251,8 @@ func TestMetricMatching(t *testing.T) {
 				})
 			})
 			Convey("match /mock/cgroups/*/test/(1|2|3)", func() {
-				nss, err := mc.MatchQuery(core.NewNamespace("mock", "cgroups", "*", "test", "(1|2|3)"))
+				mc.UpdateQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "test", "(1|2|3)"))
+				nss, err := mc.GetQueriedNamespaces(core.NewNamespace("mock", "cgroups", "*", "test", "(1|2|3)"))
 				So(err, ShouldBeNil)
 				So(len(nss), ShouldEqual, 3)
 				So(nss, ShouldResemble, []core.Namespace{

--- a/control/runner.go
+++ b/control/runner.go
@@ -198,6 +198,14 @@ func (r *runner) startPlugin(p executablePlugin) (*availablePlugin, error) {
 		"available-plugin-type": ap.TypeName(),
 	}).Info("available plugin started")
 
+	defer r.emitter.Emit(&control_event.StartPluginEvent{
+		Name:    ap.Name(),
+		Version: ap.Version(),
+		Type:    int(ap.Type()),
+		Key:     ap.key,
+		Id:      ap.ID(),
+	})
+
 	return ap, nil
 }
 

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -493,6 +493,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 			Convey("stopPlugin", func() {
 				Convey("should return an AvailablePlugin in a Running state", func() {
 					r := newRunner()
+					r.SetEmitter(new(MockEmitter))
 					a := plugin.Arg{
 						PluginLogPath: "/tmp/snap-test-plugin-stop.log",
 					}

--- a/core/control_event/control_event.go
+++ b/core/control_event/control_event.go
@@ -23,6 +23,7 @@ const (
 	AvailablePluginDead      = "Control.AvailablePluginDead"
 	AvailablePluginRestarted = "Control.RestartedAvailablePlugin"
 	PluginRestartsExceeded   = "Control.PluginRestartsExceeded"
+	PluginStarted            = "Control.PluginStarted"
 	PluginLoaded             = "Control.PluginLoaded"
 	PluginUnloaded           = "Control.PluginUnloaded"
 	PluginsSwapped           = "Control.PluginsSwapped"
@@ -35,6 +36,18 @@ const (
 	HealthCheckFailed        = "Control.PluginHealthCheckFailed"
 	MoveSubscription         = "Control.PluginSubscriptionMoved"
 )
+
+type StartPluginEvent struct {
+	Name    string
+	Version int
+	Type    int
+	Key     string
+	Id      uint32
+}
+
+func (e StartPluginEvent) Namespace() string {
+	return PluginStarted
+}
 
 type LoadPluginEvent struct {
 	Name    string

--- a/core/tribe_event/tribe_event.go
+++ b/core/tribe_event/tribe_event.go
@@ -1,0 +1,41 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tribe_event
+
+import "github.com/intelsdi-x/snap/core"
+
+const (
+	PluginAdded = "Tribe.PluginAdded"
+)
+
+type AddPluginEvent struct {
+	Agreement struct {
+		Name string
+	}
+	Plugin struct {
+		Name    string
+		Type    core.PluginType
+		Version int
+	}
+}
+
+func (e AddPluginEvent) Namespace() string {
+	return PluginAdded
+}

--- a/grpc/common/common.proto
+++ b/grpc/common/common.proto
@@ -57,6 +57,11 @@ message Metric {
 	}
 }
 
+message RequestedMetric {
+	repeated NamespaceElement Namespace = 1;
+	int64 Version = 2;
+}
+
 message NamespaceElement {
 	string Value = 1;
 	string Description = 2;
@@ -77,6 +82,10 @@ message ConfigMap {
 	// double is float64
 	map<string, double> FloatMap = 3;
 	map<string, bool> BoolMap = 4;
+}
+
+message ConfigTree {
+	repeated ConfigMap Node = 1;
 }
 
 // core.Plugin

--- a/grpc/controlproxy/controlproxy.go
+++ b/grpc/controlproxy/controlproxy.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/grpc/common"
@@ -204,6 +205,14 @@ func (c ControlProxy) GetAutodiscoverPaths() []string {
 		return nil
 	}
 	return reply.Paths
+}
+
+func (c ControlProxy) AddTaskIDData(taskID string, metrics []core.RequestedMetric, config *cdata.ConfigDataTree, plugins []core.SubscribedPlugin) {
+	// TODO
+}
+
+func (c ControlProxy) RemoveTaskIDData(taskID string) {
+	// TODO
 }
 
 ///---------Util-------------------------------------------------------------------------

--- a/grpc/controlproxy/rpc/control.proto
+++ b/grpc/controlproxy/rpc/control.proto
@@ -123,6 +123,17 @@ message ExpandWildcardsReply {
 	common.SnapError Error = 2;
 }
 
+message AddTaskIDDataRequest {
+	string TaskID = 1;
+	repeated common.RequestedMetric Metrics = 2;
+	common.ConfigTree ConfigTree = 3;
+	common.SubscribedPlugin Plugins = 4;
+}
+
+message RemoveTaskIDDataRequest {
+	string TaskID = 1;
+}
+
 message GetAutodiscoverPathsReply{
 	repeated string Paths = 1;
 }

--- a/plugin/collector/snap-collector-anothermock1/README.md
+++ b/plugin/collector/snap-collector-anothermock1/README.md
@@ -1,0 +1,58 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## snap Collector Plugin Structure
+---
+Mock plugins are for testing purposes and not meant as examples. 
+
+#### Plugin binary
+
+./main.go
+
+#### Collector Implementation
+
+./collector/collector.go
+
+#### JSON RPC examples (using curl)
+
+If calling a GO based plugin you will want to ensure that the plugin is started in JSON RPC mode.  This is done by setting the plugins meta data field RPCType to plugin.JSONRPC. 
+
+You can start a plugin manually for testing by increasing the ping timeout duration.  The timeout will be reset each time you call into the plugin.
+
+```
+./snap-collector-anothermock1 '{"NoDaemon": false, "PingTimeoutDuration": 1000000000000}'
+```
+
+###### GetConfigPolicy
+
+```
+curl -d '{"method": "Collector.GetConfigPolicy", "params": [], "id": 1}' http://127.0.0.1:<REPLACE WITH PORT> | python -m "json.tool"
+```
+
+###### GetMetricTypes
+
+```
+curl -d '{"method": "Collector.GetMetricTypes", "params": [], "id": 1}' http://127.0.0.1:<REPLACE WITH PORT>
+```
+
+###### CollectMetrics
+
+```
+curl -X POST -H "Content-Type: application/json" -d '{"method": "Collector.CollectMetrics", "params": [[{"namespace": ["intel","anothermock", "bar"]},{"namespace": ["intel","anothermock","foo"], "config": {"table": {"password": {"Value": "asdf"}}}}]], "id": 1}' http://127.0.0.1:<REPLACE WITH PORT> | python -m "json.tool"
+```

--- a/plugin/collector/snap-collector-anothermock1/anothermock/anothermock.go
+++ b/plugin/collector/snap-collector-anothermock1/anothermock/anothermock.go
@@ -1,0 +1,145 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anothermock
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/ctypes"
+)
+
+const (
+	// Name of plugin
+	Name = "anothermock"
+	// Version of plugin
+	Version = 1
+	// Type of plugin
+	Type = plugin.CollectorPluginType
+)
+
+// Mock collector implementation used for testing
+type AnotherMock struct {
+}
+
+// CollectMetrics collects metrics for testing
+func (f *AnotherMock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
+	for _, p := range mts {
+		log.Printf("collecting %+v\n", p)
+	}
+
+	rand.Seed(time.Now().UTC().UnixNano())
+	metrics := []plugin.MetricType{}
+	for i := range mts {
+		if c, ok := mts[i].Config().Table()["panic"]; ok && c.(ctypes.ConfigValueBool).Value {
+			panic("Oops!")
+		}
+		if mts[i].Namespace()[2].Value == "*" {
+			for j := 0; j < 10; j++ {
+				ns := make([]core.NamespaceElement, len(mts[i].Namespace()))
+				copy(ns, mts[i].Namespace())
+				ns[2].Value = fmt.Sprintf("host%d", j)
+				data := randInt(65, 90)
+				mt := plugin.MetricType{
+					Data_:      data,
+					Namespace_: ns,
+					Timestamp_: time.Now(),
+					Version_:   mts[i].Version(),
+					Unit_:      mts[i].Unit(),
+				}
+				metrics = append(metrics, mt)
+			}
+		} else {
+			data := randInt(65, 90)
+			mts[i].Data_ = data
+			mts[i].Timestamp_ = time.Now()
+			metrics = append(metrics, mts[i])
+		}
+	}
+	return metrics, nil
+}
+
+//GetMetricTypes returns metric types for testing
+func (f *AnotherMock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error) {
+	mts := []plugin.MetricType{}
+	if _, ok := cfg.Table()["test-fail"]; ok {
+		return mts, fmt.Errorf("testing")
+	}
+	if _, ok := cfg.Table()["test"]; ok {
+		mts = append(mts, plugin.MetricType{
+			Namespace_:   core.NewNamespace("intel", "anothermock", "test"),
+			Description_: "anothermock description",
+			Unit_:        "anothermock unit",
+		})
+	}
+	mts = append(mts, plugin.MetricType{
+		Namespace_:   core.NewNamespace("intel", "anothermock", "foo"),
+		Description_: "anothermock description",
+		Unit_:        "anothermock unit",
+	})
+	mts = append(mts, plugin.MetricType{
+		Namespace_:   core.NewNamespace("intel", "anothermock", "bar"),
+		Description_: "anothermock description",
+		Unit_:        "anothermock unit",
+	})
+	mts = append(mts, plugin.MetricType{
+		Namespace_: core.NewNamespace("intel", "anothermock").
+			AddDynamicElement("host", "name of the host").
+			AddStaticElement("baz"),
+		Description_: "anothermock description",
+		Unit_:        "anothermock unit",
+	})
+	return mts, nil
+}
+
+//GetConfigPolicy returns a ConfigPolicy for testing
+func (f *AnotherMock) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	c := cpolicy.New()
+	rule, _ := cpolicy.NewStringRule("name", false, "bob")
+	rule2, _ := cpolicy.NewStringRule("password", true)
+	p := cpolicy.NewPolicyNode()
+	p.Add(rule)
+	p.Add(rule2)
+	c.Add([]string{"intel", "anothermock", "foo"}, p)
+	return c, nil
+}
+
+//Meta returns meta data for testing
+func Meta() *plugin.PluginMeta {
+	return plugin.NewPluginMeta(
+		Name,
+		Version,
+		Type,
+		[]string{plugin.SnapGOBContentType},
+		[]string{plugin.SnapGOBContentType},
+		plugin.CacheTTL(100*time.Millisecond),
+		plugin.RoutingStrategy(plugin.StickyRouting),
+	)
+}
+
+//Random number generator
+func randInt(min int, max int) int {
+	return min + rand.Intn(max-min)
+}

--- a/plugin/collector/snap-collector-anothermock1/main.go
+++ b/plugin/collector/snap-collector-anothermock1/main.go
@@ -1,0 +1,42 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the snap plugin library
+	"github.com/intelsdi-x/snap/control/plugin"
+	// Import our collector plugin implementation
+	"github.com/intelsdi-x/snap/plugin/collector/snap-collector-anothermock1/anothermock"
+)
+
+func main() {
+	// Provided:
+	//   the definition of the plugin metadata
+	//   the implementation satisfying plugin.CollectorPlugin
+
+	// Define metadata about Plugin
+	meta := anothermock.Meta()
+	// meta.RPCType = plugin.JSONRPC
+
+	// Start a collector
+	plugin.Start(meta, new(anothermock.AnotherMock), os.Args[1])
+}

--- a/plugin/collector/snap-collector-anothermock1/main_small_test.go
+++ b/plugin/collector/snap-collector-anothermock1/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/collector/snap-collector-anothermock1/main_test.go
+++ b/plugin/collector/snap-collector-anothermock1/main_test.go
@@ -1,0 +1,62 @@
+// +build legacy
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/plugin/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	PluginName = "snap-collector-anothermock1"
+	PluginType = "collector"
+	SnapPath   = os.Getenv("SNAP_PATH")
+	PluginPath = path.Join(SnapPath, "plugin", PluginName)
+)
+
+func TestMockPluginLoad(t *testing.T) {
+	// These tests only work if SNAP_PATH is known.
+	// It is the responsibility of the testing framework to
+	// build the plugins first into the build dir.
+	if SnapPath != "" {
+		// Helper plugin trigger build if possible for this plugin
+		helper.BuildPlugin(PluginType, PluginName)
+		//
+		Convey("ensure plugin loads and responds", t, func() {
+			c := control.New(control.GetDefaultConfig())
+			c.Start()
+			rp, _ := core.NewRequestedPlugin(PluginPath)
+			_, err := c.Load(rp)
+
+			So(err, ShouldBeNil)
+		})
+	} else {
+		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
+	}
+}

--- a/plugin/collector/snap-collector-anothermock1/main_test.go
+++ b/plugin/collector/snap-collector-anothermock1/main_test.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2016 Intel Corporation
+Copyright 2015 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -44,11 +43,11 @@ func TestMockPluginLoad(t *testing.T) {
 	// These tests only work if SNAP_PATH is known.
 	// It is the responsibility of the testing framework to
 	// build the plugins first into the build dir.
-	if SnapPath != "" {
-		// Helper plugin trigger build if possible for this plugin
-		helper.BuildPlugin(PluginType, PluginName)
-		//
-		Convey("ensure plugin loads and responds", t, func() {
+	Convey("make sure plugin has been built", t, func() {
+		err := helper.CheckPluginBuilt(SnapPath, PluginName)
+		So(err, ShouldBeNil)
+
+		Convey("ensure plugin loads and responds", func() {
 			c := control.New(control.GetDefaultConfig())
 			c.Start()
 			rp, _ := core.NewRequestedPlugin(PluginPath)
@@ -56,7 +55,6 @@ func TestMockPluginLoad(t *testing.T) {
 
 			So(err, ShouldBeNil)
 		})
-	} else {
-		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
-	}
+
+	})
 }

--- a/scheduler/scheduler_medium_test.go
+++ b/scheduler/scheduler_medium_test.go
@@ -128,6 +128,12 @@ func (m *mockMetricManager) GetAutodiscoverPaths() []string {
 	return m.autodiscoverPaths
 }
 
+func (m *mockMetricManager) AddTaskIDData(taskID string, metrics []core.RequestedMetric, configTree *cdata.ConfigDataTree, plugins []core.SubscribedPlugin) {
+}
+
+func (m *mockMetricManager) RemoveTaskIDData(taskID string) {
+}
+
 type mockMetricManagerError struct {
 	errs []error
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -128,6 +128,9 @@ func (m *mockMetricManager) GetAutodiscoverPaths() []string {
 	return m.autodiscoverPaths
 }
 
+func (m *mockMetricManager) AddTaskIDData(taskID string, metrics []core.RequestedMetric, configTree *cdata.ConfigDataTree, plugins []core.SubscribedPlugin) {
+}
+
 type mockMetricManagerError struct {
 	errs []error
 }


### PR DESCRIPTION
Fixes #832

> Summary of changes (16-Jun-2016):
> - Add RefreshTaskSubscription() method to scheduler, which calls SubscribeDeps() and ValidateDeps() for all task dependencies (code moved from startTask() method and slightly modified)
> - Add SetTaskScheduler() method to pluginControl and pluginRunner for access to scheduler from plugin runner
> - Call scheduler's RefreshTaskSubscription() for all tasks from control_event.LoadPluginEvent event in runner
> - Add new mock plugin anothermock1 (based on mock2) with another name and namespace for testing purposes (plugin is used in RefreshTaskSubscription() unit test)

#### Summary of changes NEW VERSION (05-Jul-2016):
- Add new mock plugin anothermock1 (based on mock2) with another name and namespace for testing purposes
- Add taskIDData map to pluginControl. Map stores task IDs, config tree and metrics of every task, so there is no need to call scheduler's GetTasks() method (as scheduler should be unknown for control).
- Add methods AddTaskIDData and RemoveTaskIDData to manage task map on control site
- Call AddTaskIDData and RemoveTaskIDData from scheduler's createTask and removeTask methods to track current tasks list on control site
- Call ValidateDeps and SubscribeDeps in LoadPluginEvent for every task from map, which metrics matches loaded plugin metrics
- newCollectorJob gets now managesMetrics instead of collectsMetrics as argument to be able to call ValidateDeps before every run, so task immidiately goes invalid when it for example doesn't contain config for newly loaded plugin. ValidateDeps is called for every remote manager.
- Add some protobuf messages to implement gRPC calls in the future (for AddTaskIDData and RemoveTaskIDData).

Testing done:
- Manual
```
1. Load plugin anothermock1
2. Create and start task which collects all metrics from /intel/* and contains config data for both plugins
3. Load second plugin mock1 - snap immidiately collects data from mock1 (and anothermock1)
4. Load third plugin mock2 - snap immidiately switches to and collects data from mock2 (and anothermock1)
```
- Unit tests

@intelsdi-x/snap-maintainers
