### PR TITLE
Fixed #1080 rules for int/floats crash plugins

### DIFF
--- a/control/plugin/cpolicy/float.go
+++ b/control/plugin/cpolicy/float.go
@@ -136,23 +136,22 @@ func (f *FloatRule) GobDecode(buf []byte) error {
 	return nil
 }
 
-// NewFloatRule Returns a new float-typed rule. Arguments are key(string), required(bool), default(float64), min(float64), max(float64)
+// NewFloatRule returns a new float-typed rule. Arguments are key(string), required(bool), default(float64)
 func NewFloatRule(key string, req bool, opts ...float64) (*FloatRule, error) {
 	// Return error if key is empty
 	if key == "" {
 		return nil, EmptyKeyError
 	}
 
-	options := make([]*float64, 1)
-	for i, o := range opts {
-		options[i] = &o
-	}
-
-	return &FloatRule{
+	f := &FloatRule{
 		key:      key,
 		required: req,
-		default_: options[0],
-	}, nil
+	}
+
+	if len(opts) > 0 {
+		f.default_ = &opts[0]
+	}
+	return f, nil
 }
 
 // Key Returns the key

--- a/control/plugin/cpolicy/integer.go
+++ b/control/plugin/cpolicy/integer.go
@@ -44,23 +44,22 @@ type IntRule struct {
 	maximum  *int
 }
 
-// Returns a new int-typed rule. Arguments are key(string), required(bool), default(int), min(int), max(int)
+// NewIntegerRule returns a new int-typed rule. Arguments are key(string), required(bool), default(int)
 func NewIntegerRule(key string, req bool, opts ...int) (*IntRule, error) {
 	// Return error if key is empty
 	if key == "" {
 		return nil, EmptyKeyError
 	}
 
-	options := make([]*int, 1)
-	for i, o := range opts {
-		options[i] = &o
-	}
-
-	return &IntRule{
+	i := &IntRule{
 		key:      key,
 		required: req,
-		default_: options[0],
-	}, nil
+	}
+
+	if len(opts) > 0 {
+		i.default_ = &opts[0]
+	}
+	return i, nil
 }
 
 func (i *IntRule) Type() string {


### PR DESCRIPTION
Fixes #1080 

Summary of changes:
- Checks "opts" length before using it
- New func only sets the default
- max and min have to be set using setters

Testing done:
- unit tests

@intelsdi-x/snap-maintainers

