### PR TITLE
cli error handling updated for snapctl

### DIFF
--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -50,8 +50,7 @@ func listMetrics(ctx *cli.Context) error {
 	}
 	mts := pClient.FetchMetrics(ns, ver)
 	if mts.Err != nil {
-		fmt.Printf("Error getting metrics: %v\n", mts.Err)
-		return errCritical
+		return fmt.Errorf("Error getting metrics: %v\n", mts.Err)
 	}
 
 	/*
@@ -97,17 +96,13 @@ func listMetrics(ctx *cli.Context) error {
 
 func getMetric(ctx *cli.Context) error {
 	if !ctx.IsSet("metric-namespace") {
-		fmt.Println("namespace is required")
-		fmt.Println("")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("namespace is required\n\n", ctx)
 	}
 	ns := ctx.String("metric-namespace")
 	ver := ctx.Int("metric-version")
 	metric := pClient.GetMetric(ns, ver)
 	if metric.Err != nil {
-		fmt.Println(metric.Err)
-		return errCritical
+		return fmt.Errorf("%v", metric.Err)
 	}
 
 	/*

--- a/cmd/snapctl/plugin.go
+++ b/cmd/snapctl/plugin.go
@@ -35,27 +35,21 @@ func loadPlugin(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) != 1 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {
 		if !strings.Contains(pAsc, ".asc") {
-			fmt.Println("Must be a .asc file for the -a flag")
-			cli.ShowCommandHelp(ctx, ctx.Command.Name)
-			return errCritical
+			return newUsageError("Must be a .asc file for the -a flag", ctx)
 		}
 		paths = append(paths, pAsc)
 	}
 	r := pClient.LoadPlugin(paths)
 	if r.Err != nil {
 		if r.Err.Fields()["error"] != nil {
-			fmt.Printf("Error loading plugin:\n%v\n%v\n", r.Err.Error(), r.Err.Fields()["error"])
-		} else {
-			fmt.Printf("Error loading plugin:\n%v\n", r.Err.Error())
+			return fmt.Errorf("Error loading plugin:\n%v\n%v\n", r.Err.Error(), r.Err.Fields()["error"])
 		}
-		return errCritical
+		return fmt.Errorf("Error loading plugin:\n%v\n", r.Err.Error())
 	}
 	for _, p := range r.LoadedPlugins {
 		fmt.Println("Plugin loaded")
@@ -80,9 +74,7 @@ func unloadPlugin(ctx *cli.Context) error {
 		pName = pDetails[1]
 		pVer, err = strconv.Atoi(pDetails[2])
 		if err != nil {
-			fmt.Println("Can't convert version string to integer")
-			cli.ShowCommandHelp(ctx, ctx.Command.Name)
-			return errCritical
+			return newUsageError("Can't convert version string to integer", ctx)
 		}
 	} else {
 		pType = ctx.String("plugin-type")
@@ -90,25 +82,18 @@ func unloadPlugin(ctx *cli.Context) error {
 		pVer = ctx.Int("plugin-version")
 	}
 	if pType == "" {
-		fmt.Println("Must provide plugin type")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin type", ctx)
 	}
 	if pName == "" {
-		fmt.Println("Must provide plugin name")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pVer < 1 {
-		fmt.Println("Must provide plugin version")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin version", ctx)
 	}
 
 	r := pClient.UnloadPlugin(pType, pName, pVer)
 	if r.Err != nil {
-		fmt.Printf("Error unloading plugin:\n%v\n", r.Err.Error())
-		return errCritical
+		return fmt.Errorf("Error unloading plugin:\n%v\n", r.Err.Error())
 	}
 
 	fmt.Println("Plugin unloaded")
@@ -124,16 +109,12 @@ func swapPlugins(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {
 		if !strings.Contains(pAsc, ".asc") {
-			fmt.Println("Must be a .asc file for the -a flag")
-			cli.ShowCommandHelp(ctx, ctx.Command.Name)
-			return errCritical
+			return newUsageError("Must be a .asc file for the -a flag", ctx)
 		}
 		paths = append(paths, pAsc)
 	}
@@ -151,14 +132,10 @@ func swapPlugins(ctx *cli.Context) error {
 			pName = pDetails[1]
 			pVer, err = strconv.Atoi(pDetails[2])
 			if err != nil {
-				fmt.Println("Can't convert version string to integer")
-				cli.ShowCommandHelp(ctx, ctx.Command.Name)
-				return errCritical
+				return newUsageError("Can't convert version string to integer", ctx)
 			}
 		} else {
-			fmt.Println("Missing type, name, or version")
-			cli.ShowCommandHelp(ctx, ctx.Command.Name)
-			return errCritical
+			return newUsageError("Missing type, name, or version", ctx)
 		}
 	} else {
 		pType = ctx.String("plugin-type")
@@ -166,25 +143,18 @@ func swapPlugins(ctx *cli.Context) error {
 		pVer = ctx.Int("plugin-version")
 	}
 	if pType == "" {
-		fmt.Println("Must provide plugin type")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin type", ctx)
 	}
 	if pName == "" {
-		fmt.Println("Must provide plugin name")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pVer < 1 {
-		fmt.Println("Must provide plugin version")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Must provide plugin version", ctx)
 	}
 
 	r := pClient.SwapPlugin(paths, pType, pName, pVer)
 	if r.Err != nil {
-		fmt.Printf("Error swapping plugins:\n%v\n", r.Err.Error())
-		return errCritical
+		return fmt.Errorf("Error swapping plugins:\n%v\n", r.Err.Error())
 	}
 
 	fmt.Println("Plugin loaded")
@@ -205,8 +175,7 @@ func swapPlugins(ctx *cli.Context) error {
 func listPlugins(ctx *cli.Context) error {
 	plugins := pClient.GetPlugins(ctx.Bool("running"))
 	if plugins.Err != nil {
-		fmt.Printf("Error: %v\n", plugins.Err)
-		return errCritical
+		return fmt.Errorf("Error: %v\n", plugins.Err)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	if ctx.Bool("running") {

--- a/cmd/snapctl/tribe.go
+++ b/cmd/snapctl/tribe.go
@@ -34,8 +34,7 @@ import (
 func listMembers(ctx *cli.Context) error {
 	resp := pClient.ListMembers()
 	if resp.Err != nil {
-		fmt.Printf("Error getting members:\n%v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error getting members:\n%v\n", resp.Err)
 	}
 
 	if len(resp.Members) > 0 {
@@ -56,15 +55,12 @@ func listMembers(ctx *cli.Context) error {
 
 func showMember(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.GetMember(ctx.Args().First())
 	if resp.Err != nil {
-		fmt.Printf("Error:\n%v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error:\n%v\n", resp.Err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
@@ -85,8 +81,7 @@ func showMember(ctx *cli.Context) error {
 	}
 	tags, err := json.Marshal(resp.Tags)
 	if err != nil {
-		fmt.Printf("Error:\n%v\n", err)
-		return errCritical
+		return fmt.Errorf("Error:\n%v\n", err)
 	}
 
 	values := []interface{}{resp.Name, resp.PluginAgreement, tasks.String()}
@@ -102,8 +97,7 @@ func showMember(ctx *cli.Context) error {
 func listAgreements(ctx *cli.Context) error {
 	resp := pClient.ListAgreements()
 	if resp.Err != nil {
-		fmt.Printf("Error getting members:\n%v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error getting members:\n%v\n", resp.Err)
 	}
 	printAgreements(resp.Agreements)
 	return nil
@@ -111,15 +105,12 @@ func listAgreements(ctx *cli.Context) error {
 
 func createAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.AddAgreement(ctx.Args().First())
 	if resp.Err != nil {
-		fmt.Printf("Error creating agreement: %v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error creating agreement: %v\n", resp.Err)
 	}
 	printAgreements(resp.Agreements)
 	return nil
@@ -127,15 +118,12 @@ func createAgreement(ctx *cli.Context) error {
 
 func deleteAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.DeleteAgreement(ctx.Args().First())
 	if resp.Err != nil {
-		fmt.Printf("Error: %v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error: %v\n", resp.Err)
 	}
 	printAgreements(resp.Agreements)
 	return nil
@@ -143,15 +131,12 @@ func deleteAgreement(ctx *cli.Context) error {
 
 func joinAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.JoinAgreement(ctx.Args().First(), ctx.Args().Get(1))
 	if resp.Err != nil {
-		fmt.Printf("Error: %v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error: %v\n", resp.Err)
 	}
 	printAgreements(map[string]*agreement.Agreement{resp.Agreement.Name: resp.Agreement})
 	return nil
@@ -159,15 +144,12 @@ func joinAgreement(ctx *cli.Context) error {
 
 func leaveAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.LeaveAgreement(ctx.Args().First(), ctx.Args().Get(1))
 	if resp.Err != nil {
-		fmt.Printf("Error: %v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error: %v\n", resp.Err)
 	}
 	printAgreements(map[string]*agreement.Agreement{resp.Agreement.Name: resp.Agreement})
 	return nil
@@ -175,15 +157,12 @@ func leaveAgreement(ctx *cli.Context) error {
 
 func agreementMembers(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		fmt.Println("Incorrect usage:")
-		cli.ShowCommandHelp(ctx, ctx.Command.Name)
-		return errCritical
+		return newUsageError("Incorrect usage:", ctx)
 	}
 
 	resp := pClient.GetAgreement(ctx.Args().First())
 	if resp.Err != nil {
-		fmt.Printf("Error: %v\n", resp.Err)
-		return errCritical
+		return fmt.Errorf("Error: %v\n", resp.Err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)


### PR DESCRIPTION
Referenced to #1023, a `cli` error type added to `snapctl` package called `usageError` that implements `error` interface. All `ActionFunc`s have been updated accordingly.

@intelsdi-x/snap-maintainers
