### PR TITLE
Fixes #1031: Adds code to start the RESTful server on the correct address/port

### DIFF
--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -186,8 +186,9 @@ func New(cfg *Config) (*Server, error) {
 	cpath := cfg.RestCertificate
 	kpath := cfg.RestKey
 	s := &Server{
-		err:      make(chan error),
-		killChan: make(chan struct{}),
+		err:        make(chan error),
+		killChan:   make(chan struct{}),
+		addrString: cfg.Address,
 	}
 	if https {
 		var err error

--- a/snapd.go
+++ b/snapd.go
@@ -787,6 +787,13 @@ func applyCmdLineFlags(cfg *Config, ctx *cli.Context) {
 		cfg.RestAPI.Port = cmdLinePort
 	} else if cfgFilePortInAddr {
 		cfg.RestAPI.Port = cfgFilePort
+	} else {
+		// if get to here, then there is no port number in the input address
+		// (regardless of whether it came from the default configuration, configuration
+		// file, an environment variable, or a command-line flag); in that case we should
+		// set the address in the RestAPI configuration to be the current address and port
+		// (separated by a ':')
+		cfg.RestAPI.Address = fmt.Sprintf("%v:%v", cfg.RestAPI.Address, cfg.RestAPI.Port)
 	}
 }
 


### PR DESCRIPTION
Fixes #1031 (Unable to start REST API)

Summary of changes:
- Adds code to set the address in the RestAPI configuration correctly (so that it is always of the form `IP_ADDR:PORT`)
- Adds code to the `New()` method in the `mgmt/rest/server.go` file to ensure that the address from the RestAPI configuration is used when the RESTful server instance is created

Testing done:
- Started the server from the command line, setting the IP address and port using all of the various combinations and permutations of ways of doing that

@intelsdi-x/snap-maintainers 