### PR TITLE
Fixes #1004: Use https link for go report card link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 [![Join the chat at https://gitter.im/intelsdi-x/snap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/intelsdi-x/snap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/intelsdi-x/snap.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap)
-[![Go Report Card](http://goreportcard.com/badge/intelsdi-x/snap)](http://goreportcard.com/report/intelsdi-x/snap)
+[![Go Report Card](https://goreportcard.com/badge/intelsdi-x/snap)](https://goreportcard.com/report/intelsdi-x/snap)
 
 <img src="https://cloud.githubusercontent.com/assets/1744971/13930753/6f676b34-ef5d-11e5-97be-8503562cd5fe.png" width="50%">
 


### PR DESCRIPTION
Fixes #1004 

@intelsdi-x/snap-maintainers

