### PR TITLE
Use go get -d to get Snap

### DIFF
--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -30,9 +30,11 @@ To build the Snap Framework you'll need:
 
 The instructions below assume that the `GOPATH` environment variable has been set properly. Many of us use [go version manager (gvm)](https://github.com/moovweb/gvm) to easily switch between Go versions.
 
-Now you can install Snap into your `$GOPATH`:
+Now you can download Snap into your `$GOPATH`:
+
 ```
-$ go get github.com/intelsdi-x/snap
+$ # -d is used to download snap without building it
+$ go get -d github.com/intelsdi-x/snap
 $ cd $GOPATH/src/github.com/intelsdi-x/snap
 ```
 


### PR DESCRIPTION
Fixes #994

This PR fixes #994 by changing the `BUILD_AND_TEST` doc to use `go get -d` rather than `go get` to download Snap. This is to just download Snap instead of also building and installing it.

Building and installing Snap with `go get` is not safe, because `go get` fetches the latest commits of the dependencies, and Snap may not compile against these commits.

In the future, Snap may rely on the Vendoring functionality, and building it at `go get` time may be possible again. See #932, #933 and #1008 for experiments.