### PR TITLE
Add snap-plugin-collector-ping to catalog

### DIFF
--- a/docs/PLUGIN_CATALOG.md
+++ b/docs/PLUGIN_CATALOG.md
@@ -57,6 +57,7 @@ This is the master catalog of plugins for snap. The plugins in this list may be 
 | Name  | Type  | Description | Link |
 | :---- | :---- | :---------- | :--- |
 | CloudWatch | Publisher | Publishes snap metrics to AWS CloudWatch | [snap-plugin-publisher-cloudwatch](https://github.com/Ticketmaster/snap-plugin-publisher-cloudwatch) |
+| Ping | Collector | Collects Ping latency measurements | [snap-plugin-collector-ping](https://github.com/raintank/snap-plugin-collector-ping) |
 
 ## Committed plugins
 These plugins are in planned/active development. This list is useful if you want to reach out and contribute to the development.


### PR DESCRIPTION
Summary of changes:
- add snap-plugin-collector-ping to Plugin catalog

@intelsdi-x/snap-maintainers

