### PR TITLE
Fix #1129 - Add schedule validation check for task manifests in snapctl

### DIFF
--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -343,6 +343,11 @@ func createTaskUsingTaskManifest(ctx *cli.Context) error {
 		return fmt.Errorf("Unsupported file type %s\n", ext)
 	}
 
+	// Validate task manifest includes schedule, workflow, and version
+	if err := validateTask(t); err != nil {
+		return err
+	}
+
 	// merge any CLI options specified by the user (if any) into the current task;
 	// if an error is encountered, return it
 	if err := t.mergeCliOptions(ctx); err != nil {
@@ -698,4 +703,21 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func validateTask(t task) error {
+	if err := validateScheduleExists(t.Schedule); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateScheduleExists(schedule *client.Schedule) error {
+	if schedule == nil {
+		return fmt.Errorf("Error: Task manifest did not include a schedule")
+	}
+	if *schedule == (client.Schedule{}) {
+		return fmt.Errorf("Error: Task manifest included an empty schedule. Task manifests need to include a schedule.")
+	}
+	return nil
 }

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -307,10 +307,6 @@ func (t *task) mergeCliOptions(ctx *cli.Context) error {
 		}
 		t.MaxFailures = maxFailures
 	}
-	// shouldn't ever happen, but...
-	if t.Version != 1 {
-		return fmt.Errorf("Invalid version provided while creating task")
-	}
 	// set the schedule for the task from the CLI options (and return the results
 	// of that method call, indicating whether or not an error was encountered while
 	// setting up that schedule)
@@ -708,6 +704,9 @@ func min(a, b int) int {
 func validateTask(t task) error {
 	if err := validateScheduleExists(t.Schedule); err != nil {
 		return err
+	}
+	if t.Version != 1 {
+		return fmt.Errorf("Error: Invalid version provided for task manifest")
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1129 

Summary of changes:
- Validates a task from a task manifest includes a schedule and the schedule is not empty.
- Moves the version check for a task manifest into a better function that includes other validations.

Testing done:
- Verified passing a task manifest without a schedule returns an error.
- Verified passing a task manifest with an empty schedule returns an error.

@intelsdi-x/snap-maintainers
