### PR TITLE
make: Change make install to build snap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ check:
 all:
 	bash -c "./scripts/build_snap.sh"
 install:
+	$(MAKE) all
 	cp build/bin/snapd /usr/local/bin/
 	cp build/bin/snapctl /usr/local/bin/
 proto:


### PR DESCRIPTION
Fixes #XXXX

Summary of changes:
- change `make install` to include building of snap before `cp` 

Testing done:
-  Tested manually

@intelsdi-x/snap-maintainers

Change `make install` also to build snap before `cp`, by adding the command for
executing `make all`. Tested manually.

Signed-off-by: Saija Sorsa <saija.sorsa@intel.com>