### PR TITLE
Fixes #1037: Adds medium tags to new test files and renames them

### DIFF
--- a/grpc/controlproxy/controlproxy_medium_test.go
+++ b/grpc/controlproxy/controlproxy_medium_test.go
@@ -1,3 +1,5 @@
+// +build medium
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/pkg/netutil/net_medium_test.go
+++ b/pkg/netutil/net_medium_test.go
@@ -1,3 +1,5 @@
+// +build medium
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/pkg/rpcutil/rpc_medium_test.go
+++ b/pkg/rpcutil/rpc_medium_test.go
@@ -1,3 +1,5 @@
+// +build medium
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 


### PR DESCRIPTION
Fixes #1037

Summary of changes:
- Adds `medium` tag to the test files identified in Issue #1037
- Renames those same files as `medium` tests

Testing done:
- Ran the tests manually, generating coverage tests for each test in each of the test files identified in Issue #1037

Note:  these files were classified as `medium` tests because the tests they contained (a) tested more than one underlying function and/or (b) made use of the network on the localhost during those same tests; as such, they should be classified as `medium` (rather than `small`) tests.

@intelsdi-x/snap-maintainers
