### PR TITLE
Fixes #979: Adds code to check the CLI and config file port definitions

### DIFF
--- a/control/flags.go
+++ b/control/flags.go
@@ -19,19 +19,21 @@ limitations under the License.
 
 package control
 
-import "github.com/codegangsta/cli"
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+)
 
 var (
-	flNumberOfPLs = cli.IntFlag{
+	flNumberOfPLs = cli.StringFlag{
 		Name:   "max-running-plugins, m",
-		Value:  defaultMaxRunningPlugins,
-		Usage:  "The maximum number of instances of a loaded plugin to run",
+		Usage:  fmt.Sprintf("The maximum number of instances of a loaded plugin to run (default: %v)", defaultMaxRunningPlugins),
 		EnvVar: "SNAP_MAX_PLUGINS",
 	}
-	flPluginTrust = cli.IntFlag{
+	flPluginTrust = cli.StringFlag{
 		Name:   "plugin-trust, t",
-		Usage:  "0-2 (Disabled, Enabled, Warning)",
-		Value:  defaultPluginTrust,
+		Usage:  fmt.Sprintf("0-2 (Disabled, Enabled, Warning; default: %v)", defaultPluginTrust),
 		EnvVar: "SNAP_TRUST_LEVEL",
 	}
 
@@ -45,16 +47,15 @@ var (
 		Usage:  "Keyring paths for signing verification separated by colons",
 		EnvVar: "SNAP_KEYRING_PATHS",
 	}
-	flCache = cli.DurationFlag{
+	flCache = cli.StringFlag{
 		Name:   "cache-expiration",
-		Usage:  "The time limit for which a metric cache entry is valid",
-		Value:  defaultCacheExpiration,
+		Usage:  fmt.Sprintf("The time limit for which a metric cache entry is valid (default: %v)", defaultCacheExpiration),
 		EnvVar: "SNAP_CACHE_EXPIRATION",
 	}
 
-	flControlRpcPort = cli.IntFlag{
+	flControlRpcPort = cli.StringFlag{
 		Name:   "control-listen-port",
-		Usage:  "Listen port for control RPC server",
+		Usage:  fmt.Sprintf("Listen port for control RPC server (default: %v)", defaultListenPort),
 		EnvVar: "SNAP_CONTROL_LISTEN_PORT",
 	}
 

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -93,7 +93,7 @@ func startAPI() string {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddress("127.0.0.1", 0)
+	r.SetAddress("127.0.0.1:0")
 	r.Start()
 	time.Sleep(100 * time.Millisecond)
 	return fmt.Sprintf("http://localhost:%d", r.Port())

--- a/mgmt/rest/client/client_tribe_func_test.go
+++ b/mgmt/rest/client/client_tribe_func_test.go
@@ -202,7 +202,7 @@ func startTribes(count int) []int {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddress("", mgtPort)
+		r.SetAddress(fmt.Sprintf("127.0.0.1:%d", mgtPort))
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -35,9 +35,9 @@ var (
 		Usage:  "API Address[:port] to bind to/listen on. Default: empty string => listen on all interfaces",
 		EnvVar: "SNAP_ADDR",
 	}
-	flAPIPort = cli.IntFlag{
+	flAPIPort = cli.StringFlag{
 		Name:   "api-port, p",
-		Usage:  fmt.Sprintf("API port (Default: %d)", defaultPort),
+		Usage:  fmt.Sprintf("API port (default: %v)", defaultPort),
 		EnvVar: "SNAP_PORT",
 	}
 	flRestHTTPS = cli.BoolFlag{

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -38,7 +38,6 @@ var (
 	flAPIPort = cli.IntFlag{
 		Name:   "api-port, p",
 		Usage:  fmt.Sprintf("API port (Default: %d)", defaultPort),
-		Value:  defaultPort,
 		EnvVar: "SNAP_PORT",
 	}
 	flRestHTTPS = cli.BoolFlag{

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -490,7 +490,7 @@ func startAPI(cfg *mockConfig) *restAPIInstance {
 		}
 		log.Fatal(err)
 	}(r.Err())
-	r.SetAddress("127.0.0.1", 0)
+	r.SetAddress("127.0.0.1:0")
 	r.Start()
 	time.Sleep(time.Millisecond * 100)
 	return &restAPIInstance{

--- a/mgmt/rest/tribe_test.go
+++ b/mgmt/rest/tribe_test.go
@@ -702,7 +702,7 @@ func startTribes(count int, seed string) ([]int, int) {
 		r.BindMetricManager(c)
 		r.BindTaskManager(s)
 		r.BindTribeManager(t)
-		r.SetAddress("", mgtPort)
+		r.SetAddress(fmt.Sprintf("127.0.0.1:%d", mgtPort))
 		r.Start()
 		wg.Add(1)
 		timer := time.After(10 * time.Second)

--- a/mgmt/tribe/flags.go
+++ b/mgmt/tribe/flags.go
@@ -19,7 +19,11 @@ limitations under the License.
 
 package tribe
 
-import "github.com/codegangsta/cli"
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+)
 
 var (
 	flTribeNodeName = cli.StringFlag{
@@ -40,10 +44,9 @@ var (
 		EnvVar: "SNAP_TRIBE_SEED",
 	}
 
-	flTribeAdvertisePort = cli.IntFlag{
+	flTribeAdvertisePort = cli.StringFlag{
 		Name:   "tribe-port",
-		Usage:  "Port tribe gossips over to maintain membership",
-		Value:  defaultBindPort,
+		Usage:  fmt.Sprintf("Port tribe gossips over to maintain membership (default: %v)", defaultBindPort),
 		EnvVar: "SNAP_TRIBE_PORT",
 	}
 

--- a/scheduler/flags.go
+++ b/scheduler/flags.go
@@ -26,17 +26,15 @@ import (
 )
 
 var (
-	flSchedulerQueueSize = cli.IntFlag{
+	flSchedulerQueueSize = cli.StringFlag{
 		Name:   "work-manager-queue-size",
-		Usage:  fmt.Sprintf("Size of the work manager queue (default: %d)", defaultWorkManagerQueueSize),
-		Value:  int(defaultWorkManagerQueueSize),
+		Usage:  fmt.Sprintf("Size of the work manager queue (default: %v)", defaultWorkManagerQueueSize),
 		EnvVar: "WORK_MANAGER_QUEUE_SIZE",
 	}
 
-	flSchedulerPoolSize = cli.IntFlag{
+	flSchedulerPoolSize = cli.StringFlag{
 		Name:   "work-manager-pool-size",
-		Usage:  fmt.Sprintf("Size of the work manager pool (default %d)", defaultWorkManagerPoolSize),
-		Value:  int(defaultWorkManagerPoolSize),
+		Usage:  fmt.Sprintf("Size of the work manager pool (default: %v)", defaultWorkManagerPoolSize),
 		EnvVar: "WORK_MANAGER_POOL_SIZE",
 	}
 

--- a/snapd.go
+++ b/snapd.go
@@ -50,10 +50,9 @@ import (
 )
 
 var (
-	flMaxProcs = cli.IntFlag{
+	flMaxProcs = cli.StringFlag{
 		Name:   "max-procs, c",
-		Usage:  fmt.Sprintf("Set max cores to use for snap Agent. Default is %d core.", defaultGoMaxProcs),
-		Value:  defaultGoMaxProcs,
+		Usage:  fmt.Sprintf("Set max cores to use for snap Agent (default: %v)", defaultGoMaxProcs),
 		EnvVar: "GOMAXPROCS",
 	}
 	// plugin
@@ -70,10 +69,9 @@ var (
 		Name:  "log-colors",
 		Usage: "Log file coloring mode. Default is true => colored (--log-colors=false => no colors).",
 	}
-	flLogLevel = cli.IntFlag{
+	flLogLevel = cli.StringFlag{
 		Name:   "log-level, l",
-		Usage:  "1-5 (Debug, Info, Warning, Error, Fatal)",
-		Value:  defaultLogLevel,
+		Usage:  fmt.Sprintf("1-5 (Debug, Info, Warning, Error, Fatal; default: %v)", defaultLogLevel),
 		EnvVar: "SNAP_LOG_LEVEL",
 	}
 	flConfig = cli.StringFlag{
@@ -550,9 +548,15 @@ func setStringVal(field string, ctx *cli.Context, flagName string) string {
 func setIntVal(field int, ctx *cli.Context, flagName string) int {
 	// check to see if a value was set (either on the command-line or via the associated
 	// environment variable, if any); if so, use that as value for the input field
-	val := ctx.Int(flagName)
-	if ctx.IsSet(flagName) || val != 0 {
-		field = val
+	val := ctx.String(flagName)
+	if ctx.IsSet(flagName) || val != "" {
+		parsedField, err := strconv.Atoi(val)
+		if err != nil {
+			splitErr := strings.Split(err.Error(), ": ")
+			errStr := splitErr[len(splitErr)-1]
+			log.Fatal(fmt.Sprintf("Error Parsing %v; value '%v' cannot be parsed as an integer (%v)", flagName, val, errStr))
+		}
+		field = int(parsedField)
 	}
 	return field
 }
@@ -560,9 +564,15 @@ func setIntVal(field int, ctx *cli.Context, flagName string) int {
 func setUIntVal(field uint, ctx *cli.Context, flagName string) uint {
 	// check to see if a value was set (either on the command-line or via the associated
 	// environment variable, if any); if so, use that as value for the input field
-	val := ctx.Int(flagName)
-	if ctx.IsSet(flagName) || val != 0 {
-		field = uint(val)
+	val := ctx.String(flagName)
+	if ctx.IsSet(flagName) || val != "" {
+		parsedField, err := strconv.Atoi(val)
+		if err != nil {
+			splitErr := strings.Split(err.Error(), ": ")
+			errStr := splitErr[len(splitErr)-1]
+			log.Fatal(fmt.Sprintf("Error Parsing %v; value '%v' cannot be parsed as an unsigned integer (%v)", flagName, val, errStr))
+		}
+		field = uint(parsedField)
 	}
 	return field
 }
@@ -570,9 +580,15 @@ func setUIntVal(field uint, ctx *cli.Context, flagName string) uint {
 func setDurationVal(field time.Duration, ctx *cli.Context, flagName string) time.Duration {
 	// check to see if a value was set (either on the command-line or via the associated
 	// environment variable, if any); if so, use that as value for the input field
-	val := ctx.Duration(flagName)
-	if ctx.IsSet(flagName) || val != 0 {
-		field = val
+	val := ctx.String(flagName)
+	if ctx.IsSet(flagName) || val != "" {
+		parsedField, err := time.ParseDuration(val)
+		if err != nil {
+			splitErr := strings.Split(err.Error(), ": ")
+			errStr := splitErr[len(splitErr)-1]
+			log.Fatal(fmt.Sprintf("Error Parsing %v; value '%v' cannot be parsed as a duration (%v)", flagName, val, errStr))
+		}
+		field = parsedField
 	}
 	return field
 }


### PR DESCRIPTION
Fixes #979

Summary of changes:
- Adds a new (unexported) flag to the RESTful server configuration so that we can determine if there was a port defined for the `restapi::port` parameter in the global configuration file and a 'getter' function to retrieve the value of that flag.
- refactors the `SetAddress` method from the `Server` type in the `mgmt/server` package so that it just takes an address (which can include a port as part of the address string); also refactored the associated tests so that they use the new form of this method.
- Adds functionality to the `snapd.go` file to carefully check all of the possible sources (the `SNAP_ADDR` and `SNAP_PORT` environment variables, the `--api-addr` and `--api-port` command-line parameters, and the `restapi::addr` and `restapi::port` parameters in the global configuration file) to make sure that the port is only defined once (either using just an address parameter or just a port parameter), but not both (you can define the port more than once, provided it the definitions are all done using the same 'type' of parameter; eg. using the `SNAP_ADDR` environment variable and the `restapi::addr` parameter in the global configuration file). Defining the port using more than one type of parameter will result in an error (eg. using the `SNAP_ADDR` environment variable and the `restapi::port` parameter in the global configuration file).
- Adds tests that check the address passed in through the `SNAP_ADDR` environment variable, the `--api-addr` command-line parameter, or the `restapi::addr` global configuration parameter to make sure it is a parseable IP address or a resolvable hostname.
- Adds tests to ensure that the port number passed in (through whatever source it is passed in) is an integer value that complies with the constraints defined for this parameter (regardless of the source it was obtained from)

Testing done:
- tested using `go run ...` commands on the CLI and passing in all of the various combinations and permutations of inputs to ensure that all of the error conditions that should be caught were caught and that the port was set correctly, regardless of the source that was used to pass this port into the Snap daemon.

@intelsdi-x/snap-maintainers