### PR TITLE
Added publishing tags by file publisher

### DIFF
--- a/examples/tasks/mock_tagged-file.json
+++ b/examples/tasks/mock_tagged-file.json
@@ -1,0 +1,43 @@
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/foo": {},
+                "/intel/mock/bar": {},
+                "/intel/mock/*/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "name": "root",
+                    "password": "secret"
+                }
+            },
+            "tags": {
+                "/intel/mock": {
+                    "experiment": "1",
+                    "os": "linux"
+                }
+            },
+
+            "process": [
+                {
+                    "plugin_name": "passthru",                    
+                    "process": null,
+                    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.log"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/plugin/publisher/snap-publisher-file/file/file.go
+++ b/plugin/publisher/snap-publisher-file/file/file.go
@@ -32,6 +32,7 @@ import (
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/ctypes"
+	"strings"
 )
 
 const (
@@ -73,11 +74,23 @@ func (f *filePublisher) Publish(contentType string, content []byte, config map[s
 	}
 	w := bufio.NewWriter(file)
 	for _, m := range metrics {
-		w.WriteString(fmt.Sprintf("%v|%v|%v\n", m.Timestamp(), m.Namespace(), m.Data()))
+		formattedTags := formatMetricTagsAsString(m.Tags())
+		w.WriteString(fmt.Sprintf("%v|%v|%v|%v\n", m.Timestamp(), m.Namespace(), m.Data(), formattedTags))
 	}
 	w.Flush()
 
 	return nil
+}
+// formatMetricTagsAsString returns metric's tags as a string in the following format tagKey:tagValue where the next tags are separated by semicolon
+func formatMetricTagsAsString(metricTags map[string]string) string {
+	var tags string
+	for tag, value := range metricTags {
+		tags += fmt.Sprintf("%s:%s; ", tag, value)
+	}
+	// trim the last semicolon
+	tags = strings.TrimSuffix(tags, "; ")
+
+	return "tags["+tags+"]"
 }
 
 func Meta() *plugin.PluginMeta {


### PR DESCRIPTION
Summary of changes:
- added publishing tags by file publisher
- added exemplary task manifest with tags section

Testing done:
- running `mock_tagged-file.json` and confirm that metrics published to /tmp/snap_published_mock_file.log contain this tags

**Before:**
/tmp/snap_published_mock_file.log
```
2016-06-03 16:29:17.907943193 +0200 CEST|/intel/mock/bar|The mock collected data! config data: user={root} password={secret}
2016-06-03 16:29:17.907946183 +0200 CEST|/intel/mock/foo|The mock collected data! config data: user={root} password={secret}
2016-06-03 16:29:17.907949792 +0200 CEST|/intel/mock/host0/baz|87
2016-06-03 16:29:17.907957581 +0200 CEST|/intel/mock/host1/baz|71
2016-06-03 16:29:17.907958358 +0200 CEST|/intel/mock/host2/baz|88
2016-06-03 16:29:17.907959743 +0200 CEST|/intel/mock/host3/baz|86
```

**After this change:**
/tmp/snap_published_mock_file.log
```

2016-06-28 16:25:21.774951286 +0200 CEST|/intel/mock/host1/baz|70|tags[os:linux; experiment:1; plugin_running_on:devmachine]
2016-06-28 16:25:21.774953488 +0200 CEST|/intel/mock/host2/baz|67|tags[experiment:1; os:linux; plugin_running_on:devmachine]
2016-06-28 16:25:21.774954979 +0200 CEST|/intel/mock/host3/baz|73|tags[experiment:1; os:linux; plugin_running_on:devmachine]
```
@intelsdi-x/snap-maintainers

