### PR TITLE
Update snap release to 0.15 for GH pages.

### DIFF
--- a/download.html
+++ b/download.html
@@ -95,11 +95,11 @@ If you come across any issues, or have any recommendations or comments, please s
         <div class="row collapse">
         <div class="large-8 columns">
           <p>Ubuntu Linux* 16.04
-          <br>Snap Telemetry v0.14.0-beta (June 7, 2016)</p>
+          <br>Snap Telemetry v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">
           <div class ="">
-          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/ubuntu/xenial/snap-telemetry_0.14.0-1xenial_amd64.deb/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> DEB <p>(Ubuntu 16.04)</p></a>
+          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/ubuntu/xenial/snap-telemetry_0.15.0-1xenial_amd64.deb/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> DEB <p>(Ubuntu 16.04)</p></a>
           </div>
           <br>
         </div>
@@ -109,12 +109,12 @@ If you come across any issues, or have any recommendations or comments, please s
         <div class="row collapse">
         <div class="large-8 columns">
           <p>Ubuntu Linux* 14.04
-          <br>Snap Telemetry v0.14.0-beta (June 7, 2016)</p>
+          <br>Snap Telemetry v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">
 
           <div class ="">
-          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/ubuntu/trusty/snap-telemetry_0.14.0-1trusty_amd64.deb/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> DEB <p>(Ubuntu 14.04)</p></a>
+          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/ubuntu/trusty/snap-telemetry_0.15.0-1trusty_amd64.deb/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> DEB <p>(Ubuntu 14.04)</p></a>
           </div><br>
         </div>
         </div>
@@ -124,12 +124,12 @@ If you come across any issues, or have any recommendations or comments, please s
         <h4>Snap Plugins</h4>
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Plugins Binary TAR v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">
 
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-plugins-v0.14.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-plugins-v0.15.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
           </div><br>
         </div>
         </div>
@@ -150,11 +150,11 @@ If you come across any issues, or have any recommendations or comments, please s
         <div class="row collapse">
         <div class="large-8 columns">
           <p> Red Hat Enterprise Linux 7/CentOS 7*
-          <br>Snap Telemetry v0.14.0-beta (June 7, 2016)</p>
+          <br>Snap Telemetry v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">
           <div class ="">
-          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/el/7/snap-telemetry-0.14.0-1.el7.x86_64.rpm/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> RPM <p>(RHEL7/CentOS 7)</p></a>
+          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/el/7/snap-telemetry-0.15.0-1.el7.x86_64.rpm/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> RPM <p>(RHEL7/CentOS 7)</p></a>
           </div><br>
         </div>
         </div>
@@ -163,12 +163,12 @@ If you come across any issues, or have any recommendations or comments, please s
         <div class="row collapse">
         <div class="large-8 columns">
           <p>Red Hat Enterprise Linux 6/CentOS 6*
-          <br>Snap Telemetry v0.14.0-beta (June 7, 2016)</p>
+          <br>Snap Telemetry v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">
 
           <div class ="">
-          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/el/6/snap-telemetry-0.14.0-1.el6.x86_64.rpm/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> RPM <p>(RHEL6/CentOS 6)</p></a>
+          <a class="button_dwnld" href="https://packagecloud.io/intelsdi-x/snap/packages/el/6/snap-telemetry-0.15.0-1.el6.x86_64.rpm/download"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> RPM <p>(RHEL6/CentOS 6)</p></a>
           </div><br>
         </div>
         </div>
@@ -178,12 +178,12 @@ If you come across any issues, or have any recommendations or comments, please s
         <h4>Snap Plugins</h4>
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Plugins Binary TAR v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">          
 
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-plugins-v0.14.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-plugins-v0.15.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
           </div><br>
         </div>
         </div>
@@ -203,11 +203,11 @@ If you come across any issues, or have any recommendations or comments, please s
         <div class="row collapse">
         <div class="large-8 columns">
 
-          <p>Snap Telemetry v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Telemetry v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">  
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-v0.14.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Download</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-v0.15.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Download</a>
           </div><br>
         </div>
         </div>
@@ -217,12 +217,12 @@ If you come across any issues, or have any recommendations or comments, please s
         <h4>Snap Plugins</h4>
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Plugins Binary TAR v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">  
 
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-plugins-v0.14.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-plugins-v0.15.0-beta-linux-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
           </div><br>
         </div>
         </div>
@@ -240,11 +240,11 @@ If you come across any issues, or have any recommendations or comments, please s
 
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Telemetry Mac Pkg v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Telemetry Mac Pkg v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">          
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-telemetry-0.14.0.pkg"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Mac Pkg</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-telemetry-0.15.0.pkg"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Mac Pkg</a>
           </div><br>
         </div>
         </div>
@@ -253,11 +253,11 @@ If you come across any issues, or have any recommendations or comments, please s
 
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Telemetry Binary TAR v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Telemetry Binary TAR v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">  
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-v0.14.0-beta-darwin-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Binary TAR</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-v0.15.0-beta-darwin-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Binary TAR</a>
           </div><br>
         </div>
         </div>
@@ -267,11 +267,11 @@ If you come across any issues, or have any recommendations or comments, please s
         <h4>Snap Plugins</h4>
         <div class="row collapse">
         <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR v0.14.0-beta (June 7, 2016)</p>
+          <p>Snap Plugins Binary TAR v0.15.0-beta (July 15, 2016)</p>
         </div>
         <div class="large-4 columns">  
           <div class ="">
-          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.14.0-beta/snap-plugins-v0.14.0-beta-darwin-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
+          <a class="button_dwnld" href="https://github.com/intelsdi-x/snap/releases/download/v0.15.0-beta/snap-plugins-v0.15.0-beta-darwin-amd64.tar.gz"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
           </div><br>
         </div>
         </div>


### PR DESCRIPTION
Update GH pages to reflect new release.

@intelsdi-x/snap-maintainers

