### PR TITLE
Fixes #1104: skips non-executable plugins in auto_discover path

### DIFF
--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -55,7 +55,13 @@ type commandWrapper struct {
 func (cw *commandWrapper) Path() string { return cw.cmd.Path }
 func (cw *commandWrapper) Kill() error {
 	// first, kill the process wrapped up in the commandWrapper
-	if err := cw.cmd.Process.Kill(); err != nil {
+	if cw.cmd.Process == nil {
+		err := fmt.Errorf("Process for plugin '%s' not started; cannot kill", path.Base(cw.Path()))
+		log.WithFields(log.Fields{
+			"_block": "Kill",
+		}).Warn(err)
+		return err
+	} else if err := cw.cmd.Process.Kill(); err != nil {
 		log.WithFields(log.Fields{
 			"_block": "Kill",
 		}).Error(err)


### PR DESCRIPTION
Fixes #1104

Summary of changes:
- Added code to skip plugins that are not executable in the `auto_discover` path

Testing done:
- Started `snapd` with the example plugins built and installed in the `auto_discover` path; verified that plugins loaded as expected
- Killed `snapd` and restarted with the same set of example plugins set as non-executable (by running a `chmod 644 build/plugin/*` command from the `snap` directory); verified that `snapd` started successfully and skipped loading of the non-executable plugins.

The following snippet shows the test that was run locally; first starting up the Snap daemon with the plugins autoloading (because they are still executable):
```bash
$ SNAP_ADDR=127.0.0.1:12345 snapd -t 0 --config eg-snap-config.yaml
INFO[2016-07-28T16:28:06-07:00] setting log level to: debug
INFO[2016-07-28T16:28:06-07:00] Starting snapd (version: tb/fix-autoloading-nonexec-plugins-8f40854)
INFO[2016-07-28T16:28:06-07:00] setting GOMAXPROCS to: 2 core(s)
DEBU[2016-07-28T16:28:06-07:00] pevent controller created                     _block=new _module=control
DEBU[2016-07-28T16:28:06-07:00] metric catalog created                        _block=new _module=control
DEBU[2016-07-28T16:28:06-07:00] plugin manager created                        _block=new _module=control
DEBU[2016-07-28T16:28:06-07:00] signing manager created                       _block=new _module=control
DEBU[2016-07-28T16:28:06-07:00] runner created                                _block=new _module=control
DEBU[2016-07-28T16:28:06-07:00] started                                       _block=start _module=control-runner
INFO[2016-07-28T16:28:06-07:00] Setting work manager queue size               _block=New _module=scheduler value=25
INFO[2016-07-28T16:28:06-07:00] Setting work manager pool size                _block=New _module=scheduler value=4
DEBU[2016-07-28T16:28:06-07:00] metric manager linked                         _block=set-metric-manager _module=scheduler
INFO[2016-07-28T16:28:06-07:00] Configuring REST API with HTTPS set to: true  _module=_mgmt-rest
INFO[2016-07-28T16:28:06-07:00] REST API is enabled
INFO[2016-07-28T16:28:06-07:00] control started                               _block=start _module=control
INFO[2016-07-28T16:28:06-07:00] auto discover path is enabled                 _block=start _module=control
INFO[2016-07-28T16:28:06-07:00] autoloading plugins from: /Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin  _block=start _module=control
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-collector-mock1
DEBU[2016-07-28T16:28:07-07:00] Getting plugin config                         _block_=getPluginConfigDataNode _module=config config-cache-key=0:mock:1 config-cache-value=&{mutex:0xc8202d2ac0 table:map[password:{Value:p@ssw0rd} user:{Value:jane}]}
INFO[2016-07-28T16:28:07-07:00] Loading plugin                                _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin-file-name=snap-plugin-collector-mock1 plugin-name=mock plugin-type=collector plugin-version=1
INFO[2016-07-28T16:28:07-07:00] No previous pool found for loaded plugin      _block=subscribe-pool _module=control-runner event=Control.PluginLoaded plugin-name=mock plugin-type=collector plugin-version=1
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Decode reply type not a pointer: interface {}  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Decrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method DecryptKey has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Encode has wrong number of ins: 2      _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Encrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method EncryptKey has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method KillChan has wrong number of ins: 1    _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method ListenAddress has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method ListenPort has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Logger has wrong number of ins: 1      _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method ResetHeartbeat has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method SetEncrypter has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method SetListenAddress has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] method Token has wrong number of ins: 1       _module=plugin-exec io=stderr plugin=snap-plugin-collector-mock2
DEBU[2016-07-28T16:28:07-07:00] Getting plugin config                         _block_=getPluginConfigDataNode _module=config config-cache-key=0:mock:2 config-cache-value=&{mutex:0xc8202c0a98 table:map[password:{Value:p@ssw0rd} user:{Value:jane}]}
INFO[2016-07-28T16:28:07-07:00] Loading plugin                                _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin-file-name=snap-plugin-collector-mock2 plugin-name=mock plugin-type=collector plugin-version=2
INFO[2016-07-28T16:28:07-07:00] No previous pool found for loaded plugin      _block=subscribe-pool _module=control-runner event=Control.PluginLoaded plugin-name=mock plugin-type=collector plugin-version=2
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Decode reply type not a pointer: interface {}  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Decrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method DecryptKey has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Encode has wrong number of ins: 2      _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Encrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method EncryptKey has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method KillChan has wrong number of ins: 1    _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method ListenAddress has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method ListenPort has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Logger has wrong number of ins: 1      _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method ResetHeartbeat has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method SetEncrypter has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method SetListenAddress has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
DEBU[2016-07-28T16:28:07-07:00] method Token has wrong number of ins: 1       _module=plugin-exec io=stderr plugin=snap-plugin-processor-passthru
INFO[2016-07-28T16:28:07-07:00] Loading plugin                                _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin-file-name=snap-plugin-processor-passthru plugin-name=passthru plugin-type=processor plugin-version=1
INFO[2016-07-28T16:28:07-07:00] No previous pool found for loaded plugin      _block=subscribe-pool _module=control-runner event=Control.PluginLoaded plugin-name=passthru plugin-type=processor plugin-version=1
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:28:07-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Decode reply type not a pointer: interface {}  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Decrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method DecryptKey has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Encode has wrong number of ins: 2      _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Encrypt has wrong number of ins: 2     _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method EncryptKey has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method KillChan has wrong number of ins: 1    _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method ListenAddress has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method ListenPort has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Logger has wrong number of ins: 1      _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method ResetHeartbeat has wrong number of ins: 1  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method SetEncrypter has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method SetListenAddress has wrong number of ins: 2  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
DEBU[2016-07-28T16:28:08-07:00] method Token has wrong number of ins: 1       _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
INFO[2016-07-28T16:28:08-07:00] Loading plugin                                _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin-file-name=snap-plugin-publisher-mock-file plugin-name=mock-file plugin-type=publisher plugin-version=3
INFO[2016-07-28T16:28:08-07:00] No previous pool found for loaded plugin      _block=subscribe-pool _module=control-runner event=Control.PluginLoaded plugin-name=mock-file plugin-type=publisher plugin-version=3
INFO[2016-07-28T16:28:08-07:00] module started                                _module=snapd block=main snap-module=control
INFO[2016-07-28T16:28:08-07:00] scheduler started                             _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:28:08-07:00] auto discover path is enabled                 _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:28:08-07:00] autoloading tasks from: /Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin  _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:28:08-07:00] module started                                _module=snapd block=main snap-module=scheduler
INFO[2016-07-28T16:28:08-07:00] Starting REST API on 127.0.0.1:12345          _module=_mgmt-rest
INFO[2016-07-28T16:28:08-07:00] REST started                                  _block=start _module=_mgmt-rest
INFO[2016-07-28T16:28:08-07:00] module started                                _module=snapd block=main snap-module=REST
INFO[2016-07-28T16:28:08-07:00] setting plugin trust level to: disabled
INFO[2016-07-28T16:28:08-07:00] snapd started                                 _module=snapd block=main

```
then, I ran a `snapctl` command to verify the plugins loaded successfully:
```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure plugin list
NAME 		 VERSION 	 TYPE 		 SIGNED 	 STATUS 	 LOADED TIME
mock 		 1 		 collector 	 false 		 loaded 	 Thu, 28 Jul 2016 16:28:07 PDT
mock 		 2 		 collector 	 false 		 loaded 	 Thu, 28 Jul 2016 16:28:07 PDT
passthru 	 1 		 processor 	 false 		 loaded 	 Thu, 28 Jul 2016 16:28:07 PDT
mock-file 	 3 		 publisher 	 false 		 loaded 	 Thu, 28 Jul 2016 16:28:08 PDT

$ 
```
then, killed the `snapd` process that was running, changed the plugins in the `auto_discover` path so that they were non-executable files and restarted the `snapd` process:
```bash
$ chmod 644 build/plugin/*
$ SNAP_ADDR=127.0.0.1:12345 snapd -t 0 --config eg-snap-config.yaml
INFO[2016-07-28T16:32:44-07:00] setting log level to: debug
INFO[2016-07-28T16:32:44-07:00] Starting snapd (version: tb/fix-autoloading-nonexec-plugins-8f40854)
INFO[2016-07-28T16:32:44-07:00] setting GOMAXPROCS to: 2 core(s)
DEBU[2016-07-28T16:32:44-07:00] pevent controller created                     _block=new _module=control
DEBU[2016-07-28T16:32:44-07:00] metric catalog created                        _block=new _module=control
DEBU[2016-07-28T16:32:44-07:00] plugin manager created                        _block=new _module=control
DEBU[2016-07-28T16:32:44-07:00] signing manager created                       _block=new _module=control
DEBU[2016-07-28T16:32:44-07:00] runner created                                _block=new _module=control
DEBU[2016-07-28T16:32:44-07:00] started                                       _block=start _module=control-runner
INFO[2016-07-28T16:32:44-07:00] Setting work manager queue size               _block=New _module=scheduler value=25
INFO[2016-07-28T16:32:44-07:00] Setting work manager pool size                _block=New _module=scheduler value=4
DEBU[2016-07-28T16:32:44-07:00] metric manager linked                         _block=set-metric-manager _module=scheduler
INFO[2016-07-28T16:32:44-07:00] Configuring REST API with HTTPS set to: true  _module=_mgmt-rest
INFO[2016-07-28T16:32:44-07:00] REST API is enabled
INFO[2016-07-28T16:32:44-07:00] control started                               _block=start _module=control
INFO[2016-07-28T16:32:44-07:00] auto discover path is enabled                 _block=start _module=control
INFO[2016-07-28T16:32:44-07:00] autoloading plugins from: /Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin  _block=start _module=control
INFO[2016-07-28T16:32:44-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:32:44-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-collector-mock1
WARN[2016-07-28T16:32:47-07:00] process for plugin 'snap-plugin-collector-mock1' not started; cannot kill  _block=Kill
ERRO[2016-07-28T16:32:47-07:00] load plugin error when starting plugin        _block=load-plugin _module=control-plugin-mgr error=timed out waiting for plugin snap-plugin-collector-mock1
ERRO[2016-07-28T16:32:47-07:00] timed out waiting for plugin snap-plugin-collector-mock1  _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin=&{name:snap-plugin-collector-mock1 size:10015792 mode:420 modTime:{sec:63605344667 nsec:0 loc:0xee6d80} sys:{Dev:16777220 Mode:33188 Nlink:1 Ino:8788158 Uid:502 Gid:20 Rdev:0 Pad_cgo_0:[0 0 0 0] Atimespec:{Sec:1469748487 Nsec:0} Mtimespec:{Sec:1469747867 Nsec:0} Ctimespec:{Sec:1469748761 Nsec:0} Birthtimespec:{Sec:1469747866 Nsec:0} Size:10015792 Blocks:19568 Blksize:4096 Flags:0 Gen:0 Lspare:0 Qspare:[0 0]}}
INFO[2016-07-28T16:32:47-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:32:47-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-collector-mock2
WARN[2016-07-28T16:32:50-07:00] process for plugin 'snap-plugin-collector-mock2' not started; cannot kill  _block=Kill
ERRO[2016-07-28T16:32:50-07:00] load plugin error when starting plugin        _block=load-plugin _module=control-plugin-mgr error=timed out waiting for plugin snap-plugin-collector-mock2
ERRO[2016-07-28T16:32:50-07:00] timed out waiting for plugin snap-plugin-collector-mock2  _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin=&{name:snap-plugin-collector-mock2 size:10015648 mode:420 modTime:{sec:63605344681 nsec:0 loc:0xee6d80} sys:{Dev:16777220 Mode:33188 Nlink:1 Ino:8788598 Uid:502 Gid:20 Rdev:0 Pad_cgo_0:[0 0 0 0] Atimespec:{Sec:1469748487 Nsec:0} Mtimespec:{Sec:1469747881 Nsec:0} Ctimespec:{Sec:1469748761 Nsec:0} Birthtimespec:{Sec:1469747879 Nsec:0} Size:10015648 Blocks:19568 Blksize:4096 Flags:0 Gen:0 Lspare:0 Qspare:[0 0]}}
INFO[2016-07-28T16:32:50-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:32:50-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-processor-passthru
WARN[2016-07-28T16:32:53-07:00] process for plugin 'snap-plugin-processor-passthru' not started; cannot kill  _block=Kill
ERRO[2016-07-28T16:32:53-07:00] load plugin error when starting plugin        _block=load-plugin _module=control-plugin-mgr error=timed out waiting for plugin snap-plugin-processor-passthru
ERRO[2016-07-28T16:32:53-07:00] timed out waiting for plugin snap-plugin-processor-passthru  _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin=&{name:snap-plugin-processor-passthru size:10010816 mode:420 modTime:{sec:63605344694 nsec:0 loc:0xee6d80} sys:{Dev:16777220 Mode:33188 Nlink:1 Ino:8789035 Uid:502 Gid:20 Rdev:0 Pad_cgo_0:[0 0 0 0] Atimespec:{Sec:1469748487 Nsec:0} Mtimespec:{Sec:1469747894 Nsec:0} Ctimespec:{Sec:1469748761 Nsec:0} Birthtimespec:{Sec:1469747893 Nsec:0} Size:10010816 Blocks:19560 Blksize:4096 Flags:0 Gen:0 Lspare:0 Qspare:[0 0]}}
INFO[2016-07-28T16:32:53-07:00] plugin load called                            _block=load _module=control
INFO[2016-07-28T16:32:53-07:00] plugin load called                            _block=load-plugin _module=control-plugin-mgr path=snap-plugin-publisher-mock-file
WARN[2016-07-28T16:32:56-07:00] process for plugin 'snap-plugin-publisher-mock-file' not started; cannot kill  _block=Kill
ERRO[2016-07-28T16:32:56-07:00] load plugin error when starting plugin        _block=load-plugin _module=control-plugin-mgr error=timed out waiting for plugin snap-plugin-publisher-mock-file
ERRO[2016-07-28T16:32:56-07:00] timed out waiting for plugin snap-plugin-publisher-mock-file  _block=start _module=control autodiscoverpath=/Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin plugin=&{name:snap-plugin-publisher-mock-file size:10014912 mode:420 modTime:{sec:63605344708 nsec:0 loc:0xee6d80} sys:{Dev:16777220 Mode:33188 Nlink:1 Ino:8789474 Uid:502 Gid:20 Rdev:0 Pad_cgo_0:[0 0 0 0] Atimespec:{Sec:1469748487 Nsec:0} Mtimespec:{Sec:1469747908 Nsec:0} Ctimespec:{Sec:1469748761 Nsec:0} Birthtimespec:{Sec:1469747907 Nsec:0} Size:10014912 Blocks:19568 Blksize:4096 Flags:0 Gen:0 Lspare:0 Qspare:[0 0]}}
INFO[2016-07-28T16:32:56-07:00] module started                                _module=snapd block=main snap-module=control
INFO[2016-07-28T16:32:56-07:00] scheduler started                             _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:32:56-07:00] auto discover path is enabled                 _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:32:56-07:00] autoloading tasks from: /Users/tjmcswee/src/go/src/github.com/intelsdi-x/snap/build/plugin  _block=start-scheduler _module=scheduler
INFO[2016-07-28T16:32:56-07:00] module started                                _module=snapd block=main snap-module=scheduler
INFO[2016-07-28T16:32:56-07:00] Starting REST API on 127.0.0.1:12345          _module=_mgmt-rest
INFO[2016-07-28T16:32:56-07:00] REST started                                  _block=start _module=_mgmt-rest
INFO[2016-07-28T16:32:56-07:00] module started                                _module=snapd block=main snap-module=REST
INFO[2016-07-28T16:32:56-07:00] setting plugin trust level to: disabled
INFO[2016-07-28T16:32:56-07:00] snapd started                                 _module=snapd block=main

```
and re-ran the `snapctl` command to verify that the plugins in the `auto_discover` path skipped properly:
```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure plugin list
NAME 	 VERSION 	 TYPE 	 SIGNED 	 STATUS 	 LOADED TIME

$ 
```
@intelsdi-x/snap-maintainers

