### PR TITLE
Refactor plugin execution to capture logs

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -79,7 +79,7 @@ type availablePlugin struct {
 
 // newAvailablePlugin returns an availablePlugin with information from a
 // plugin.Response
-func newAvailablePlugin(resp *plugin.Response, emitter gomit.Emitter, ep executablePlugin) (*availablePlugin, error) {
+func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executablePlugin) (*availablePlugin, error) {
 	if resp.Type != plugin.CollectorPluginType && resp.Type != plugin.ProcessorPluginType && resp.Type != plugin.PublisherPluginType {
 		return nil, strategy.ErrBadType
 	}

--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -36,7 +36,7 @@ func TestAvailablePlugin(t *testing.T) {
 		Convey("returns an availablePlugin", func() {
 			ln, _ := net.Listen("tcp", ":4000")
 			defer ln.Close()
-			resp := &plugin.Response{
+			resp := plugin.Response{
 				Meta: plugin.PluginMeta{
 					Name:    "testPlugin",
 					Version: 1,
@@ -104,7 +104,7 @@ func TestAvailablePlugins(t *testing.T) {
 		})
 	})
 	Convey("it returns an error if client cannot be created", t, func() {
-		resp := &plugin.Response{
+		resp := plugin.Response{
 			Meta: plugin.PluginMeta{
 				Name:    "test",
 				Version: 1,

--- a/control/control.go
+++ b/control/control.go
@@ -71,13 +71,10 @@ var (
 	ErrControllerNotStarted = errors.New("Must start Controller before use")
 )
 
-type executablePlugins []plugin.ExecutablePlugin
-
 type pluginControl struct {
 	// TODO, going to need coordination on changing of these
-	RunningPlugins executablePlugins
-	Started        bool
-	Config         *Config
+	Started bool
+	Config  *Config
 
 	autodiscoverPaths []string
 	eventManager      *gomit.EventController
@@ -361,9 +358,9 @@ func (p *pluginControl) Stop() {
 	}
 
 	// stop running plugins
-	for _, rp := range p.RunningPlugins {
+	for _, rp := range p.pluginRunner.AvailablePlugins().all() {
 		controlLogger.Debug("Stopping running plugin")
-		rp.Kill()
+		rp.Stop("daemon exiting")
 	}
 
 	// unload plugins

--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -22,89 +22,39 @@ package plugin
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
-	"log"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
+	"path"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	log "github.com/Sirupsen/logrus"
 )
 
-var (
-	execLogger = logrus.WithField("_module", "control-plugin-execution")
-)
+var execLogger = log.WithField("_module", "plugin-exec")
 
-const (
-	// enums for different waiting states
-	pluginKilled      waitSignal = iota // plugin was killed
-	pluginTimeout                       // plugin timed out
-	pluginResponseOk                    // plugin response received (valid)
-	pluginResponseBad                   // plugin response received (invalid)
-)
-
-// A plugin that is executable as a forked process on *Linux.
 type ExecutablePlugin struct {
-	cmd    *exec.Cmd
+	cmd    command
 	stdout io.Reader
 	stderr io.Reader
-	args   Arg
 }
 
-// A interface representing an executable plugin.
-type pluginExecutor interface {
+// An interface for the interactions ExecutablePlugin has with an exec.Cmd
+// This way, the underlying Cmd can be mocked.
+type command interface {
+	Start()
 	Kill() error
-	WaitForExit() error
-	ResponseReader() io.Reader
-	ErrorResponseReader() io.Reader
+	Path() string
 }
 
-type waitSignal int
-
-type waitSignalValue struct {
-	Signal   waitSignal
-	Response *Response
-	Error    *error
+// The implementation of command used here.
+type commandWrapper struct {
+	cmd *exec.Cmd
 }
 
-// Starts the plugin and returns error if one occurred. This is non blocking.
-func (e *ExecutablePlugin) Start() error {
-	err := e.cmd.Start()
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"_module":  "control-executableplugin",
-			"_block":   "start",
-			"cmd path": e.cmd.Path,
-			"cmd args": e.cmd.Args,
-			"error":    err.Error(),
-		}).Error("error in starting executable plugin")
-	}
-	return err
-}
-
-// Kills the plugin and returns error if one occurred. This is blocking.
-func (e *ExecutablePlugin) Kill() error {
-	execLogger.WithField("path", e.cmd.Path).Debug("Hard killing plugin")
-	return e.cmd.Process.Kill()
-}
-
-// Waits for plugin to halt. If error is returned then plugin stopped with error. If not plugin stopped safely.
-func (e *ExecutablePlugin) WaitForExit() error {
-	return e.cmd.Wait()
-}
-
-// The STDOUT pipe for the plugin as io.Reader. Use to read from plugin process STDOUT.
-func (e *ExecutablePlugin) ResponseReader() io.Reader {
-	return e.stdout
-}
-
-// The STDERR pipe for the plugin as a io.reader
-func (e *ExecutablePlugin) ErrorResponseReader() io.Reader {
-	return e.stderr
-}
+func (cw *commandWrapper) Path() string { return cw.cmd.Path }
+func (cw *commandWrapper) Kill() error  { return cw.cmd.Process.Kill() }
+func (cw *commandWrapper) Start()       { cw.cmd.Start() }
 
 // Initialize a new ExecutablePlugin from path to executable and daemon mode (true or false)
 func NewExecutablePlugin(a Arg, path string) (*ExecutablePlugin, error) {
@@ -112,11 +62,10 @@ func NewExecutablePlugin(a Arg, path string) (*ExecutablePlugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Init the cmd
-	cmd := new(exec.Cmd)
-	cmd.Path = path
-	cmd.Args = []string{path, string(jsonArgs)}
-	// Link the stdout for response reading
+	cmd := &exec.Cmd{
+		Path: path,
+		Args: []string{path, string(jsonArgs)},
+	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -125,222 +74,71 @@ func NewExecutablePlugin(a Arg, path string) (*ExecutablePlugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Init the ExecutablePlugin and return
-	ePlugin := new(ExecutablePlugin)
-	ePlugin.cmd = cmd
-	ePlugin.stdout = stdout
-	ePlugin.args = a
-	ePlugin.stderr = stderr
-
-	return ePlugin, nil
+	return &ExecutablePlugin{
+		cmd:    &commandWrapper{cmd},
+		stdout: stdout,
+		stderr: stderr,
+	}, nil
 }
 
-// Waits for a plugin response from a started plugin
-func (e *ExecutablePlugin) WaitForResponse(timeout time.Duration) (*Response, error) {
-	r, err := waitHandling(e, timeout, e.args.PluginLogPath)
-	return r, err
-}
+// Run executes the plugin and waits for a response, or times out.
+func (e *ExecutablePlugin) Run(timeout time.Duration) (Response, error) {
+	var (
+		respReceived bool
+		resp         Response
+		err          error
+	)
 
-// Private method which handles behavior for wait for response for daemon and non-daemon modes.
-func waitHandling(p pluginExecutor, timeout time.Duration, logpath string) (*Response, error) {
-	log := execLogger.WithField("_block", "waitHandling")
+	doneChan := make(chan struct{})
+	stdOutScanner := bufio.NewScanner(e.stdout)
 
-	/*
-		Bit of complex behavior so some notes:
-			A. We need to wait for three scenarios depending on the daemon setting
-					1)	plugin is killed (like a safe exit in non-daemon)
-						causing WaitForExit to fire
-					2) 	plugin timeout fires calling Kill() and causing
-						WaitForExit to fire
-					3)	A response is returned before either 1 or 2 occur
-
-				notes:
-					*	In daemon mode (daemon == true) we want to wait until (1) or
-						(2 then 1) or (3) occurs and stop waiting right after.
-					*	In non-daemon mode (daemon == false) we want to return on (1)
-						or (2 then 1) regardless of whether (3) occurs before or after.
-
-			B. We will start three go routines to handle
-					1)	waiting for timeout, on timeout we signal timeout and then
-						kill plugin
-					2)	wait for exit, also known as wait for kill, on kill we fire
-						proper code to waitChannel
-					3)	wait for response, on response we fire proper code to waitChannel
-
-			C. The wait behavior loops collecting
-					1)	timeout signal, this is used to mark exit by timeout
-					2)	killed signal, signal the plugin has stopped - this exits
-						the loop for all scenarios
-					3)	response received, signal the plugin has responded - this exits
-						the loop if daemon == true, otherwise waits for (2)
-					4)	response received but corrupt
-	*/
-
-	// wait channel
-	waitChannel := make(chan waitSignalValue, 3)
-
-	// send timeout signal to our channel on timeout
-	log.Debug("timeout chan start")
-	go waitForPluginTimeout(timeout, p, waitChannel)
-
-	// send response received signal to our channel on response
-	log.Debug("response chan start")
-	go waitForResponseFromPlugin(p.ResponseReader(), waitChannel, logpath)
-
-	// log stderr from the plugin
-	go logStdErr(p.ErrorResponseReader(), logpath)
-
-	// send killed plugin signal to our channel on kill
-	log.Debug("kill chan start")
-	go waitForKilledPlugin(p, waitChannel)
-
-	// flag to indicate a timeout occurred
-	var timeoutFlag bool
-	// error value indicating a bad response was found
-	var errResponse *error
-	// var holding a good response (or nil if none was returned)
-	var response *Response
-	// Loop to wait for signals and return
-	for {
-		w := <-waitChannel
-		switch w.Signal {
-		case pluginTimeout: // plugin timeout signal received
-			log.Debug("plugin timeout signal received")
-			// If timeout received after response we are ok with it and
-			// don't need to flip the timeout flag.
-			if response == nil {
-				log.Debug("timeout flag set")
-				// We got a timeout without getting a response
-				// set the flag
-				timeoutFlag = true
-				// Kill the plugin.
-				p.Kill()
-				break
-			}
-			log.Debug("timeout flag ignored because of response")
-
-		case pluginKilled: // plugin killed signal received
-			log.Error("plugin kill signal received")
-			// We check a few scenarios and return based on how things worked out to this point
-			// 1) If a bad response was received we return signalling this with an error (fail)
-			if errResponse != nil {
-				log.Error("returning with error (bad response)")
-				return nil, *errResponse
-			}
-			// 2) If a timeout occurred we return that as error (fail)
-			if timeoutFlag {
-				log.Error("returning with error (timeout)")
-				return nil, errors.New("timeout waiting for response")
-			}
-			// 3) If a good response was returned we return that with no error (success)
-			if response != nil {
-				log.Error("returning with response (after wait for kill)")
-				return response, nil
-			}
-			// 4) otherwise we return no response and an error that no response was received (fail)
-			log.Error("returning with error (killed without response)")
-			// The kill could have been without error so we check if ExitError was returned and return
-			// our own if not.
-			if *w.Error != nil {
-				return nil, *w.Error
+	// Start the command and begin reading its output.
+	e.cmd.Start()
+	e.captureStderr()
+	go func() {
+		for stdOutScanner.Scan() {
+			// The first chunk from the scanner is the plugin's response to the
+			// handshake.  Once we've received that, we can begin to forward
+			// logs on to snapd's log.
+			if !respReceived {
+				respBytes := stdOutScanner.Bytes()
+				err = json.Unmarshal(respBytes, &resp)
+				respReceived = true
+				close(doneChan)
 			} else {
-				return nil, errors.New("plugin died without sending response")
+				execLogger.Debug(fmt.Sprintf("%s plugin: %s",
+					path.Base(e.cmd.Path()), stdOutScanner.Text()))
 			}
-
-		case pluginResponseOk: // plugin response (valid) signal received
-			log.Debug("plugin response (ok) received")
-			// If in daemon mode we can return now (succes) since the plugin will continue to run
-			// if not we let the loop continue (to wait for kill)
-			response = w.Response
-			return response, nil
-
-		case pluginResponseBad: // plugin response (invalid) signal received
-			log.Error("plugin response (bad) received")
-			// A bad response is end of game in all scerarios and indictive of an unhealthy or unsupported plugin
-			// We save the response bad error var (for handling later on plugin kill)
-			errResponse = w.Error
 		}
+	}()
+
+	// Wait until:
+	//   a) We receive a signal that the plugin has responded
+	// OR
+	//   b) The timeout expires
+	select {
+	case <-doneChan:
+	case <-time.After(timeout):
+		// We timed out waiting for the plugin's response.  Set err.
+		err = fmt.Errorf("timed out waiting for plugin %s", path.Base(e.cmd.Path()))
 	}
+	if err != nil {
+		// Kill the plugin if we failed to load it.
+		e.Kill()
+	}
+	return resp, err
 }
 
-func waitForPluginTimeout(timeout time.Duration, p pluginExecutor, waitChannel chan waitSignalValue) {
-	// sleep for timeout duration
-	time.Sleep(timeout)
-	// Check if waitChannel is closed. If it is we exit now.
-	// Send out timeout signal, waiting method will still wait for exit caused by p.Kill
-	// Because this channel is shared this ensures that the resulting kill signals the channel after
-	// the response has already queued across it.
-	waitChannel <- waitSignalValue{Signal: pluginTimeout}
+func (e *ExecutablePlugin) Kill() error {
+	return e.cmd.Kill()
 }
 
-func waitForResponseFromPlugin(r io.Reader, waitChannel chan waitSignalValue, logpath string) {
-	lp := strings.TrimSuffix(logpath, filepath.Ext(logpath))
-	lf, _ := os.OpenFile(lp+".stdout", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-	defer lf.Close()
-	logger := log.New(lf, "", log.Ldate|log.Ltime)
-	processedResponse := false
-	scanner := bufio.NewScanner(r)
-	resp := new(Response)
-	// scan until we get a response or reader is closed
-OK:
-	for scanner.Scan() {
-		if !processedResponse {
-			// Get bytes
-			b := scanner.Bytes()
-			// attempt to unmarshall into struct
-			err := json.Unmarshal(b, resp)
-			if err != nil {
-				log.Println("JSON error in response: " + err.Error())
-				log.Printf("response: \"%s\"\n", string(b))
-				e := errors.New("JSONError - " + err.Error())
-				// send plugin response received but bad
-				waitChannel <- waitSignalValue{Signal: pluginResponseBad, Error: &e}
-				// exit function
-				return
-			}
-			// send plugin response received (valid)
-			waitChannel <- waitSignalValue{Signal: pluginResponseOk, Response: resp}
-			processedResponse = true
-		} else {
-			logger.Println(scanner.Text())
+func (e *ExecutablePlugin) captureStderr() {
+	stdErrScanner := bufio.NewScanner(e.stderr)
+	go func() {
+		for stdErrScanner.Scan() {
+			execLogger.Debug(fmt.Sprintf("%s plugin stderr: %s",
+				path.Base(e.cmd.Path()), stdErrScanner.Text()))
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		if err == bufio.ErrTooLong {
-			reader := bufio.NewReader(r)
-			logger.Println(reader.ReadLine())
-			goto OK
-		}
-		logger.Println(err)
-	}
-}
-
-func logStdErr(r io.Reader, logpath string) {
-	lp := strings.TrimSuffix(logpath, filepath.Ext(logpath))
-	lf, _ := os.OpenFile(lp+".stderr", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-	defer lf.Close()
-	logger := log.New(lf, "", log.Ldate|log.Ltime)
-	scanner := bufio.NewScanner(r)
-OK:
-	for scanner.Scan() {
-		logger.Println(scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		if err == bufio.ErrTooLong {
-			reader := bufio.NewReader(r)
-			logger.Println(reader.ReadLine())
-			goto OK
-		}
-		logger.Println(err)
-	}
-}
-
-func waitForKilledPlugin(p pluginExecutor, waitChannel chan waitSignalValue) {
-	// simply wait for this to return (blocking method)
-	// TODO, refactor not to block. In daemon mode this would hang for the life of process.
-	// ideally this should check if running or waitChannel closed and then exit on either.
-	e := p.WaitForExit()
-	time.Sleep(time.Millisecond * 100)
-	// send signal
-	waitChannel <- waitSignalValue{Signal: pluginKilled, Error: &e}
+	}()
 }

--- a/control/plugin/execution_test.go
+++ b/control/plugin/execution_test.go
@@ -1,4 +1,4 @@
-// +build legacy
+// +build small
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -22,206 +22,58 @@ limitations under the License.
 package plugin
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
 	"io"
-	"os"
-	"path"
-	"time"
-
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var (
-	PluginName = "snap-collector-mock2"
-	SnapPath   = os.Getenv("SNAP_PATH")
-	PluginPath = path.Join(SnapPath, "plugin", PluginName)
-)
+type mockCmd struct{}
 
-type MockController struct {
-}
+func (mc *mockCmd) Path() string { return "" }
+func (mc *mockCmd) Kill() error  { return nil }
+func (mc *mockCmd) Start()       {}
 
-func (p *MockController) GenerateArgs() Arg {
-	a := Arg{
-		PluginLogPath: "/tmp/plugin.log",
-	}
-	return a
-}
-
-// Mock Executor used to test
-type MockPluginExecutor struct {
-	Killed          bool
-	Response        string
-	WaitTime        time.Duration
-	WaitError       error
-	WaitForResponse func(time.Duration) (Response, error)
-}
-
-// Mock
-func (m *MockPluginExecutor) WaitForExit() error {
-	t := time.Now()
-
-	// Loop until wait time expired
-	for time.Now().Sub(t) < m.WaitTime {
-		// Return if Killed while waiting
-		if m.Killed {
-			return m.WaitError
+func setupMockExec(resp []byte, timeout bool) *ExecutablePlugin {
+	stdout, stdoutw := io.Pipe()
+	stderr, _ := io.Pipe()
+	go func() {
+		if timeout {
+			time.Sleep(time.Second)
 		}
+		stdoutw.Write(resp)
+		stdoutw.Close()
+	}()
+	return &ExecutablePlugin{
+		cmd:    &mockCmd{},
+		stdout: stdout,
+		stderr: stderr,
 	}
-	return m.WaitError
 }
 
-// Mock
-func (m *MockPluginExecutor) Kill() error {
-	m.Killed = true
-	return nil
-}
-
-// Mock
-func (m *MockPluginExecutor) ResponseReader() io.Reader {
-	readbuffer := bytes.NewBuffer([]byte(m.Response))
-	reader := bufio.NewReader(readbuffer)
-	return reader
-}
-
-func (m *MockPluginExecutor) ErrorResponseReader() io.Reader {
-	readbuffer := bytes.NewBuffer([]byte(m.Response))
-	reader := bufio.NewReader(readbuffer)
-	return reader
-}
-
-func TestNewExecutablePlugin(t *testing.T) {
-	Convey("pluginControl.WaitForResponse", t, func() {
-		c := new(MockController)
-
-		ex, err := NewExecutablePlugin(c.GenerateArgs(), "/foo/bar")
-
-		Convey("returns ExecutablePlugin", func() {
-			So(ex, ShouldNotBeNil)
-		})
-
-		Convey("does not return error", func() {
-			So(err, ShouldBeNil)
-		})
-
+func TestExecutablePlugin(t *testing.T) {
+	Convey("NewExecutablePlugin returns a pointer to the correct type", t, func() {
+		e, err := NewExecutablePlugin(Arg{}, "")
+		So(err, ShouldBeNil)
+		So(e, ShouldHaveSameTypeAs, &ExecutablePlugin{})
 	})
-
-}
-
-func TestWaitForPluginResponse(t *testing.T) {
-	Convey(".waitHandling", t, func() {
-
-		Convey("called with PluginExecutor that returns a valid response", func() {
-			mockExecutor := new(MockPluginExecutor)
-			mockExecutor.Response = "{}"
-			mockExecutor.WaitTime = time.Millisecond * 1
-			Convey("daemon mode off", func() {
-				resp, err := waitHandling(mockExecutor, time.Second*3, "/tmp/some.log")
-
-				So(mockExecutor.Killed, ShouldEqual, false)
-				So(resp, ShouldNotBeNil)
-				So(err, ShouldBeNil)
-			})
-			Convey("daemon mode on", func() {
-				resp, err := waitHandling(mockExecutor, time.Second*3, "/tmp/some.log")
-
-				So(mockExecutor.Killed, ShouldEqual, false)
-				So(resp, ShouldNotBeNil)
-				So(err, ShouldBeNil)
-			})
+	Convey("Run()", t, func() {
+		Convey("returns a valid response when a valid response is given", func() {
+			e := setupMockExec([]byte(`{"Token": "a token"}`), false)
+			resp, err := e.Run(time.Second * 1)
+			So(err, ShouldBeNil)
+			So(resp.Token, ShouldEqual, "a token")
 		})
-
-		Convey("called with PluginExecutor that returns an invalid response", func() {
-			mockExecutor := new(MockPluginExecutor)
-			mockExecutor.Response = "junk"
-			mockExecutor.WaitTime = time.Millisecond * 1000
-
-			Convey("daemon mode off", func() {
-				resp, err := waitHandling(mockExecutor, time.Millisecond*100, "/tmp/some.log")
-				So(mockExecutor.Killed, ShouldEqual, true)
-				So(resp, ShouldBeNil)
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldStartWith, "JSONError")
-			})
-			Convey("daemon mode on", func() {
-				resp, err := waitHandling(mockExecutor, time.Millisecond*100, "/tmp/some.log")
-				So(mockExecutor.Killed, ShouldEqual, true)
-				So(resp, ShouldBeNil)
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldStartWith, "JSONError")
-			})
-		})
-
-		Convey("called with PluginExecutor that exits immediately without returning a response", func() {
-			mockExecutor := new(MockPluginExecutor)
-			mockExecutor.WaitTime = time.Millisecond * 100
-			mockExecutor.WaitError = errors.New("Exit 127")
-			resp, err := waitHandling(mockExecutor, time.Millisecond*500, "/tmp/some.log")
-
-			So(mockExecutor.Killed, ShouldEqual, false)
-			So(resp, ShouldBeNil)
+		Convey("returns an error if an invalid response is given", func() {
+			e := setupMockExec([]byte(`this is bad`), false)
+			_, err := e.Run(time.Second * 1)
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "Exit 127")
 		})
-
-		Convey("called with PluginExecutor that will run longer than timeout without responding", func() {
-			mockExecutor := new(MockPluginExecutor)
-			mockExecutor.WaitTime = time.Second * 120
-			resp, err := waitHandling(mockExecutor, time.Millisecond*100, "/tmp/some.log")
-
-			So(mockExecutor.Killed, ShouldEqual, true)
-			So(resp, ShouldBeNil)
+		Convey("returns an error if the timeout expires", func() {
+			e := setupMockExec([]byte(`{"Token": "a token"}`), true)
+			_, err := e.Run(time.Millisecond * 100)
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "timeout waiting for response")
 		})
-
-		// These tests don't mock and directly use mock collector plugin
-		// They require snap path being set and a recent build of the plugin
-		// WIP
-		if PluginPath != "" {
-			Convey("mock", func() {
-				m := new(MockController)
-				a := m.GenerateArgs()
-				a.PluginLogPath = "/tmp/snap-mock.log"
-				ex, err := NewExecutablePlugin(a, PluginPath)
-				if err != nil {
-					panic(err)
-				}
-
-				ex.Start()
-				r, e := ex.WaitForResponse(time.Second * 5)
-				if r != nil {
-					println("ListenAddress: " + r.ListenAddress)
-				}
-				if e != nil {
-					println(e.Error())
-				}
-
-			})
-
-			Convey("mock2", func() {
-				m := new(MockController)
-				a := m.GenerateArgs()
-				a.PluginLogPath = "/tmp/snap-mock.log"
-				ex, err := NewExecutablePlugin(a, PluginPath)
-				if err != nil {
-					panic(err)
-				}
-
-				ex.Start()
-				r, e := ex.WaitForResponse(time.Second * 5)
-				if r != nil {
-					println("ListenAddress: " + r.ListenAddress)
-				}
-				if e != nil {
-					println(e.Error())
-				}
-
-			})
-		}
-
 	})
 }

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -286,7 +286,6 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 		"path":   filepath.Base(lPlugin.Details.Exec),
 	}).Info("plugin load called")
 	ePlugin, err := plugin.NewExecutablePlugin(p.GenerateArgs(lPlugin.Details.Exec), path.Join(lPlugin.Details.ExecPath, lPlugin.Details.Exec))
-
 	if err != nil {
 		pmLogger.WithFields(log.Fields{
 			"_block": "load-plugin",
@@ -295,23 +294,12 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 		return nil, serror.New(err)
 	}
 
-	err = ePlugin.Start()
+	resp, err := ePlugin.Run(time.Second * 3)
 	if err != nil {
 		pmLogger.WithFields(log.Fields{
 			"_block": "load-plugin",
 			"error":  err.Error(),
-		}).Error("load plugin error while starting plugin")
-		return nil, serror.New(err)
-	}
-
-	var resp *plugin.Response
-	resp, err = ePlugin.WaitForResponse(time.Second * 3)
-
-	if err != nil {
-		pmLogger.WithFields(log.Fields{
-			"_block": "load-plugin",
-			"error":  err.Error(),
-		}).Error("load plugin error while waiting for response from plugin")
+		}).Error("load plugin error when starting plugin")
 		return nil, serror.New(err)
 	}
 

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -73,16 +73,16 @@ func (m *MockExecutablePlugin) Wait() error {
 	return nil
 }
 
-func (m *MockExecutablePlugin) WaitForResponse(t time.Duration) (*plugin.Response, error) {
+func (m *MockExecutablePlugin) Run(t time.Duration) (plugin.Response, error) {
 	if m.Timeout {
-		return nil, errors.New("timeout")
+		return plugin.Response{}, errors.New("timeout")
 	}
 
 	if m.NilResponse {
-		return nil, nil
+		return plugin.Response{}, nil
 	}
 
-	resp := new(plugin.Response)
+	var resp plugin.Response
 	resp.Type = plugin.CollectorPluginType
 	if m.PluginFailure {
 		resp.State = plugin.PluginFailure
@@ -477,7 +477,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						So(ap.failedHealthChecks, ShouldEqual, 3)
 					})
 
-					Convey("should return error for WaitForResponse error", func() {
+					Convey("should return error for Run error", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						exPlugin := new(MockExecutablePlugin)
@@ -485,42 +485,9 @@ func TestRunnerPluginRunning(t *testing.T) {
 						ap, e := r.startPlugin(exPlugin)
 
 						So(ap, ShouldBeNil)
-						So(e, ShouldResemble, errors.New("error while waiting for response: timeout"))
-					})
-
-					Convey("should return error for nil availablePlugin", func() {
-						r := newRunner()
-						exPlugin := new(MockExecutablePlugin)
-						exPlugin.NilResponse = true // set to not response
-						ap, e := r.startPlugin(exPlugin)
-
-						So(e, ShouldResemble, errors.New("no response object returned from plugin"))
-						So(ap, ShouldBeNil)
-					})
-
-					Convey("should return error if plugin fails while starting", func() {
-						r := newRunner()
-						exPlugin := &MockExecutablePlugin{
-							StartError: true,
-						}
-						ap, e := r.startPlugin(exPlugin)
-
-						So(e, ShouldResemble, errors.New("error while starting plugin: start error"))
-						So(ap, ShouldBeNil)
-					})
-
-					Convey("should return error if plugin fails to start", func() {
-						r := newRunner()
-						exPlugin := &MockExecutablePlugin{
-							PluginFailure: true,
-						}
-						ap, e := r.startPlugin(exPlugin)
-
-						So(e, ShouldResemble, errors.New("plugin could not start error: plugin start error"))
-						So(ap, ShouldBeNil)
+						So(e, ShouldResemble, errors.New("error starting plugin: timeout"))
 					})
 				}
-
 			})
 
 			Convey("stopPlugin", func() {


### PR DESCRIPTION
Summary of changes:
- Simplifies plugin execution in preparation for untangling `control`'s needs in `control/plugin` and a client libraries needs in that package.
- Add log capturing from plugins to be carried through to `snapd`'s logs

Testing done:
- Local: plugins load, timeouts working, &c
- Tests rewrites forthcoming - I'd like to get @intelsdi-x/snap-maintainers' opinions on this approach. (e.g. -- probably not `INFO` level for plugin logs?  Debug? configurable?)

Tangentially related to: https://github.com/intelsdi-x/snap/issues/957