### PR TITLE
If max-failures value is -1, snap will never disable a task with consecutive failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ tags
 
 # OSX stuff
 .DS_Store
+
+*.cov

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 [![Join the chat at https://gitter.im/intelsdi-x/snap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/intelsdi-x/snap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/intelsdi-x/snap.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap)
-[![Go Report Card](http://goreportcard.com/badge/intelsdi-x/snap)](http://goreportcard.com/report/intelsdi-x/snap)
+[![Go Report Card](https://goreportcard.com/badge/intelsdi-x/snap)](https://goreportcard.com/report/intelsdi-x/snap)
 
 <img src="https://cloud.githubusercontent.com/assets/1744971/13930753/6f676b34-ef5d-11e5-97be-8503562cd5fe.png" width="50%">
 

--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -49,6 +49,7 @@ var (
 						flTaskSchedDuration,
 						flTaskSchedNoStart,
 						flTaskDeadline,
+						flTaskFailure,
 					},
 				},
 				{

--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -49,7 +49,7 @@ var (
 						flTaskSchedDuration,
 						flTaskSchedNoStart,
 						flTaskDeadline,
-						flTaskFailure,
+						flTaskFailures,
 					},
 				},
 				{

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -22,7 +22,7 @@ package main
 import "github.com/codegangsta/cli"
 
 const (
-	default_failure = 10
+	DefaultFailureRetry = 10
 )
 
 var (
@@ -129,7 +129,7 @@ var (
 	flTaskFailure = cli.IntFlag{
 		Name:  "failure",
 		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
-		Value: default_failure,
+		Value: DefaultFailureRetry,
 	}
 
 	// metric

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -21,6 +21,10 @@ package main
 
 import "github.com/codegangsta/cli"
 
+const (
+	default_failure = 10
+)
+
 var (
 
 	// Main flags
@@ -125,7 +129,7 @@ var (
 	flTaskFailure = cli.IntFlag{
 		Name:  "failure",
 		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
-		Value: 10,
+		Value: default_failure,
 	}
 
 	// metric

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -122,9 +122,10 @@ var (
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
 	}
-	flTaskFailure = cli.StringFlag{
+	flTaskFailure = cli.IntFlag{
 		Name:  "failure",
 		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
+		Value: 10,
 	}
 
 	// metric

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -22,7 +22,7 @@ package main
 import "github.com/codegangsta/cli"
 
 const (
-	DefaultFailureRetry = 10
+	DefaultMaxFailures = 10
 )
 
 var (
@@ -126,10 +126,10 @@ var (
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
 	}
-	flTaskFailure = cli.IntFlag{
-		Name:  "failure",
+	flTaskFailures = cli.IntFlag{
+		Name:  "max-failures",
 		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
-		Value: DefaultFailureRetry,
+		Value: DefaultMaxFailures,
 	}
 
 	// metric

--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -122,6 +122,10 @@ var (
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
 	}
+	flTaskFailure = cli.StringFlag{
+		Name:  "failure",
+		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
+	}
 
 	// metric
 	flMetricVersion = cli.IntFlag{

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -78,12 +78,12 @@ func trunc(n int) string {
 }
 
 type task struct {
-	Version  int
-	Schedule *client.Schedule
-	Workflow *wmap.WorkflowMap
-	Name     string
-	Deadline string
-	Failure  uint
+	Version     int
+	Schedule    *client.Schedule
+	Workflow    *wmap.WorkflowMap
+	Name        string
+	Deadline    string
+	MaxFailures uint `json:"max-failures"`
 }
 
 func createTask(ctx *cli.Context) {
@@ -137,13 +137,13 @@ func createTaskUsingTaskManifest(ctx *cli.Context) {
 		os.Exit(1)
 	}
 
-	// If the number of failure does not specific, default value is 10
-	if t.Failure == 0 {
-		fmt.Println("If the number of failures is not specified, use default value of", DefaultFailureRetry)
-		t.Failure = DefaultFailureRetry
+	// If the number of failures does not specific, default value is 10
+	if t.MaxFailures == 0 {
+		fmt.Println("If the number of maximum failures is not specified, use default value of", DefaultMaxFailures)
+		t.MaxFailures = DefaultMaxFailures
 	}
 
-	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.Failure)
+	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.MaxFailures)
 
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -139,8 +139,8 @@ func createTaskUsingTaskManifest(ctx *cli.Context) {
 
 	// If the number of failure does not specific, default value is 10
 	if t.Failure == 0 {
-		fmt.Println("Not specific the number of failures to disable the task.  Use default value: 10")
-		t.Failure = 10
+		fmt.Println("If the number of failures is not specified, use default value of", default_failure)
+		t.Failure = default_failure
 	}
 
 	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.Failure)

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -83,7 +83,7 @@ type task struct {
 	Workflow    *wmap.WorkflowMap
 	Name        string
 	Deadline    string
-	MaxFailures uint `json:"max-failures"`
+	MaxFailures int `json:"max-failures"`
 }
 
 func createTask(ctx *cli.Context) {

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -209,13 +209,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) {
 
 	// Deadline for a task
 	dl := ctx.String("deadline")
-
-	var failure uint
-	if ctx.IsSet("failure") {
-		failure = uint(ctx.Int("failure"))
-	} else {
-		failure = 10
-	}
+	failure := uint(ctx.Int("failure"))
 
 	var sch *client.Schedule
 	// None of these mean it is a simple schedule

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -139,8 +139,8 @@ func createTaskUsingTaskManifest(ctx *cli.Context) {
 
 	// If the number of failure does not specific, default value is 10
 	if t.Failure == 0 {
-		fmt.Println("If the number of failures is not specified, use default value of", default_failure)
-		t.Failure = default_failure
+		fmt.Println("If the number of failures is not specified, use default value of", DefaultFailureRetry)
+		t.Failure = DefaultFailureRetry
 	}
 
 	r := pClient.CreateTask(t.Schedule, t.Workflow, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.Failure)

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -209,7 +209,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) {
 
 	// Deadline for a task
 	dl := ctx.String("deadline")
-	failure := uint(ctx.Int("failure"))
+	maxFailures := ctx.Int("max-failures")
 
 	var sch *client.Schedule
 	// None of these mean it is a simple schedule
@@ -278,7 +278,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) {
 		}
 	}
 	// Create task
-	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"), failure)
+	r := pClient.CreateTask(sch, wf, name, dl, !ctx.IsSet("no-start"), maxFailures)
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
 		fmt.Println("Error creating task:")

--- a/core/task.go
+++ b/core/task.go
@@ -82,8 +82,8 @@ type Task interface {
 	DeadlineDuration() time.Duration
 	SetDeadlineDuration(time.Duration)
 	SetTaskID(id string)
-	SetStopOnFailure(uint)
-	GetStopOnFailure() uint
+	SetStopOnFailure(int)
+	GetStopOnFailure() int
 	Option(...TaskOption) TaskOption
 	WMap() *wmap.WorkflowMap
 	Schedule() schedule.Schedule

--- a/core/task.go
+++ b/core/task.go
@@ -113,7 +113,7 @@ func TaskDeadlineDuration(v time.Duration) TaskOption {
 // TaskStopOnFailure sets the tasks stopOnFailure
 // The stopOnFailure is the number of consecutive task failures that will
 // trigger disabling the task
-func OptionStopOnFailure(v uint) TaskOption {
+func OptionStopOnFailure(v int) TaskOption {
 	return func(t Task) TaskOption {
 		previous := t.GetStopOnFailure()
 		t.SetStopOnFailure(v)

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -15,7 +15,7 @@ The manifest can be divided into two parts: Header and Workflow.
   schedule:
     type: "simple"
     interval: "1s"
-  failure: 10
+  max-failures: 10
 ```
 
 #### Version
@@ -33,13 +33,13 @@ The schedule describes the schedule type and interval for running the task.  The
         "type": "cron",
         "interval" : "0 30 * * * *"
     },
-    "failure": 10,
+    "max-failures": 10,
 ```
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
 
 #### Failure
-By default, snap will disable a task if there is 10 consecutive error from any plugins within the workflow.  The configuration
-can be changing by specifying the number of failures value in the task header.
+By default, snap will disable a task if there is 10 consecutive errors from any plugins within the workflow.  The configuration
+can be changed by specifying the number of failures value in the task header.
 
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -39,7 +39,7 @@ More on cron expressions can be found here: https://godoc.org/github.com/robfig/
 
 #### Failure
 By default, snap will disable a task if there is 10 consecutive error from any plugins within the workflow.  The configuration
-can be changed by specific the number of failures value in the task header.
+can be changing by specifying the number of failures value in the task header.
 
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -37,9 +37,11 @@ The schedule describes the schedule type and interval for running the task.  The
 ```
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
 
-#### Failure
+#### Max-Failures
 By default, snap will disable a task if there is 10 consecutive errors from any plugins within the workflow.  The configuration
-can be changed by specifying the number of failures value in the task header.
+can be changed by specifying the number of failures value in the task header.  If the max-failures value is -1, snap will
+not disable a task with consecutive failure.  Instead, snap will sleep for 1 second for every 10 consective failures
+and retry again.
 
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -15,6 +15,7 @@ The manifest can be divided into two parts: Header and Workflow.
   schedule:
     type: "simple"
     interval: "1s"
+  failure: 10
 ```
 
 #### Version
@@ -32,8 +33,14 @@ The schedule describes the schedule type and interval for running the task.  The
         "type": "cron",
         "interval" : "0 30 * * * *"
     },
+    "failure": 10,
 ```
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
+
+#### Failure
+By default, snap will disable a task if there is 10 consecutive error from any plugins within the workflow.  The configuration
+can be changed by specific the number of failures value in the task header.
+
 
 For more on tasks, visit [`SNAPCTL.md`](SNAPCTL.md).
 

--- a/examples/tasks/ceph-file.json
+++ b/examples/tasks/ceph-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/ceph-file.json
+++ b/examples/tasks/ceph-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "failure": 10,
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/distributed-mock-file.json
+++ b/examples/tasks/distributed-mock-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/distributed-mock-file.json
+++ b/examples/tasks/distributed-mock-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "failure": 10,
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "failure": 10,
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -3,7 +3,7 @@
   schedule: 
     type: "simple"
     interval: "1s"
-  failure: 10
+  max-failure: 10
   workflow: 
     collect: 
       metrics: 

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -3,6 +3,7 @@
   schedule: 
     type: "simple"
     interval: "1s"
+  failure: 10
   workflow: 
     collect: 
       metrics: 

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -3,7 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
-  failure: 10
+  max-failure: 10
   workflow:
     collect:
       metrics:

--- a/examples/tasks/psutil-file.yaml
+++ b/examples/tasks/psutil-file.yaml
@@ -3,6 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
+  failure: 10
   workflow:
     collect:
       metrics:

--- a/examples/tasks/psutil-file_no-processor.yaml
+++ b/examples/tasks/psutil-file_no-processor.yaml
@@ -3,7 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
-  failure: 10
+  max-failure: 10
   workflow: 
     collect:
       metrics:

--- a/examples/tasks/psutil-file_no-processor.yaml
+++ b/examples/tasks/psutil-file_no-processor.yaml
@@ -3,6 +3,7 @@
   schedule:
     type: "simple"
     interval: "1s"
+  failure: 10
   workflow: 
     collect:
       metrics:

--- a/examples/tasks/psutil-influx.json
+++ b/examples/tasks/psutil-influx.json
@@ -4,6 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
+    "failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/examples/tasks/psutil-influx.json
+++ b/examples/tasks/psutil-influx.json
@@ -4,7 +4,7 @@
         "type": "simple",
         "interval": "1s"
     },
-    "failure": 10,
+    "max-failure": 10,
     "workflow": {
         "collect": {
             "metrics": {

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -160,7 +160,7 @@ func TestSnapClient(t *testing.T) {
 					So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("Task not found: ID(%s)", uuid))
 				})
 				Convey("invalid task (missing metric)", func() {
-					tt := c.CreateTask(sch, wf, "baron", "", true)
+					tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
 					So(tt.Err, ShouldNotBeNil)
 					So(tt.Err.Error(), ShouldContainSubstring, "Metric not found: /intel/mock/foo")
 				})
@@ -193,7 +193,7 @@ func TestSnapClient(t *testing.T) {
 				So(p.AvailablePlugins, ShouldBeEmpty)
 			})
 			Convey("invalid task (missing publisher)", func() {
-				tf := c.CreateTask(sch, wf, "baron", "", false)
+				tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 				So(tf.Err, ShouldNotBeNil)
 				So(tf.Err.Error(), ShouldContainSubstring, "Plugin not found: type(publisher) name(file)")
 			})
@@ -338,11 +338,11 @@ func TestSnapClient(t *testing.T) {
 		Convey("Tasks", func() {
 			Convey("Passing a bad task manifest", func() {
 				wfb := getWMFromSample("bad.json")
-				ttb := c.CreateTask(sch, wfb, "bad", "", true)
+				ttb := c.CreateTask(sch, wfb, "bad", "", true, rest.DefaultMaxFailures)
 				So(ttb.Err, ShouldNotBeNil)
 			})
 
-			tf := c.CreateTask(sch, wf, "baron", "", false)
+			tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 			Convey("valid task not started on creation", func() {
 				So(tf.Err, ShouldBeNil)
 				So(tf.Name, ShouldEqual, "baron")
@@ -385,7 +385,7 @@ func TestSnapClient(t *testing.T) {
 				})
 			})
 
-			tt := c.CreateTask(sch, wf, "baron", "", true)
+			tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
 			Convey("valid task started on creation", func() {
 				So(tt.Err, ShouldBeNil)
 				So(tt.Name, ShouldEqual, "baron")
@@ -473,7 +473,7 @@ func TestSnapClient(t *testing.T) {
 					Convey("event stream", func() {
 						rest.StreamingBufferWindow = 0.01
 						sch := &Schedule{Type: "simple", Interval: "100ms"}
-						tf := c.CreateTask(sch, wf, "baron", "", false)
+						tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
 
 						type ea struct {
 							events []string

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -48,7 +48,7 @@ type Schedule struct {
 // If the startTask flag is true, the newly created task is started after the creation.
 // Otherwise, it's in the Stopped state. CreateTask is accomplished through a POST HTTP JSON request.
 // A ScheduledTask is returned if it succeeds, otherwise an error is returned.
-func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool) *CreateTaskResult {
+func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, failure uint) *CreateTaskResult {
 	t := request.TaskCreationRequest{
 		Schedule: request.Schedule{
 			Type:     s.Type,
@@ -56,6 +56,7 @@ func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, dead
 		},
 		Workflow: wf,
 		Start:    startTask,
+		Failure:  failure,
 	}
 	// Add start and/or stop timestamps if they exist
 	if s.StartTime != nil {

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -48,15 +48,15 @@ type Schedule struct {
 // If the startTask flag is true, the newly created task is started after the creation.
 // Otherwise, it's in the Stopped state. CreateTask is accomplished through a POST HTTP JSON request.
 // A ScheduledTask is returned if it succeeds, otherwise an error is returned.
-func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, failure uint) *CreateTaskResult {
+func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, maxFailures uint) *CreateTaskResult {
 	t := request.TaskCreationRequest{
 		Schedule: request.Schedule{
 			Type:     s.Type,
 			Interval: s.Interval,
 		},
-		Workflow: wf,
-		Start:    startTask,
-		Failure:  failure,
+		Workflow:    wf,
+		Start:       startTask,
+		MaxFailures: maxFailures,
 	}
 	// Add start and/or stop timestamps if they exist
 	if s.StartTime != nil {

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -48,7 +48,7 @@ type Schedule struct {
 // If the startTask flag is true, the newly created task is started after the creation.
 // Otherwise, it's in the Stopped state. CreateTask is accomplished through a POST HTTP JSON request.
 // A ScheduledTask is returned if it succeeds, otherwise an error is returned.
-func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, maxFailures uint) *CreateTaskResult {
+func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, maxFailures int) *CreateTaskResult {
 	t := request.TaskCreationRequest{
 		Schedule: request.Schedule{
 			Type:     s.Type,

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -25,6 +25,10 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+const (
+	DefaultMaxFailures = 10
+)
+
 var (
 	flAPIDisabled = cli.BoolFlag{
 		Name:  "disable-api, d",

--- a/mgmt/rest/request/task.go
+++ b/mgmt/rest/request/task.go
@@ -29,6 +29,7 @@ type TaskCreationRequest struct {
 	Workflow *wmap.WorkflowMap `json:"workflow"`
 	Schedule Schedule          `json:"schedule"`
 	Start    bool              `json:"start"`
+	Failure  uint              `json:"failure"`
 }
 
 type Schedule struct {

--- a/mgmt/rest/request/task.go
+++ b/mgmt/rest/request/task.go
@@ -29,7 +29,7 @@ type TaskCreationRequest struct {
 	Workflow    *wmap.WorkflowMap `json:"workflow"`
 	Schedule    Schedule          `json:"schedule"`
 	Start       bool              `json:"start"`
-	MaxFailures uint              `json:"max-failures"`
+	MaxFailures int               `json:"max-failures"`
 }
 
 type Schedule struct {

--- a/mgmt/rest/request/task.go
+++ b/mgmt/rest/request/task.go
@@ -24,12 +24,12 @@ import (
 )
 
 type TaskCreationRequest struct {
-	Name     string            `json:"name"`
-	Deadline string            `json:"deadline"`
-	Workflow *wmap.WorkflowMap `json:"workflow"`
-	Schedule Schedule          `json:"schedule"`
-	Start    bool              `json:"start"`
-	Failure  uint              `json:"failure"`
+	Name        string            `json:"name"`
+	Deadline    string            `json:"deadline"`
+	Workflow    *wmap.WorkflowMap `json:"workflow"`
+	Schedule    Schedule          `json:"schedule"`
+	Start       bool              `json:"start"`
+	MaxFailures uint              `json:"max-failures"`
 }
 
 type Schedule struct {

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -66,7 +66,7 @@ type task struct {
 	FailedCount        uint                    `json:"failed_count,omitempty"`
 	LastFailureMessage string                  `json:"last_failure_message,omitempty"`
 	State              string                  `json:"task_state"`
-	Failure            uint                    `json:"failure"`
+	MaxFailure         uint                    `json:"max_failure"`
 }
 
 func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -96,7 +96,7 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	if tr.Name != "" {
 		opts = append(opts, core.SetTaskName(tr.Name))
 	}
-	opts = append(opts, core.OptionStopOnFailure(tr.Failure))
+	opts = append(opts, core.OptionStopOnFailure(tr.MaxFailures))
 
 	task, errs := s.mt.CreateTask(sch, tr.Workflow, tr.Start, opts...)
 	if errs != nil && len(errs.Errors()) != 0 {

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -66,6 +66,7 @@ type task struct {
 	FailedCount        uint                    `json:"failed_count,omitempty"`
 	LastFailureMessage string                  `json:"last_failure_message,omitempty"`
 	State              string                  `json:"task_state"`
+	Failure            uint                    `json:"failure"`
 }
 
 func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -95,7 +96,7 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	if tr.Name != "" {
 		opts = append(opts, core.SetTaskName(tr.Name))
 	}
-	opts = append(opts, core.OptionStopOnFailure(10))
+	opts = append(opts, core.OptionStopOnFailure(tr.Failure))
 
 	task, errs := s.mt.CreateTask(sch, tr.Workflow, tr.Start, opts...)
 	if errs != nil && len(errs.Errors()) != 0 {

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -96,7 +96,12 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	if tr.Name != "" {
 		opts = append(opts, core.SetTaskName(tr.Name))
 	}
-	opts = append(opts, core.OptionStopOnFailure(tr.MaxFailures))
+
+	if tr.MaxFailures != 0 {
+		opts = append(opts, core.OptionStopOnFailure(tr.MaxFailures))
+	} else {
+		opts = append(opts, core.OptionStopOnFailure(DefaultMaxFailures))
+	}
 
 	task, errs := s.mt.CreateTask(sch, tr.Workflow, tr.Start, opts...)
 	if errs != nil && len(errs.Errors()) != 0 {

--- a/mgmt/tribe/tribe_test.go
+++ b/mgmt/tribe/tribe_test.go
@@ -67,11 +67,12 @@ func (t *mockTask) CreationTime() *time.Time                  { return nil }
 func (t *mockTask) DeadlineDuration() time.Duration           { return 0 }
 func (t *mockTask) SetDeadlineDuration(time.Duration)         { return }
 func (t *mockTask) SetTaskID(id string)                       { return }
-func (t *mockTask) SetStopOnFailure(uint)                     { return }
-func (t *mockTask) GetStopOnFailure() uint                    { return 0 }
+func (t *mockTask) SetStopOnFailure(int)                      { return }
+func (t *mockTask) GetStopOnFailure() int                     { return 0 }
 func (t *mockTask) Option(...core.TaskOption) core.TaskOption { return core.TaskDeadlineDuration(0) }
 func (t *mockTask) WMap() *wmap.WorkflowMap                   { return nil }
 func (t *mockTask) Schedule() schedule.Schedule               { return nil }
+
 
 func getTestConfig() *Config {
 	cfg := GetDefaultConfig()

--- a/mgmt/tribe/tribe_test.go
+++ b/mgmt/tribe/tribe_test.go
@@ -73,7 +73,6 @@ func (t *mockTask) Option(...core.TaskOption) core.TaskOption { return core.Task
 func (t *mockTask) WMap() *wmap.WorkflowMap                   { return nil }
 func (t *mockTask) Schedule() schedule.Schedule               { return nil }
 
-
 func getTestConfig() *Config {
 	cfg := GetDefaultConfig()
 	cfg.BindAddr = "127.0.0.1"

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -330,6 +330,11 @@ func (t *task) spin() {
 						"consecutive failure limit": t.stopOnFailure,
 						"error":                     t.lastFailureMessage,
 					}).Warn("Task failed")
+
+					// Sleep for 1 second for every 10 consecutive failures
+					if consecutiveFailures%10 == 0 {
+						time.Sleep(1000 * time.Millisecond)
+					}
 				}
 			// Schedule has ended
 			case schedule.Ended:


### PR DESCRIPTION
Fixes #967 

Summary of changes:
- This is part 2 of issue#967 which will never disable a task with consecutive failure when max-failures is negative value

Testing done:
- Using a task manifest of max-failures value is -1

@intelsdi-x/snap-maintainers
