### PR TITLE
Altered plugin test files and helper.go

### DIFF
--- a/plugin/collector/snap-collector-mock1/main_test.go
+++ b/plugin/collector/snap-collector-mock1/main_test.go
@@ -22,7 +22,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -44,11 +43,12 @@ func TestMockPluginLoad(t *testing.T) {
 	// These tests only work if SNAP_PATH is known.
 	// It is the responsibility of the testing framework to
 	// build the plugins first into the build dir.
-	if SnapPath != "" {
-		// Helper plugin trigger build if possible for this plugin
-		helper.BuildPlugin(PluginType, PluginName)
-		//
-		Convey("ensure plugin loads and responds", t, func() {
+
+	Convey("make sure plugin has been built", t, func() {
+		err := helper.CheckPluginBuilt(SnapPath, PluginName)
+		So(err, ShouldBeNil)
+
+		Convey("ensure plugin loads and responds", func() {
 			c := control.New(control.GetDefaultConfig())
 			c.Start()
 			rp, _ := core.NewRequestedPlugin(PluginPath)
@@ -56,7 +56,6 @@ func TestMockPluginLoad(t *testing.T) {
 
 			So(err, ShouldBeNil)
 		})
-	} else {
-		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
-	}
+
+	})
 }

--- a/plugin/collector/snap-collector-mock2/main_test.go
+++ b/plugin/collector/snap-collector-mock2/main_test.go
@@ -22,7 +22,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -44,11 +43,11 @@ func TestMockPluginLoad(t *testing.T) {
 	// These tests only work if SNAP_PATH is known.
 	// It is the responsibility of the testing framework to
 	// build the plugins first into the build dir.
-	if SnapPath != "" {
-		// Helper plugin trigger build if possible for this plugin
-		helper.BuildPlugin(PluginType, PluginName)
-		//
-		Convey("ensure plugin loads and responds", t, func() {
+	Convey("make sure plugin has been built", t, func() {
+		err := helper.CheckPluginBuilt(SnapPath, PluginName)
+		So(err, ShouldBeNil)
+
+		Convey("ensure plugin loads and responds", func() {
 			c := control.New(control.GetDefaultConfig())
 			c.Start()
 			rp, _ := core.NewRequestedPlugin(PluginPath)
@@ -56,7 +55,6 @@ func TestMockPluginLoad(t *testing.T) {
 
 			So(err, ShouldBeNil)
 		})
-	} else {
-		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
-	}
+
+	})
 }

--- a/plugin/helper/helper.go
+++ b/plugin/helper/helper.go
@@ -21,31 +21,21 @@ limitations under the License.
 package helper
 
 import (
-	// "fmt"
+	"fmt"
 	"os"
-	"os/exec"
-	"path"
-	"strings"
 )
 
-var (
-	buildScript = "/scripts/build.sh"
-)
+//SNAP_PATH should be set to Snap's build directory
 
-// BuildPlugin attempts to make the plugins before each test.
-func BuildPlugin(pluginType, pluginName string) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
+//CheckPluginBuilt checks if PluginName has been built.
+func CheckPluginBuilt(SnapPath string, PluginName string) error {
+	if SnapPath == "" {
+		return fmt.Errorf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
 	}
-
-	bPath := strings.Replace(wd, path.Join("/", "plugin", pluginType, pluginName), buildScript, 1)
-	sPath := strings.Replace(wd, path.Join("/", "plugin", pluginType, pluginName), "", 1)
-
-	// fmt.Println(bPath, sPath, pluginType, pluginName)
-	c := exec.Command(bPath, sPath, pluginType, pluginName)
-
-	_, e := c.Output()
-	// fmt.Println(string(o))
-	return e
+	bPath := fmt.Sprintf("%s/plugin/%s", SnapPath, PluginName)
+	if _, err := os.Stat(bPath); os.IsNotExist(err) {
+		//the binary has not been built yet
+		return fmt.Errorf("Error: $SNAP_PATH/plugin/%s does not exist. Run make to build it.", PluginName)
+	}
+	return nil
 }

--- a/plugin/publisher/snap-publisher-file/main_test.go
+++ b/plugin/publisher/snap-publisher-file/main_test.go
@@ -22,7 +22,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -44,12 +43,12 @@ func TestFilePublisherLoad(t *testing.T) {
 	// These tests only work if SNAP_PATH is known.
 	// It is the responsibility of the testing framework to
 	// build the plugins first into the build dir.
-	if SnapPath != "" {
-		// Helper plugin trigger build if possible for this plugin
-		helper.BuildPlugin(PluginType, PluginName)
-		//
-		//TODO cannot test this locally. We need AMQP and integration tests.
-		SkipConvey("ensure plugin loads and responds", t, func() {
+
+	Convey("make sure plugin has been built", t, func() {
+		err := helper.CheckPluginBuilt(SnapPath, PluginName)
+		So(err, ShouldBeNil)
+
+		Convey("ensure plugin loads and responds", func() {
 			c := control.New(control.GetDefaultConfig())
 			c.Start()
 			rp, _ := core.NewRequestedPlugin(PluginPath)
@@ -57,7 +56,5 @@ func TestFilePublisherLoad(t *testing.T) {
 
 			So(err, ShouldBeNil)
 		})
-	} else {
-		fmt.Printf("SNAP_PATH not set. Cannot test %s plugin.\n", PluginName)
-	}
+	})
 }


### PR DESCRIPTION
Fixes #

Summary of changes:
- Got rid of BuildPlugin func in helper.go, replaced with CheckPluginBuilt
- ^because of that, plugin main_test.go no longer unnecessarily rebuilds plugins 
- instated check to main_test.go to check if plugin executables exist

Testing done:
- 

@intelsdi-x/snap-maintainers
