### PR TITLE
Fix #285: Allow setting of task name in manifest with override from commandline flag

### DIFF
--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -124,7 +124,11 @@ func createTaskUsingTaskManifest(ctx *cli.Context) error {
 		return fmt.Errorf("Unsupported file type %s\n", ext)
 	}
 
-	t.Name = ctx.String("name")
+	// Set t.Name to value of --name flag if set on command line
+	if ctx.IsSet("name") {
+		t.Name = ctx.String("name")
+	}
+
 	if t.Version != 1 {
 		return fmt.Errorf("Invalid version provided")
 	}

--- a/core/task_test.go
+++ b/core/task_test.go
@@ -136,7 +136,7 @@ func TestMarshalTask(t *testing.T) {
 		task, err := marshalTask(file)
 		So(err, ShouldBeNil)
 		So(task, ShouldNotBeNil)
-		So(task.Name, ShouldEqual, "")
+		So(task.Name, ShouldEqual, "mock-file")
 		So(task.Deadline, ShouldEqual, "")
 		So(task.Schedule.Type, ShouldEqual, "simple")
 		So(task.Schedule.Interval, ShouldEqual, "1s")

--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -1,5 +1,6 @@
 {
     "version": 1,
+    "name": "mock-file",
     "schedule": {
         "type": "simple",
         "interval": "1s"

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -1,5 +1,6 @@
 ---
   version: 1
+  name: mock-file
   schedule: 
     type: "simple"
     interval: "1s"


### PR DESCRIPTION
Fixes #285

Summary of changes:
- Only uses `--name` flag for setting name if --name was set on the command line. Add name field to task manifest will set the name for a task.
- Add a `name` field to a task manifest will set the name of the task.
- Updated example mock-file.json and mock-file.yaml to include `name` field

Testing done:
- Verified task name can be set from task manifest or overriding from `--name` flag

Updated mock-file.json
```json
{
    "version": 1,
    "name": "mock-file",
    "schedule": {
        "type": "simple",
        "interval": "1s"
    },
    "max-failures": 10,
    "workflow": {
        "collect": {
            "metrics": {
                "/intel/mock/foo": {},
                "/intel/mock/bar": {},
                "/intel/mock/*/baz": {}
            },
            "config": {
                "/intel/mock": {
                    "name": "root",
                    "password": "secret"
                }
            },
            "process": [
                {
                    "plugin_name": "passthru",
                    "process": null,
                    "publish": [
                        {
                            "plugin_name": "mock-file",
                            "config": {
                                "file": "/tmp/snap_published_mock_file.log"
                            }
                        }
                    ]
                }
            ]
        }
    }
}
```

![screen shot 2016-08-03 at 10 56 35 am](https://cloud.githubusercontent.com/assets/1395030/17376136/ff910efc-5968-11e6-8fec-fca6f2871bd3.png)


@intelsdi-x/snap-maintainers
