### PR TITLE
docs: add missing definition for space

### DIFF
--- a/docs/PLUGIN_AUTHORING.md
+++ b/docs/PLUGIN_AUTHORING.md
@@ -65,7 +65,7 @@ snap-plugin-[type]-[name]
 A plugin should **NOT** advertise metrics which namespaces contain:
 
 ##### a) the following characters in a namespace:
-    - spaces
+    - spaces	` `
     - brackets: `()[]{}`
     - slashes:  `| \ /`
     - carets:   `^`


### PR DESCRIPTION
Fixes #none 

Summary of changes:
- Added space definition

Testing done:
- none

@intelsdi-x/snap-maintainers

The definition for space was missing in PLUGIN_AUTHORING documentation.
Added ' ' for defining a space, as \s.

Signed-off-by: Saija Sorsa <saija.sorsa@intel.com>