### PR TITLE
Updating documentation phrasing + plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# **snap** <sup><sub>_A powerful telemetry framework_</sub></sup>
+# **snap** <sup><sub>_the open telemetry framework_</sub></sup>
 
 [![Join the chat on Slack](https://intelsdi-x.herokuapp.com/badge.svg)](https://intelsdi-x.herokuapp.com/)
 [![Build Status](https://travis-ci.org/intelsdi-x/snap.svg?branch=master)](https://travis-ci.org/intelsdi-x/snap)
 [![Go Report Card](https://goreportcard.com/badge/intelsdi-x/snap)](https://goreportcard.com/report/intelsdi-x/snap)
 
-<img src="https://cloud.githubusercontent.com/assets/1744971/13930753/6f676b34-ef5d-11e5-97be-8503562cd5fe.png" width="50%">
+<img src="https://cloud.githubusercontent.com/assets/1744971/16677455/f1d4e9de-448a-11e6-9afb-c31dcc7e3274.png" width="50%">
 
 ----
 

--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -45,7 +45,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "snapctl"
 	app.Version = gitversion
-	app.Usage = "A powerful telemetry framework"
+	app.Usage = "The open telemetry framework"
 	app.Flags = []cli.Flag{flURL, flSecure, flAPIVer, flPassword, flConfig}
 	app.Commands = append(commands, tribeCommands...)
 	sort.Sort(ByCommand(app.Commands))

--- a/docs/PLUGIN_CATALOG.md
+++ b/docs/PLUGIN_CATALOG.md
@@ -25,6 +25,7 @@ This is the master catalog of plugins for snap. The plugins in this list may be 
 | Libvirt | Collector | Collects from libvirt | [snap-plugin-collector-libvirt](https://github.com/intelsdi-x/snap-plugin-collector-libvirt) | [Linux](https://s3-us-west-1.amazonaws.com/snap-plugins-linux-latest/snap-plugin-collector-libvirt)
 | Load | Collector | Collects plaform load metrics from Linux procfs | [snap-plugin-collector-load](https://github.com/intelsdi-x/snap-plugin-collector-load) | [Linux](https://s3-us-west-1.amazonaws.com/snap-plugins-linux-latest/snap-plugin-collector-load)
 | Meminfo | Collector | Collects memory related metrics from Linux procfs | [snap-plugin-collector-meminfo](https://github.com/intelsdi-x/snap-plugin-collector-meminfo) | [Linux](https://s3-us-west-1.amazonaws.com/snap-plugins-linux-latest/snap-plugin-collector-meminfo)
+| Mesos | Collector | Collects metrics from an Apache Mesos cluster | [snap-plugin-collector-mesos](https://github.com/intelsdi-x/snap-plugin-collector-mesos) | 
 | MySQL | Collector | Collects metrics from MySQL DB | [snap-plugin-collector-mysql](https://github.com/intelsdi-x/snap-plugin-collector-mysql) | [Linux](https://s3-us-west-1.amazonaws.com/snap-plugins-linux-latest/snap-plugin-publisher-mysql) &#124; [Darwin](https://s3-us-west-1.amazonaws.com/snap-plugins-darwin-latest/snap-plugin-publisher-mysql)
 | Neutron | Collector | Collect from OpenStack Neutron | [snap-plugin-collector-neutron](https://github.com/intelsdi-x/snap-plugin-collector-neutron) | [Linux](https://s3-us-west-1.amazonaws.com/snap-plugins-linux-latest/snap-plugin-collector-neutron)
 | NFS Client | Collector | Collect NFS client counters and RPC data | [snap-plugin-collector-nfsclient](https://github.com/intelsdi-x/snap-plugin-collector-nfsclient) |
@@ -79,8 +80,6 @@ This is a wish list of plugins for snap. If you see one here and want to start o
 - snap App Endpoint (needs event spec)
 - Intel NIC
 - Kubernetes Minion
-- Mesos Slave
-- Mesos Master
 - JVM (via JMX)
 
 #### Processor

--- a/snapd.go
+++ b/snapd.go
@@ -195,7 +195,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "snapd"
 	app.Version = gitversion
-	app.Usage = "A powerful telemetry framework"
+	app.Usage = "The open telemetry framework"
 	app.Flags = []cli.Flag{
 		flLogLevel,
 		flLogPath,


### PR DESCRIPTION
Fixes incongruence between phrasing and style + Adding a Collector 

Summary of changes:
- Adding Mesos Collector
- Correcting Snap tagline 
- Using the main Snappy image, full body, as the default on the repo

Testing done:
- Rendered as markdown to check text. Didn't check edits to files given that it's log text only.

@intelsdi-x/snap-maintainers