### PR TITLE
Fix #1013: Standardisation for setting time when an entry is added to the cache

### DIFF
--- a/control/strategy/cache.go
+++ b/control/strategy/cache.go
@@ -108,7 +108,7 @@ func (c *cache) put(ns string, version int, m interface{}) {
 		}
 	case []core.Metric:
 		if _, ok := c.table[key]; ok {
-			c.table[key].time = time.Now()
+			c.table[key].time = chrono.Chrono.Now()
 			c.table[key].metrics = metric
 		} else {
 			c.table[key] = &cachecell{


### PR DESCRIPTION
Fixes #1013 

Standardisation of chrono.Chrono.Now() for setting time when an entry is added to the cache.

@intelsdi-x/snap-maintainers
