### PR TITLE
Makes plugins used in example tasks consistent

### DIFF
--- a/examples/tasks/mock-file.json
+++ b/examples/tasks/mock-file.json
@@ -24,7 +24,7 @@
                     "process": null,
                     "publish": [
                         {
-                            "plugin_name": "mock-file",                            
+                            "plugin_name": "file",                            
                             "config": {
                                 "file": "/tmp/snap_published_mock_file.log"
                             }

--- a/examples/tasks/mock-file.yaml
+++ b/examples/tasks/mock-file.yaml
@@ -22,7 +22,7 @@
           process: null
           publish: 
             - 
-              plugin_name: "mock-file"
+              plugin_name: "file"
               config: 
                 file: "/tmp/snap_published_mock_file.log"
                 debug: true

--- a/examples/tasks/mock_tagged-file.json
+++ b/examples/tasks/mock_tagged-file.json
@@ -30,7 +30,7 @@
                     "process": null,
                     "publish": [
                         {
-                            "plugin_name": "mock-file",                            
+                            "plugin_name": "file",                            
                             "config": {
                                 "file": "/tmp/snap_published_mock_file.log"
                             }


### PR DESCRIPTION
Fixes #1141 

Summary of changes:
- Changed all references to publisher plugins in examples/tasks to reference "file" publisher rather than "mock-file"
- Tasks are now consistent with the top-level README.md and won't run tasks that call plugins that haven't been loaded as per README instructions

Testing done:
- Verified that the examples in top-level README now work

@intelsdi-x/snap-maintainers