### PR TITLE
Fixes #1113: removes fixed max-failure value from task creation

### DIFF
--- a/cmd/snapctl/flags.go
+++ b/cmd/snapctl/flags.go
@@ -21,10 +21,6 @@ package main
 
 import "github.com/codegangsta/cli"
 
-const (
-	DefaultMaxFailures = 10
-)
-
 var (
 
 	// Main flags
@@ -126,10 +122,9 @@ var (
 		Name:  "deadline",
 		Usage: "The deadline for the task to be killed after started if the task runs too long (All tasks default to 5s)",
 	}
-	flTaskMaxFailures = cli.IntFlag{
+	flTaskMaxFailures = cli.StringFlag{
 		Name:  "max-failures",
-		Usage: "The number of consecutive failures before snap disable the task (Default 10 consective failures)",
-		Value: DefaultMaxFailures,
+		Usage: "The number of consecutive failures before snap disables the task",
 	}
 
 	// metric

--- a/core/task.go
+++ b/core/task.go
@@ -197,7 +197,12 @@ func CreateTaskFromContent(body io.ReadCloser,
 	if tr.Name != "" {
 		opts = append(opts, SetTaskName(tr.Name))
 	}
-	opts = append(opts, OptionStopOnFailure(10))
+
+	// if a MaxFailures value is included as part of the task creation request
+	if tr.MaxFailures > 0 {
+		// then set the appropriate value in the opts
+		opts = append(opts, OptionStopOnFailure(tr.MaxFailures))
+	}
 
 	if mode == nil {
 		mode = &tr.Start

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -160,7 +160,7 @@ func TestSnapClient(t *testing.T) {
 					So(t1.Err.Error(), ShouldEqual, fmt.Sprintf("Task not found: ID(%s)", uuid))
 				})
 				Convey("invalid task (missing metric)", func() {
-					tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
+					tt := c.CreateTask(sch, wf, "baron", "", true, 0)
 					So(tt.Err, ShouldNotBeNil)
 					So(tt.Err.Error(), ShouldContainSubstring, "Metric not found: /intel/mock/foo")
 				})
@@ -193,7 +193,7 @@ func TestSnapClient(t *testing.T) {
 				So(p.AvailablePlugins, ShouldBeEmpty)
 			})
 			Convey("invalid task (missing publisher)", func() {
-				tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
+				tf := c.CreateTask(sch, wf, "baron", "", false, 0)
 				So(tf.Err, ShouldNotBeNil)
 				So(tf.Err.Error(), ShouldContainSubstring, "Plugin not found: type(publisher) name(mock-file)")
 			})
@@ -338,11 +338,11 @@ func TestSnapClient(t *testing.T) {
 		Convey("Tasks", func() {
 			Convey("Passing a bad task manifest", func() {
 				wfb := getWMFromSample("bad.json")
-				ttb := c.CreateTask(sch, wfb, "bad", "", true, rest.DefaultMaxFailures)
+				ttb := c.CreateTask(sch, wfb, "bad", "", true, 0)
 				So(ttb.Err, ShouldNotBeNil)
 			})
 
-			tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
+			tf := c.CreateTask(sch, wf, "baron", "", false, 0)
 			Convey("valid task not started on creation", func() {
 				So(tf.Err, ShouldBeNil)
 				So(tf.Name, ShouldEqual, "baron")
@@ -385,7 +385,7 @@ func TestSnapClient(t *testing.T) {
 				})
 			})
 
-			tt := c.CreateTask(sch, wf, "baron", "", true, rest.DefaultMaxFailures)
+			tt := c.CreateTask(sch, wf, "baron", "", true, 0)
 			Convey("valid task started on creation", func() {
 				So(tt.Err, ShouldBeNil)
 				So(tt.Name, ShouldEqual, "baron")
@@ -473,7 +473,7 @@ func TestSnapClient(t *testing.T) {
 					Convey("event stream", func() {
 						rest.StreamingBufferWindow = 0.01
 						sch := &Schedule{Type: "simple", Interval: "100ms"}
-						tf := c.CreateTask(sch, wf, "baron", "", false, rest.DefaultMaxFailures)
+						tf := c.CreateTask(sch, wf, "baron", "", false, 0)
 
 						type ea struct {
 							events []string

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -25,10 +25,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-const (
-	DefaultMaxFailures = 10
-)
-
 var (
 	flAPIDisabled = cli.BoolFlag{
 		Name:  "disable-api, d",

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -41,8 +41,8 @@ import (
 const (
 	// DefaultDeadlineDuration - The default timeout is 5 second
 	DefaultDeadlineDuration = time.Second * 5
-	// DefaultStopOnFailure - The default stopping a failure is after three tries
-	DefaultStopOnFailure = 3
+	// DefaultStopOnFailure is used to set the number of failures before a task is disabled
+	DefaultStopOnFailure = 10
 )
 
 var (


### PR DESCRIPTION
Fixes #1113

Summary of changes:
- Modified  a single line of code from the `core/task.go` file that used to set the `max-failure` value to `10` for all tasks; now it sets the value to whatever was received in the task creation request instead
- Modified the `cmd/snapctl/flags.go` and `scheduler/task.go` files so that they used a single parameter (the `DefaultMaxFailures` constant from the `mgmt/rest` package) to set the default value they use for the number of times a task can fail before it is disabled; previously this parameter was set with separate fixed values in these two files and those fixed values did not match (the default was set to `3` in the `scheduler/task.go` file and to `10` in the `cmd/snapctl/flags.go` file)

Testing done:
- started `snapd`
- created a task using a copy of the `eg-file.yaml` task configuration from the Snap distribution; in the copy being used for this part of the test, the `max-failures` value in the task configuration was set to `3`
- unloaded the underlying mock collector plugin (both versions)
- verified that the task was disabled after three consecutive failures
- killed and restarted `snapd`
- ran the same test with the `max-failures` value unspecified in the task configuration file that was used and verified that the task was disabled after 10 consecutive failures (the default value for this parameter once this PR has been applied)
- ran the same test with the `max-failures` value set to `-1` and verified that the task was  once again disabled after 10 consecutive failures (the default value for this parameter)

see the command-line output, below, for details; here's the head of the three YAML files used in the testing (to show the differences in the `max-failure` parameter value defined in each):

```bash
$ head -6 mock-file*
==> mock-file-neg-one-max-failures.yaml <==
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  max-failures: -1

==> mock-file-three-max-faiures.yaml <==
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  max-failures: 3

==> mock-file-unspecified-max-failures.yaml <==
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
#  max-failures: -1

$ 
```
next, we started up `snapd` in a separate window:
```bash
$ SNAP_ADDR=127.0.0.1:12345 snapd -t 0 --config eg-snap-config.yaml 2>&1 | tee t.t
...
...
...
```
once `snapd` was up and running, created a task that should be disabled after three concurrent failures, then unloaded the two versions of the collector plugin that the task depends on (so that the task would fail); once the task had been disabled, went back and counted the number of times it failed before `snapd` disabled that task by grep'ing for the line denoting the task failure in the log output of the `snapd` instance (the `t.t` file):
```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure task create -t ./mock-file-three-max-faiures.yaml
Using task manifest to create task
Task created
ID: 2fa9ae52-d108-4cae-b7b1-b573e50633e7
Name: Task-2fa9ae52-d108-4cae-b7b1-b573e50633e7
State: Running

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:1
Plugin unloaded
Name: mock
Version: 1
Type: collector

$ grep 'Task failed' t.t | wc
       3      51     879

$ 
```
next, restarted `snapd` (using the same `snapd` command shown above) and once it was up and running again re-ran the test, this time using the task configuration file that doesn't specify a value for the `max-failures` parameter:
```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure task create -t ./mock-file-unspecified-max-failures.yaml
Using task manifest to create task
Task created
ID: 5ec3dd4c-8895-48cc-8b7c-19e9763d49db
Name: Task-5ec3dd4c-8895-48cc-8b7c-19e9763d49db
State: Running

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:1
Plugin unloaded
Name: mock
Version: 1
Type: collector

$ grep 'Task failed' t.t | wc
      10     170    2941

$ 
```
and finally, restarted `snapd` and once it was up and running again ran the test for the task configuration file that specifies a value of `-1` for the `max-failures` parameter:
```bash
$ snapctl -u "https://127.0.0.1:12345" --insecure task create -t ./mock-file-neg-one-max-failures.yaml
Using task manifest to create task
Task created
ID: f95046d1-742d-4a5a-b222-50ee20b17867
Name: Task-f95046d1-742d-4a5a-b222-50ee20b17867
State: Running

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snapctl -u "https://127.0.0.1:12345" --insecure plugin unload collector:mock:1
Plugin unloaded
Name: mock
Version: 1
Type: collector

$ grep 'Task failed' t.t | wc
      10     170    2941

$ 
```
As you can see, in the first case we saw three lines in the log output indicating that the task had failed before the task was disabled, while for the last two tests we saw ten lines in the log output, showing that the default value is used for the latter two and for any value greater than zero (`3` in this case) the number of consecutive failures before the task is disabled is set using the specified `max-failure` value.

@intelsdi-x/snap-maintainers

