### PR TITLE
make: Change 'make install' NOT to build Snap. Revert of #1094

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ check:
 all:
 	bash -c "./scripts/build_snap.sh"
 install:
-	$(MAKE) all
 	cp build/bin/snapd /usr/local/bin/
 	cp build/bin/snapctl /usr/local/bin/
 proto:


### PR DESCRIPTION
Fixes #1108: 

Summary of changes:
~~Small update for BUILD_AND_TEST.md tutorial.~~
~~After changing 'make install' to also compile Snap source, the GOPATH environment variable needs to set up for root as well. Otherwise one gets a compilation error.~~
- Changes in Makefile: remove `make all` from `make install`

@intelsdi-x/snap-maintainers

