### PR TITLE
Fixed Bug #1042 Snapctl error message should truncate

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -56,6 +56,9 @@ var (
 					Name:   "list",
 					Usage:  "list",
 					Action: listTask,
+					Flags: []cli.Flag{
+						flVerbose,
+					},
 				},
 				{
 					Name:   "start",


### PR DESCRIPTION
Fixes #1042 

Summary of changes:
-  Long error messages will not wrap any more unless --verbose is specified
-  Error will display until edge of terminal window and end with '...'
-  If terminal is large enough for whole error message or --verbose is specified, whole error message will be shown

Testing done:
-  Tested with mock-file.yaml and mock.go to display error messages of varying length

@intelsdi-x/snap-maintainers

Error message size adjusts based on size of terminal so that it does not wrap.