### PR TITLE
resolves the missing SNAP_TEST_TYPE in calling scripts/test.sh

### DIFF
--- a/docs/BUILD_AND_TEST.md
+++ b/docs/BUILD_AND_TEST.md
@@ -159,5 +159,5 @@ The Snap Framework supports running tests in an isolated container as opposed to
 
 ```
 $ cd $GOPATH/src/github.com/intelsdi-x/snap
-$ scripts/run_tests_with_docker.sh`  
+$ scripts/run_tests_with_docker.sh [SNAP_TEST_TYPE]  
 ```

--- a/scripts/run_tests_with_docker.sh
+++ b/scripts/run_tests_with_docker.sh
@@ -17,5 +17,14 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
+if [[ $# -ne 1 ]]; then
+	echo "ERROR; missing SNAP_TEST_TYPE (Usage: $0 SNAP_TEST_TYPE)"
+	exit -2
+elif [[ “$1” != “legacy” && "$1" != "small" && “$1” != “medium” && “$1” != “large” ]]; then
+	echo "Error; invalid SNAP_TEST_TYPE (value must be one of 'legacy', 'small', 'medium', or 'large'; received $1)"
+	exit -1
+fi
+SNAP_TEST_TYPE=$1
+
 docker build -t intelsdi-x/snap-test -f scripts/Dockerfile .
-docker run -it intelsdi-x/snap-test scripts/test.sh
+docker run -it intelsdi-x/snap-test scripts/test.sh $SNAP_TEST_TYPE


### PR DESCRIPTION
Fixes #1019 

Summary of changes:
- I have added script to check if the `SNAP_TEST_TYPE` is provided and is valid, before building the docker image inside `scripts/run_tests_with_docker.sh`
- I have updated the document in `docs/BUILD_AND_TEST.md`

@intelsdi-x/snap-maintainers
