### PR TITLE
Fix two test files to run tests only when legacy test type is specified.

### DIFF
--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -1,4 +1,4 @@
-/// +build legacy
+// +build legacy
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,4 +1,4 @@
-/// +build legacy
+// +build legacy
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
Summary of changes:
- Removes `/` from first comment in two files that was causing the build flag for testing to not be seen by  `go test`. This was running `legacy` tests for any test type specified.

Testing done:
- Verified tests files are only run for appropriate test type.

@intelsdi-x/snap-maintainers

