### PR TITLE
Customizable number of failures before snap disable the task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ tags
 
 # OSX stuff
 .DS_Store
+
+*.cov

--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -49,7 +49,7 @@ var (
 						flTaskSchedDuration,
 						flTaskSchedNoStart,
 						flTaskDeadline,
-						flTaskFailures,
+						flTaskMaxFailures,
 					},
 				},
 				{

--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -49,6 +49,7 @@ var (
 						flTaskSchedDuration,
 						flTaskSchedNoStart,
 						flTaskDeadline,
+						flTaskFailures,
 					},
 				},
 				{

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -126,7 +126,7 @@ var (
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
 	}
-	flTaskFailures = cli.IntFlag{
+	flTaskMaxFailures = cli.IntFlag{
 		Name:  "max-failures",
 		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
 		Value: DefaultMaxFailures,

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -21,6 +21,10 @@ package main
 
 import "github.com/codegangsta/cli"
 
+const (
+	DefaultMaxFailures = 10
+)
+
 var (
 
 	// Main flags
@@ -121,6 +125,11 @@ var (
 	flTaskDeadline = cli.StringFlag{
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
+	}
+	flTaskFailures = cli.IntFlag{
+		Name:  "max-failures",
+		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
+		Value: DefaultMaxFailures,
 	}
 
 	// metric

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -210,7 +210,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) error {
 
 	// Deadline for a task
 	dl := ctx.String("deadline")
-	failure := uint(ctx.Int("failure"))
+	maxFailures := ctx.Int("max-failures")
 
 	var sch *client.Schedule
 	// None of these mean it is a simple schedule
@@ -279,7 +279,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) error {
 		}
 	}
 	// Create task
-	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"), failure)
+	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"), maxFailures)
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
 		fmt.Println("Error creating task:")

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -78,11 +78,12 @@ func trunc(n int) string {
 }
 
 type task struct {
-	Version  int
-	Schedule *client.Schedule
-	Workflow *wmap.WorkflowMap
-	Name     string
-	Deadline string
+	Version     int
+	Schedule    *client.Schedule
+	Workflow    *wmap.WorkflowMap
+	Name        string
+	Deadline    string
+	MaxFailures int `json:"max-failures"`
 }
 
 func createTask(ctx *cli.Context) error {
@@ -134,7 +135,14 @@ func createTaskUsingTaskManifest(ctx *cli.Context) error {
 		fmt.Println("Invalid version provided")
 		return errCritical
 	}
-	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"))
+
+	// If the number of failures does not specific, default value is 10
+	if t.MaxFailures == 0 {
+		fmt.Println("If the number of maximum failures is not specified, use default value of", DefaultMaxFailures)
+		t.MaxFailures = DefaultMaxFailures
+	}
+
+	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.MaxFailures)
 
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
@@ -202,6 +210,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) error {
 
 	// Deadline for a task
 	dl := ctx.String("deadline")
+	failure := uint(ctx.Int("failure"))
 
 	var sch *client.Schedule
 	// None of these mean it is a simple schedule
@@ -270,7 +279,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) error {
 		}
 	}
 	// Create task
-	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"))
+	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"), failure)
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
 		fmt.Println("Error creating task:")

--- a/core/task.go
+++ b/core/task.go
@@ -117,7 +117,7 @@ func TaskDeadlineDuration(v time.Duration) TaskOption {
 // TaskStopOnFailure sets the tasks stopOnFailure
 // The stopOnFailure is the number of consecutive task failures that will
 // trigger disabling the task
-func OptionStopOnFailure(v uint) TaskOption {
+func OptionStopOnFailure(v int) TaskOption {
 	return func(t Task) TaskOption {
 		previous := t.GetStopOnFailure()
 		t.SetStopOnFailure(v)
@@ -156,11 +156,12 @@ type TaskErrors interface {
 }
 
 type TaskCreationRequest struct {
-	Name     string            `json:"name"`
-	Deadline string            `json:"deadline"`
-	Workflow *wmap.WorkflowMap `json:"workflow"`
-	Schedule Schedule          `json:"schedule"`
-	Start    bool              `json:"start"`
+	Name        string            `json:"name"`
+	Deadline    string            `json:"deadline"`
+	Workflow    *wmap.WorkflowMap `json:"workflow"`
+	Schedule    Schedule          `json:"schedule"`
+	Start       bool              `json:"start"`
+	MaxFailures int               `json:"max-failures"`
 }
 
 // Function used to create a task according to content (1st parameter)

--- a/core/task.go
+++ b/core/task.go
@@ -86,8 +86,8 @@ type Task interface {
 	DeadlineDuration() time.Duration
 	SetDeadlineDuration(time.Duration)
 	SetTaskID(id string)
-	SetStopOnFailure(uint)
-	GetStopOnFailure() uint
+	SetStopOnFailure(int)
+	GetStopOnFailure() int
 	Option(...TaskOption) TaskOption
 	WMap() *wmap.WorkflowMap
 	Schedule() schedule.Schedule

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -37,10 +37,11 @@ The schedule describes the schedule type and interval for running the task.  The
 ```
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
 
-#### Failure
+#### Max-Failures
 By default, snap will disable a task if there is 10 consecutive errors from any plugins within the workflow.  The configuration
-can be changed by specifying the number of failures value in the task header.
-
+can be changed by specifying the number of failures value in the task header.  If the max-failures value is -1, snap will
+not disable a task with consecutive failure.  Instead, snap will sleep for 1 second for every 10 consective failures
+and retry again.
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -15,6 +15,7 @@ The manifest can be divided into two parts: Header and Workflow.
   schedule:
     type: "simple"
     interval: "1s"
+  max-failures: 10
 ```
 
 #### Version
@@ -32,8 +33,14 @@ The schedule describes the schedule type and interval for running the task.  The
         "type": "cron",
         "interval" : "0 30 * * * *"
     },
+    "max-failures": 10,
 ```
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
+
+#### Failure
+By default, snap will disable a task if there is 10 consecutive errors from any plugins within the workflow.  The configuration
+can be changed by specifying the number of failures value in the task header.
+
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).
 

--- a/examples/tasks/ceph-file.json
+++ b/examples/tasks/ceph-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/ceph-file.json
+++ b/examples/tasks/ceph-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "max-failure": 10,
+    "max-failures": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/distributed-mock-file.json
+++ b/examples/tasks/distributed-mock-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/distributed-mock-file.json
+++ b/examples/tasks/distributed-mock-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "max-failure": 10,
+    "max-failures": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "max-failure": 10,
+    "max-failures": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -3,6 +3,7 @@
   schedule: 
     type: "simple"
     interval: "1s"
+  max-failure: 10
   workflow: 
     collect: 
       metrics: 

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -3,7 +3,7 @@
   schedule: 
     type: "simple"
     interval: "1s"
-  max-failure: 10
+  max-failures: 10
   workflow: 
     collect: 
       metrics: 

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -3,7 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
-  max-failure: 10
+  max-failures: 10
   workflow:
     collect:
       metrics:

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -3,6 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
+  max-failure: 10
   workflow:
     collect:
       metrics:

--- a/examples/tasks/psutil-file_no-processor.yaml
+++ b/examples/tasks/psutil-file_no-processor.yaml
@@ -3,7 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
-  max-failure: 10
+  max-failures: 10
   workflow: 
     collect:
       metrics:

--- a/examples/tasks/psutil-file_no-processor.yaml
+++ b/examples/tasks/psutil-file_no-processor.yaml
@@ -3,6 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
+  max-failure: 10
   workflow: 
     collect:
       metrics:

--- a/examples/tasks/psutil-influx.json
+++ b/examples/tasks/psutil-influx.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/psutil-influx.json
+++ b/examples/tasks/psutil-influx.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "max-failure": 10,
+    "max-failures": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -160,7 +160,7 @@ func TestSnapClient(t *testing.T) {
 					So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("Task not found: ID(%s)", uuid))
 				})
 				Convey("invalid task (missing metric)", func() {
-					tt := c.CreateTask(sch, wf, "baron", "", true)
+					tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
 					So(tt.Err, ShouldNotBeNil)
 					So(tt.Err.Error(), ShouldContainSubstring, "Metric not found: /intel/mock/foo")
 				})
@@ -193,7 +193,7 @@ func TestSnapClient(t *testing.T) {
 				So(p.AvailablePlugins, ShouldBeEmpty)
 			})
 			Convey("invalid task (missing publisher)", func() {
-				tf := c.CreateTask(sch, wf, "baron", "", false)
+				tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 				So(tf.Err, ShouldNotBeNil)
 				So(tf.Err.Error(), ShouldContainSubstring, "Plugin not found: type(publisher) name(file)")
 			})
@@ -338,11 +338,11 @@ func TestSnapClient(t *testing.T) {
 		Convey("Tasks", func() {
 			Convey("Passing a bad task manifest", func() {
 				wfb := getWMFromSample("bad.json")
-				ttb := c.CreateTask(sch, wfb, "bad", "", true)
+				ttb := c.CreateTask(sch, wfb, "bad", "", true, rest.DefaultMaxFailures)
 				So(ttb.Err, ShouldNotBeNil)
 			})
 
-			tf := c.CreateTask(sch, wf, "baron", "", false)
+			tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 			Convey("valid task not started on creation", func() {
 				So(tf.Err, ShouldBeNil)
 				So(tf.Name, ShouldEqual, "baron")
@@ -385,7 +385,7 @@ func TestSnapClient(t *testing.T) {
 				})
 			})
 
-			tt := c.CreateTask(sch, wf, "baron", "", true)
+			tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
 			Convey("valid task started on creation", func() {
 				So(tt.Err, ShouldBeNil)
 				So(tt.Name, ShouldEqual, "baron")
@@ -473,7 +473,7 @@ func TestSnapClient(t *testing.T) {
 					Convey("event stream", func() {
 						rest.StreamingBufferWindow = 0.01
 						sch := &Schedule{Type: "simple", Interval: "100ms"}
-						tf := c.CreateTask(sch, wf, "baron", "", false)
+						tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 
 						type ea struct {
 							events []string

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -48,14 +48,15 @@ type Schedule struct {
 // If the startTask flag is true, the newly created task is started after the creation.
 // Otherwise, it's in the Stopped state. CreateTask is accomplished through a POST HTTP JSON request.
 // A ScheduledTask is returned if it succeeds, otherwise an error is returned.
-func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool) *CreateTaskResult {
+func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, maxFailures int) *CreateTaskResult {
 	t := core.TaskCreationRequest{
 		Schedule: core.Schedule{
 			Type:     s.Type,
 			Interval: s.Interval,
 		},
-		Workflow: wf,
-		Start:    startTask,
+		Workflow:    wf,
+		Start:       startTask,
+		MaxFailures: maxFailures,
 	}
 	// Add start and/or stop timestamps if they exist
 	if s.StartTime != nil {

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -25,6 +25,10 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+const (
+	DefaultMaxFailures = 10
+)
+
 var (
 	flAPIDisabled = cli.BoolFlag{
 		Name:  "disable-api, d",

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -43,12 +43,66 @@ var (
 	ErrTaskDisabledNotRunnable = errors.New("Task is disabled. Cannot be started")
 )
 
+<<<<<<< 0995570155aeaa57088aedc64b522204046a9c3c
+=======
+type configItem struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+type task struct {
+	ID                 uint64                  `json:"id"`
+	Config             map[string][]configItem `json:"config"`
+	Name               string                  `json:"name"`
+	Deadline           string                  `json:"deadline"`
+	Workflow           wmap.WorkflowMap        `json:"workflow"`
+	Schedule           cschedule.Schedule      `json:"schedule"`
+	CreationTime       time.Time               `json:"creation_timestamp,omitempty"`
+	LastRunTime        time.Time               `json:"last_run_timestamp,omitempty"`
+	HitCount           uint                    `json:"hit_count,omitempty"`
+	MissCount          uint                    `json:"miss_count,omitempty"`
+	FailedCount        uint                    `json:"failed_count,omitempty"`
+	LastFailureMessage string                  `json:"last_failure_message,omitempty"`
+	State              string                  `json:"task_state"`
+	MaxFailure         uint                    `json:"max_failure"`
+}
+
+>>>>>>> issue#967: Customizable number of failures before snap disable the task
 func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	task, err := core.CreateTaskFromContent(r.Body, nil, s.mt.CreateTask)
 	if err != nil {
 		respond(500, rbody.FromError(err), w)
 		return
 	}
+<<<<<<< 0995570155aeaa57088aedc64b522204046a9c3c
+=======
+
+	var opts []core.TaskOption
+	if tr.Deadline != "" {
+		dl, err := time.ParseDuration(tr.Deadline)
+		if err != nil {
+			respond(500, rbody.FromError(err), w)
+			return
+		}
+		opts = append(opts, core.TaskDeadlineDuration(dl))
+	}
+
+	if tr.Name != "" {
+		opts = append(opts, core.SetTaskName(tr.Name))
+	}
+	opts = append(opts, core.OptionStopOnFailure(tr.MaxFailures))
+
+	task, errs := s.mt.CreateTask(sch, tr.Workflow, tr.Start, opts...)
+	if errs != nil && len(errs.Errors()) != 0 {
+		var errMsg string
+		for _, e := range errs.Errors() {
+			errMsg = errMsg + e.Error() + " -- "
+		}
+		respond(500, rbody.FromError(errors.New(errMsg[:len(errMsg)-4])), w)
+		return
+	}
+
+>>>>>>> issue#967: Customizable number of failures before snap disable the task
 	taskB := rbody.AddSchedulerTaskFromTask(task)
 	taskB.Href = taskURI(r.Host, task)
 	respond(201, taskB, w)

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -43,66 +43,12 @@ var (
 	ErrTaskDisabledNotRunnable = errors.New("Task is disabled. Cannot be started")
 )
 
-<<<<<<< 0995570155aeaa57088aedc64b522204046a9c3c
-=======
-type configItem struct {
-	Key   string      `json:"key"`
-	Value interface{} `json:"value"`
-}
-
-type task struct {
-	ID                 uint64                  `json:"id"`
-	Config             map[string][]configItem `json:"config"`
-	Name               string                  `json:"name"`
-	Deadline           string                  `json:"deadline"`
-	Workflow           wmap.WorkflowMap        `json:"workflow"`
-	Schedule           cschedule.Schedule      `json:"schedule"`
-	CreationTime       time.Time               `json:"creation_timestamp,omitempty"`
-	LastRunTime        time.Time               `json:"last_run_timestamp,omitempty"`
-	HitCount           uint                    `json:"hit_count,omitempty"`
-	MissCount          uint                    `json:"miss_count,omitempty"`
-	FailedCount        uint                    `json:"failed_count,omitempty"`
-	LastFailureMessage string                  `json:"last_failure_message,omitempty"`
-	State              string                  `json:"task_state"`
-	MaxFailure         uint                    `json:"max_failure"`
-}
-
->>>>>>> issue#967: Customizable number of failures before snap disable the task
 func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	task, err := core.CreateTaskFromContent(r.Body, nil, s.mt.CreateTask)
 	if err != nil {
 		respond(500, rbody.FromError(err), w)
 		return
 	}
-<<<<<<< 0995570155aeaa57088aedc64b522204046a9c3c
-=======
-
-	var opts []core.TaskOption
-	if tr.Deadline != "" {
-		dl, err := time.ParseDuration(tr.Deadline)
-		if err != nil {
-			respond(500, rbody.FromError(err), w)
-			return
-		}
-		opts = append(opts, core.TaskDeadlineDuration(dl))
-	}
-
-	if tr.Name != "" {
-		opts = append(opts, core.SetTaskName(tr.Name))
-	}
-	opts = append(opts, core.OptionStopOnFailure(tr.MaxFailures))
-
-	task, errs := s.mt.CreateTask(sch, tr.Workflow, tr.Start, opts...)
-	if errs != nil && len(errs.Errors()) != 0 {
-		var errMsg string
-		for _, e := range errs.Errors() {
-			errMsg = errMsg + e.Error() + " -- "
-		}
-		respond(500, rbody.FromError(errors.New(errMsg[:len(errMsg)-4])), w)
-		return
-	}
-
->>>>>>> issue#967: Customizable number of failures before snap disable the task
 	taskB := rbody.AddSchedulerTaskFromTask(task)
 	taskB.Href = taskURI(r.Host, task)
 	respond(201, taskB, w)

--- a/mgmt/tribe/tribe_test.go
+++ b/mgmt/tribe/tribe_test.go
@@ -67,11 +67,12 @@ func (t *mockTask) CreationTime() *time.Time                  { return nil }
 func (t *mockTask) DeadlineDuration() time.Duration           { return 0 }
 func (t *mockTask) SetDeadlineDuration(time.Duration)         { return }
 func (t *mockTask) SetTaskID(id string)                       { return }
-func (t *mockTask) SetStopOnFailure(uint)                     { return }
-func (t *mockTask) GetStopOnFailure() uint                    { return 0 }
+func (t *mockTask) SetStopOnFailure(int)                      { return }
+func (t *mockTask) GetStopOnFailure() int                     { return 0 }
 func (t *mockTask) Option(...core.TaskOption) core.TaskOption { return core.TaskDeadlineDuration(0) }
 func (t *mockTask) WMap() *wmap.WorkflowMap                   { return nil }
 func (t *mockTask) Schedule() schedule.Schedule               { return nil }
+func (t *mockTask) MaxFailures() int                          { return 10 }
 
 func getTestConfig() *Config {
 	cfg := GetDefaultConfig()


### PR DESCRIPTION
Fixes #967 

Summary of changes:
- Adding a new optional field "failure" under Snap task header.  This field defines the number of consecutive failures when snap disable the task.  If the field is missing, the default value will be 10.
- Update the task documentation to reflect the change
- Adding --failure for the command line

Testing done:
- Creating task via task manifest using the example folder

@intelsdi-x/snap-maintainers

