### PR TITLE
Eliminates plugin log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ profile.cov
 gin-bin
 tags
 .vscode/
+vendor/
+glide.lock
 
 # we don't vendor godep _workspace
 **/Godeps/_workspace/**

--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -54,9 +54,7 @@ func TestAvailablePlugin(t *testing.T) {
 		Convey("returns nil if plugin successfully stopped", func() {
 			r := newRunner()
 			r.SetEmitter(new(MockEmitter))
-			a := plugin.Arg{
-				PluginLogPath: "/tmp/snap-test-plugin-stop.log",
-			}
+			a := plugin.Arg{}
 
 			exPlugin, _ := plugin.NewExecutablePlugin(a, fixtures.PluginPath)
 			ap, err := r.startPlugin(exPlugin)

--- a/control/control.go
+++ b/control/control.go
@@ -125,7 +125,7 @@ type managesPlugins interface {
 	LoadPlugin(*pluginDetails, gomit.Emitter) (*loadedPlugin, serror.SnapError)
 	UnloadPlugin(core.Plugin) (*loadedPlugin, serror.SnapError)
 	SetMetricCatalog(catalogsMetrics)
-	GenerateArgs(pluginPath string) plugin.Arg
+	GenerateArgs(logLevel int) plugin.Arg
 	SetPluginConfig(*pluginConfig)
 }
 

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -75,7 +75,7 @@ func (m *MockPluginManagerBadSwap) teardown()                         {}
 func (m *MockPluginManagerBadSwap) SetPluginConfig(*pluginConfig)     {}
 func (m *MockPluginManagerBadSwap) SetMetricCatalog(catalogsMetrics)  {}
 func (m *MockPluginManagerBadSwap) SetEmitter(gomit.Emitter)          {}
-func (m *MockPluginManagerBadSwap) GenerateArgs(string) plugin.Arg    { return plugin.Arg{} }
+func (m *MockPluginManagerBadSwap) GenerateArgs(int) plugin.Arg       { return plugin.Arg{} }
 
 func (m *MockPluginManagerBadSwap) all() map[string]*loadedPlugin {
 	return m.loadedPlugins.table

--- a/control/plugin/collector_proxy.go
+++ b/control/plugin/collector_proxy.go
@@ -54,7 +54,7 @@ type collectorPluginProxy struct {
 func (c *collectorPluginProxy) GetMetricTypes(args []byte, reply *[]byte) error {
 	defer catchPluginPanic(c.Session.Logger())
 
-	c.Session.Logger().Println("GetMetricTypes called")
+	c.Session.Logger().Debugln("GetMetricTypes called")
 	// Reset heartbeat
 	c.Session.ResetHeartbeat()
 
@@ -77,7 +77,7 @@ func (c *collectorPluginProxy) GetMetricTypes(args []byte, reply *[]byte) error 
 
 func (c *collectorPluginProxy) CollectMetrics(args []byte, reply *[]byte) error {
 	defer catchPluginPanic(c.Session.Logger())
-	c.Session.Logger().Println("CollectMetrics called")
+	c.Session.Logger().Debugln("CollectMetrics called")
 	// Reset heartbeat
 	c.Session.ResetHeartbeat()
 

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -23,8 +23,6 @@ package plugin
 
 import (
 	"errors"
-	"log"
-	"os"
 	"testing"
 	"time"
 

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/intelsdi-x/snap/control/plugin/encoding"
 	"github.com/intelsdi-x/snap/core"
 
+	log "github.com/Sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -98,9 +99,7 @@ func (p *mockErrorPlugin) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 func TestCollectorProxy(t *testing.T) {
 	Convey("Test collector plugin proxy for get metric types ", t, func() {
 
-		logger := log.New(os.Stdout,
-			"test: ",
-			log.Ldate|log.Ltime|log.Lshortfile)
+		logger := log.New()
 		mockPlugin := &mockPlugin{}
 
 		mockSessionState := &MockSessionState{

--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -124,8 +124,10 @@ func (e *ExecutablePlugin) Run(timeout time.Duration) (Response, error) {
 				respReceived = true
 				close(doneChan)
 			} else {
-				execLogger.WithField("plugin", path.Base(e.cmd.Path())).
-					Debug(stdOutScanner.Text())
+				execLogger.WithFields(log.Fields{
+					"plugin": path.Base(e.cmd.Path()),
+					"io":     "stdout",
+				}).Debug(stdOutScanner.Text())
 			}
 		}
 	}()
@@ -157,7 +159,9 @@ func (e *ExecutablePlugin) captureStderr() {
 		for stdErrScanner.Scan() {
 			execLogger.
 				WithField("io", "stderr").
-				WithField("plugin", path.Base(e.cmd.Path())).Debug(stdErrScanner.Text())
+				WithField("plugin", path.Base(e.cmd.Path())).
+				Debug(stdErrScanner.Text())
+
 		}
 	}()
 }

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -329,20 +329,19 @@ func Start(m *PluginMeta, c Plugin, requestString string) (error, int) {
 	e := rpc.Register(s)
 	if e != nil {
 		if e.Error() != "rpc: service already defined: SessionState" {
-			log.Println(e.Error())
-			s.Logger().Println(e.Error())
+			s.Logger().Error(e.Error())
 			return e, 2
 		}
 	}
 
 	l, err := net.Listen("tcp", "127.0.0.1:"+s.ListenPort())
 	if err != nil {
-		s.Logger().Println(err.Error())
+		s.Logger().Error(err.Error())
 		panic(err)
 	}
 	s.SetListenAddress(l.Addr().String())
-	s.Logger().Printf("Listening %s\n", l.Addr())
-	s.Logger().Printf("Session token %s\n", s.Token())
+	s.Logger().Debugf("Listening %s\n", l.Addr())
+	s.Logger().Debugf("Session token %s\n", s.Token())
 
 	switch r.Meta.RPCType {
 	case JSONRPC:

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io" // Don't use "fmt.Print*"
-	"log"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -34,6 +33,8 @@ import (
 	"regexp"
 	"runtime"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 )
@@ -225,8 +226,8 @@ func NewPluginMeta(name string, version int, pluginType PluginType, acceptConten
 
 // Arguments passed to startup of Plugin
 type Arg struct {
-	// Plugin file path to binary
-	PluginLogPath string
+	// Plugin log level
+	LogLevel log.Level
 	// Ping timeout duration
 	PingTimeoutDuration time.Duration
 
@@ -235,9 +236,9 @@ type Arg struct {
 	listenPort string
 }
 
-func NewArg(logpath string) Arg {
+func NewArg(logLevel int) Arg {
 	return Arg{
-		PluginLogPath:       logpath,
+		LogLevel:            log.Level(logLevel),
 		PingTimeoutDuration: PingTimeoutDurationDefault,
 	}
 }

--- a/control/plugin/plugin_test.go
+++ b/control/plugin/plugin_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -60,7 +61,7 @@ func TestMetricType(t *testing.T) {
 
 func TestArg(t *testing.T) {
 	Convey("NewArg", t, func() {
-		arg := NewArg("/tmp/snap/plugin.log")
+		arg := NewArg(int(log.InfoLevel))
 		So(arg, ShouldNotBeNil)
 	})
 }

--- a/control/plugin/session.go
+++ b/control/plugin/session.go
@@ -313,9 +313,8 @@ func init() {
 // simpleFormatter is a logrus formatter that includes only the message.
 type simpleFormatter struct{}
 
-func (_ *simpleFormatter) Format(entry *log.Entry) ([]byte, error) {
+func (*simpleFormatter) Format(entry *log.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
-	fmt.Fprintf(b, "%s", entry.Message)
-	b.WriteByte('\n')
+	fmt.Fprintf(b, "%s\n", entry.Message)
 	return b.Bytes(), nil
 }

--- a/control/plugin/session_test.go
+++ b/control/plugin/session_test.go
@@ -24,10 +24,10 @@ package plugin
 import (
 	"encoding/json"
 	"errors"
-	"log"
-	"os"
 	"testing"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/control/plugin/encoding"
@@ -127,7 +127,7 @@ func TestSessionState(t *testing.T) {
 			Arg:      &Arg{PingTimeoutDuration: 500 * time.Millisecond},
 			Encoder:  encoding.NewJsonEncoder(),
 		}
-		ss.logger = log.New(os.Stdout, ">>>", log.Ldate|log.Ltime)
+		ss.logger = log.New()
 		Convey("Ping", func() {
 
 			ss.Ping([]byte{}, &[]byte{})
@@ -202,9 +202,7 @@ func TestSessionState(t *testing.T) {
 
 func TestGetConfigPolicy(t *testing.T) {
 	Convey("Get Config Policy", t, func() {
-		logger := log.New(os.Stdout,
-			"test: ",
-			log.Ldate|log.Ltime|log.Lshortfile)
+		logger := log.New()
 		mockPlugin := &mockPlugin{}
 
 		mockSessionState := &MockSessionState{
@@ -227,9 +225,7 @@ func TestGetConfigPolicy(t *testing.T) {
 		So(cpr.Policy, ShouldNotBeNil)
 	})
 	Convey("Get error in Config Policy ", t, func() {
-		logger := log.New(os.Stdout,
-			"test: ",
-			log.Ldate|log.Ltime|log.Lshortfile)
+		logger := log.New()
 		errSession := &errSessionState{
 			&MockSessionState{
 				Encoder:             encoding.NewGobEncoder(),

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -285,7 +285,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 		"_block": "load-plugin",
 		"path":   filepath.Base(lPlugin.Details.Exec),
 	}).Info("plugin load called")
-	ePlugin, err := plugin.NewExecutablePlugin(p.GenerateArgs(lPlugin.Details.Exec), path.Join(lPlugin.Details.ExecPath, lPlugin.Details.Exec))
+	ePlugin, err := plugin.NewExecutablePlugin(p.GenerateArgs(int(log.GetLevel())), path.Join(lPlugin.Details.ExecPath, lPlugin.Details.Exec))
 	if err != nil {
 		pmLogger.WithFields(log.Fields{
 			"_block": "load-plugin",
@@ -559,9 +559,8 @@ func (p *pluginManager) UnloadPlugin(pl core.Plugin) (*loadedPlugin, serror.Snap
 }
 
 // GenerateArgs generates the cli args to send when stating a plugin
-func (p *pluginManager) GenerateArgs(pluginPath string) plugin.Arg {
-	pluginLog := filepath.Join(p.logPath, filepath.Base(pluginPath)) + ".log"
-	return plugin.NewArg(pluginLog)
+func (p *pluginManager) GenerateArgs(logLevel int) plugin.Arg {
+	return plugin.NewArg(logLevel)
 }
 
 func (p *pluginManager) teardown() {

--- a/control/runner.go
+++ b/control/runner.go
@@ -312,7 +312,7 @@ func (r *runner) runPlugin(details *pluginDetails) error {
 		}
 		details.ExecPath = path.Join(tempPath, "rootfs")
 	}
-	ePlugin, err := plugin.NewExecutablePlugin(r.pluginManager.GenerateArgs(details.Exec), path.Join(details.ExecPath, details.Exec))
+	ePlugin, err := plugin.NewExecutablePlugin(r.pluginManager.GenerateArgs(int(log.GetLevel())), path.Join(details.ExecPath, details.Exec))
 	if err != nil {
 		runnerLog.WithFields(log.Fields{
 			"_block": "run-plugin",

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -40,8 +40,7 @@ type MockController struct {
 
 func (p *MockController) GenerateArgs(daemon bool) plugin.Arg {
 	a := plugin.Arg{
-		PluginLogPath: "/tmp/snap-test-plugin.log",
-		NoDaemon:      daemon,
+		NoDaemon: daemon,
 	}
 	return a
 }
@@ -353,10 +352,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("should return an AvailablePlugin", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin.log",
-							// Daemon:        true,
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -378,9 +374,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("availablePlugins should include returned availablePlugin", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin.log",
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -398,9 +392,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("healthcheck on healthy plugin does not increment failedHealthChecks", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin.log",
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -417,9 +409,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("healthcheck on unhealthy plugin increments failedHealthChecks", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin.log",
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -436,9 +426,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("successful healthcheck resets failedHealthChecks", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin-foo.log",
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -459,9 +447,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					Convey("three consecutive failedHealthChecks disables the plugin", func() {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
-						a := plugin.Arg{
-							PluginLogPath: "/tmp/snap-test-plugin.log",
-						}
+						a := plugin.Arg{}
 						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 						if err != nil {
 							panic(err)
@@ -494,9 +480,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 				Convey("should return an AvailablePlugin in a Running state", func() {
 					r := newRunner()
 					r.SetEmitter(new(MockEmitter))
-					a := plugin.Arg{
-						PluginLogPath: "/tmp/snap-test-plugin-stop.log",
-					}
+					a := plugin.Arg{}
 					exPlugin, err := newExecutablePlugin(a, fixtures.PluginPath)
 					if err != nil {
 						panic(err)

--- a/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
@@ -53,6 +53,14 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 	rand.Seed(time.Now().UTC().UnixNano())
 	metrics := []plugin.MetricType{}
 	for i := range mts {
+		if c, ok := mts[i].Config().Table()["long_print"]; ok && c.(ctypes.ConfigValueBool).Value {
+			letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+			longLine := []byte{}
+			for i := 0; i < 8193; i++ {
+				longLine = append(longLine, letterBytes[rand.Intn(len(letterBytes))])
+			}
+			fmt.Println(string(longLine))
+		}
 		if c, ok := mts[i].Config().Table()["panic"]; ok && c.(ctypes.ConfigValueBool).Value {
 			panic("Oops!")
 		}

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -21,7 +21,6 @@ package scheduler
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -241,7 +241,7 @@ func (s *schedulerWorkflow) Start(t *task) {
 		"_block":    "workflow-start",
 		"task-id":   t.id,
 		"task-name": t.name,
-	}).Info(fmt.Sprintf("Starting workflow for task (%s\\%s)", t.id, t.name))
+	}).Debug("Starting workflow")
 	s.state = WorkflowStarted
 	j := newCollectorJob(s.metrics, t.deadlineDuration, t.metricsManager, t.workflow.configTree, t.id, s.tags)
 


### PR DESCRIPTION
Fixes #1102 

A plugins stdout and stderr are already captured by snapd and logged
to snapd's log file.  This commit removes the log file created by the
client lib that captures much of the boiler plate interaction between
control and the plugin including including logging heart beats, which
RPC methods were invoked, etc.

Summary of changes:
- Removes PluginLogPath from plugin args
- Adds LogLevel to args sent to a plugin
- Replaces standard log with logrus 

Testing done:
- Unit
- Manual
 - latest snapd + latest plugins
 - latest snapd + plugins from v0.15
 - v0.15 snapd + latest plugins

@intelsdi-x/snap-maintainers