### PR TITLE
all signatures of cli commands changed to return error

### DIFF
--- a/cmd/snapctl/config.go
+++ b/cmd/snapctl/config.go
@@ -52,7 +52,7 @@ func (c *config) loadConfig(path string) error {
 	return nil
 }
 
-func getConfig(ctx *cli.Context) {
+func getConfig(ctx *cli.Context) error {
 	pDetails := filepath.SplitList(ctx.Args().First())
 	var ptyp string
 	var pname string
@@ -66,7 +66,7 @@ func getConfig(ctx *cli.Context) {
 		if err != nil {
 			fmt.Println("Can't convert version string to integer")
 			cli.ShowCommandHelp(ctx, ctx.Command.Name)
-			os.Exit(1)
+			return errCritical
 		}
 	} else {
 		ptyp = ctx.String("plugin-type")
@@ -77,24 +77,24 @@ func getConfig(ctx *cli.Context) {
 	if ptyp == "" {
 		fmt.Println("Must provide plugin type")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 	if pname == "" {
 		fmt.Println("Must provide plugin name")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 	if pver < 1 {
 		fmt.Println("Must provide plugin version")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	defer w.Flush()
 	r := pClient.GetPluginConfig(ptyp, pname, strconv.Itoa(pver))
 	if r.Err != nil {
 		fmt.Println("Error requesting info: ", r.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printFields(w, false, 0,
 		"NAME",
@@ -113,4 +113,6 @@ func getConfig(ctx *cli.Context) {
 			printFields(w, false, 0, k, t.Value, t.Type())
 		}
 	}
+
+	return nil
 }

--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -32,7 +32,7 @@ import (
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
 )
 
-func listMetrics(ctx *cli.Context) {
+func listMetrics(ctx *cli.Context) error {
 	ns := ctx.String("metric-namespace")
 	ver := ctx.Int("metric-version")
 	verbose := ctx.Bool("verbose")
@@ -51,7 +51,7 @@ func listMetrics(ctx *cli.Context) {
 	mts := pClient.FetchMetrics(ns, ver)
 	if mts.Err != nil {
 		fmt.Printf("Error getting metrics: %v\n", mts.Err)
-		os.Exit(1)
+		return errCritical
 	}
 
 	/*
@@ -74,7 +74,7 @@ func listMetrics(ctx *cli.Context) {
 			printFields(w, false, 0, namespace, mt.Version, mt.Unit, mt.Description)
 		}
 		w.Flush()
-		return
+		return nil
 	}
 	metsByVer := make(map[string][]string)
 	for _, mt := range mts.Catalog {
@@ -92,22 +92,22 @@ func listMetrics(ctx *cli.Context) {
 		printFields(w, false, 0, ns, strings.Join(metsByVer[ns], ","))
 	}
 	w.Flush()
-	return
+	return nil
 }
 
-func getMetric(ctx *cli.Context) {
+func getMetric(ctx *cli.Context) error {
 	if !ctx.IsSet("metric-namespace") {
 		fmt.Println("namespace is required")
 		fmt.Println("")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return
+		return errCritical
 	}
 	ns := ctx.String("metric-namespace")
 	ver := ctx.Int("metric-version")
 	metric := pClient.GetMetric(ns, ver)
 	if metric.Err != nil {
 		fmt.Println(metric.Err)
-		return
+		return errCritical
 	}
 
 	/*
@@ -155,6 +155,8 @@ func getMetric(ctx *cli.Context) {
 		printFields(w, true, 6, rule.Name, rule.Type, rule.Default, rule.Required, rule.Minimum, rule.Maximum)
 	}
 	w.Flush()
+
+	return nil
 }
 
 func getNamespace(mt *rbody.Metric) string {

--- a/cmd/snapctl/tribe.go
+++ b/cmd/snapctl/tribe.go
@@ -31,11 +31,11 @@ import (
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 )
 
-func listMembers(ctx *cli.Context) {
+func listMembers(ctx *cli.Context) error {
 	resp := pClient.ListMembers()
 	if resp.Err != nil {
 		fmt.Printf("Error getting members:\n%v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 
 	if len(resp.Members) > 0 {
@@ -50,19 +50,21 @@ func listMembers(ctx *cli.Context) {
 	} else {
 		fmt.Println("None")
 	}
+
+	return nil
 }
 
-func showMember(ctx *cli.Context) {
+func showMember(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.GetMember(ctx.Args().First())
 	if resp.Err != nil {
 		fmt.Printf("Error:\n%v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
@@ -84,7 +86,7 @@ func showMember(ctx *cli.Context) {
 	tags, err := json.Marshal(resp.Tags)
 	if err != nil {
 		fmt.Printf("Error:\n%v\n", err)
-		os.Exit(1)
+		return errCritical
 	}
 
 	values := []interface{}{resp.Name, resp.PluginAgreement, tasks.String()}
@@ -94,88 +96,94 @@ func showMember(ctx *cli.Context) {
 
 	printFields(w, false, 0, values...)
 
+	return nil
 }
 
-func listAgreements(ctx *cli.Context) {
+func listAgreements(ctx *cli.Context) error {
 	resp := pClient.ListAgreements()
 	if resp.Err != nil {
 		fmt.Printf("Error getting members:\n%v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printAgreements(resp.Agreements)
+	return nil
 }
 
-func createAgreement(ctx *cli.Context) {
+func createAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.AddAgreement(ctx.Args().First())
 	if resp.Err != nil {
 		fmt.Printf("Error creating agreement: %v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printAgreements(resp.Agreements)
+	return nil
 }
 
-func deleteAgreement(ctx *cli.Context) {
+func deleteAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.DeleteAgreement(ctx.Args().First())
 	if resp.Err != nil {
 		fmt.Printf("Error: %v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printAgreements(resp.Agreements)
+	return nil
 }
 
-func joinAgreement(ctx *cli.Context) {
+func joinAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.JoinAgreement(ctx.Args().First(), ctx.Args().Get(1))
 	if resp.Err != nil {
 		fmt.Printf("Error: %v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printAgreements(map[string]*agreement.Agreement{resp.Agreement.Name: resp.Agreement})
+	return nil
 }
 
-func leaveAgreement(ctx *cli.Context) {
+func leaveAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.LeaveAgreement(ctx.Args().First(), ctx.Args().Get(1))
 	if resp.Err != nil {
 		fmt.Printf("Error: %v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 	printAgreements(map[string]*agreement.Agreement{resp.Agreement.Name: resp.Agreement})
+	return nil
 }
 
-func agreementMembers(ctx *cli.Context) {
+func agreementMembers(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
 		fmt.Println("Incorrect usage:")
 		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		os.Exit(1)
+		return errCritical
 	}
 
 	resp := pClient.GetAgreement(ctx.Args().First())
 	if resp.Err != nil {
 		fmt.Printf("Error: %v\n", resp.Err)
-		os.Exit(1)
+		return errCritical
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
@@ -184,6 +192,8 @@ func agreementMembers(ctx *cli.Context) {
 	for _, v := range resp.Agreement.Members {
 		printFields(w, false, 0, v.Name)
 	}
+
+	return nil
 }
 
 func printAgreements(agreements map[string]*agreement.Agreement) {

--- a/snapd.go
+++ b/snapd.go
@@ -210,10 +210,12 @@ func main() {
 	app.Flags = append(app.Flags, tribe.Flags...)
 
 	app.Action = action
-	app.Run(os.Args)
+	if app.Run(os.Args) != nil {
+		os.Exit(1)
+	}
 }
 
-func action(ctx *cli.Context) {
+func action(ctx *cli.Context) error {
 	// get default configuration
 	cfg := getDefaultConfig()
 


### PR DESCRIPTION
All `ActionFunc` signatures has been updated to return `error` according to the latest changes in [cli](github.com/codegangsta/cli) package.
In this case, all the such functions return a predefined error which will be handled in `main()` function.
This commit eliminates the `DEPRECATED Action signature` error when executing a `snapctl` command.
The next essential step would be creating a more clear solution for raising and handling the errors.

@intelsdi-x/snap-maintainers

