### PR TITLE
Fixes #1058: Adds code to ensure Snap restarts in response to a SIGHUP

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -1123,10 +1123,10 @@ func TestCollectDynamicMetrics(t *testing.T) {
 				pool.SelectAndKill("1", "unsubscription event")
 				So(pool.Count(), ShouldEqual, 0)
 				So(pool.SubscriptionCount(), ShouldEqual, 0)
-				c.Stop()
-				time.Sleep(100 * time.Millisecond)
 			})
 		})
+		c.Stop()
+		time.Sleep(100 * time.Millisecond)
 	})
 }
 

--- a/docs/SNAPD_CONFIGURATION.md
+++ b/docs/SNAPD_CONFIGURATION.md
@@ -216,6 +216,17 @@ The same configuration settings above can also be provided in a JSON formatted c
 }
 ```
 
+## Restarting snapd to pick up configuration changes
+If changes are made to the configuration file, `snapd` must be restarted to pick up those changes. Fortunately, this is a simple matter of sending a `SIGHUP` signal to the `snapd` process. For example, the following command will restart the `snapd` process on the local system:
+
+```bash
+$ kill -HUP `pidof snapd`
+```
+
+Note that in this example, we are using the `pidof` command to retrieve the process ID of the `snapd` process. If the `pidof` command is not available on your system you might have to use a `ps aux` command and pipe the output of that command to a `grep snapd` command in order to obtain the process ID of the `snapd` process. Once the `snapd` process receives that signal it will restart and pick up any changes that have been made to the configuration file that was originally used to Âstart the `snapd` process.
+
+Do keep in mind that this signal will trigger a **restart** of the `snapd` process. This means that any running tasks will be shut down and any loaded plugins will be unloaded. In reality, this means that when the `snapd` process restarts any plugins not in the `auto_discover_path` will need to be loaded manually once the `snapd` process restarts (and any tasks not in that same `auto_discover_path` will need to be restarted). However, any plugins in the `auto_discover_path` will be automatically reloaded and any tasks in that same `auto_discover_path` will be automatically restarted when the when the `snapd` process restarts in response to a `SIGHUP` signal.
+
 ## More information
 * [SNAPD.md](SNAPD.md)
 * [REST_API.md](REST_API.md)

--- a/mgmt/rest/snapTLS.go
+++ b/mgmt/rest/snapTLS.go
@@ -31,12 +31,12 @@ import (
 	"time"
 )
 
-type tls struct {
+type snapTLS struct {
 	cert, key string
 }
 
-func newtls(certPath, keyPath string) (*tls, error) {
-	t := &tls{}
+func newtls(certPath, keyPath string) (*snapTLS, error) {
+	t := &snapTLS{}
 	if certPath != "" && keyPath != "" {
 		cert, err := os.Open(certPath)
 		if err != nil {
@@ -78,7 +78,7 @@ func newtls(certPath, keyPath string) (*tls, error) {
 	return t, nil
 }
 
-func generateCert(t *tls) error {
+func generateCert(t *snapTLS) error {
 	// good for 1 year
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour * 24 * 365)


### PR DESCRIPTION
Fixes #1058

Summary of changes:
- Adds code to ensure that the gRPC server and RESTful server both shut down cleanly when their respective `Stop()` methods are called; previously these two servers only shut down because the Snap server exited in response to a SIGTERM, SIGINT, or SIGKILL (killing these threads)
- Adds code to ensure that any requests being processed by the gRPC and RESTful servers finish before their respective servers shut down (previously, these servers would shut down when the Snap server exited in response to the signals shown above, and the Snap server would not wait for any requests that were "in flight" to complete before exiting)
- Adds code to restart the Snap server in response to a SIGHUP (shutting down the Snap server and it's modules cleanly, then restarting the Snap server); the result will be that the Snap server can be forced to restart and pick up any changes that may have been made to it's global configuration file by sending a SIGHUP signal to the Snap process (eg. by running a `kill -HUP [PROC_ID]` where the `[PROC_ID]` value is the process ID of the Snap process).
- refactored the `mgmt/rest/tls.go` file, renaming it as `mgmt/rest/snapTLS.go` and renaming the `tls` struct it contained to use the name `snapTLS` instead; this helped us avoid shadowing of the `crypto/tls` library from the Go standard libraries with our `mgmt/rest/tls.go` file

Testing done:
- Manually started the Snap server as both an HTTP and HTTPS server (using an autogenerated certificate for the HTTPS server) where Snap's global configuration file was configured to set the Snap server log level to `INFO`
- verified that the server log level was set to `INFO` and that the server could be accessed in both of these scenarios using the `snapctl -u "[SNAP_URL]" plugin list` and `snapctl -u "[SNAP_URL]" --insecure plugin list` commands (respectively)
- modified the global configuration file being used so that it was configured to set the Snap server log level to `DEBUG`
- restarted the server using a `kill -HUP [PROC_ID]` command
- verified that the server log level was set to `DEBUG` and that the server could still be accessed in both of these scenarios using the `snapctl -u "[SNAP_URL]" plugin list` and `snapctl -u "[SNAP_URL]" --insecure plugin list` commands (respectively)

@intelsdi-x/snap-maintainers

