### PR TITLE
Fixes #1031: sets address that the REST server binds to

### DIFF
--- a/snapd.go
+++ b/snapd.go
@@ -352,6 +352,11 @@ func action(ctx *cli.Context) error {
 		}
 		go monitorErrors(r.Err())
 		coreModules = append(coreModules, r)
+		if cfg.RestAPI.Port != 0 && !strings.Contains(cfg.RestAPI.Address, ":") {
+			r.SetAddress(fmt.Sprintf("%s:%d", cfg.RestAPI.Address, cfg.RestAPI.Port))
+		} else {
+			r.SetAddress(cfg.RestAPI.Address)
+		}
 		log.Info("REST API is enabled")
 	} else {
 		log.Info("REST API is disabled")


### PR DESCRIPTION
Sets the address the snapd REST server binds to.  

### Testing done 
Started snap providing
* the *default* address and port
*  port
*  address
* address and port

cc: @tjmcs 