### PR TITLE
Fixes 1043: Modifies snap to allow for removal of disabled tasks

### DIFF
--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -428,7 +428,7 @@ func (t *taskCollection) remove(task *task) error {
 	t.Lock()
 	defer t.Unlock()
 	if _, ok := t.table[task.id]; ok {
-		if task.state != core.TaskStopped {
+		if task.state != core.TaskStopped && task.state != core.TaskDisabled {
 			taskLogger.WithFields(log.Fields{
 				"_block":  "remove",
 				"task id": task.id,


### PR DESCRIPTION
Fixes #1043 

Summary of changes:
- Modified conditional statement in `scheduler/task.go` to allow for removal of **both** stopped **and** disabled tasks

Testing done:
- started `snapd` and checked to make sure the mock plugins autoloaded
- created a task that utilized the mock plugins
- unloaded the mock collector plugins
- checked to make sure that the task entered a disabled state
- removed the disabled task

here's the output of the terminal session from the point where I created the task through to the point where the task was removed:

```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure task create -t examples/tasks/mock-file.json
Using task manifest to create task
Task created
ID: a61d2366-402d-475c-b169-49fc1d6cd13e
Name: Task-a61d2366-402d-475c-b169-49fc1d6cd13e
State: Running

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:1
Plugin unloaded
Name: mock
Version: 1
Type: collector

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snapctl -u "https://127.0.0.1:12345" --insecure task list
ID 					 NAME 						 STATE 		 HIT 	 MISS 	 FAIL 	 CREATED 		 LAST FAILURE
a61d2366-402d-475c-b169-49fc1d6cd13e 	 Task-a61d2366-402d-475c-b169-49fc1d6cd13e 	 Running 	 19 	 0 	 9 	 11:57AM 7-14-2016 	 Metric not found: /intel/mock/*/baz

$ snapctl -u "https://127.0.0.1:12345" --insecure task list
ID 					 NAME 						 STATE 		 HIT 	 MISS 	 FAIL 	 CREATED 		 LAST FAILURE
a61d2366-402d-475c-b169-49fc1d6cd13e 	 Task-a61d2366-402d-475c-b169-49fc1d6cd13e 	 Disabled 	 20 	 0 	 10 	 11:57AM 7-14-2016 	 Metric not found: /intel/mock/*/baz

$ snapctl -u "https://127.0.0.1:12345" --insecure task remove a61d2366-402d-475c-b169-49fc1d6cd13e
Task removed:
ID: a61d2366-402d-475c-b169-49fc1d6cd13e

$ snapctl -u "https://127.0.0.1:12345" --insecure task list
ID 	 NAME 	 STATE 	 HIT 	 MISS 	 FAIL 	 CREATED 	 LAST FAILURE

$
```
@intelsdi-x/snap-maintainers

