### PR TITLE
Fixed named list returned by metric API

### DIFF
--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -70,7 +70,7 @@ func listMetrics(ctx *cli.Context) error {
 
 		printFields(w, false, 0, "NAMESPACE", "VERSION", "UNIT", "DESCRIPTION")
 		for _, mt := range mts.Catalog {
-			namespace := getNamespace(mt)
+			namespace := getNamespace(&mt)
 			printFields(w, false, 0, namespace, mt.Version, mt.Unit, mt.Description)
 		}
 		w.Flush()

--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -246,64 +246,35 @@ _**Example Response**_
     "type": "metrics_returned",
     "version": 1
   },
-  "body": [
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/*/baz",
-      "version": 1
-    },
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/*/baz",
-      "version": 2
-    },
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/bar",
-      "version": 1
-    },
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/bar",
-      "version": 2
-    },
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/foo",
-      "version": 1,
-      "policy": [
-        {
-          "name": "password",
-          "type": "string",
-          "required": true
-        },
-        {
-          "name": "name",
-          "type": "string",
-          "default": "bob",
-          "required": false
-        }
-      ]
-    },
-    {
-      "last_advertised_timestamp": 1447977606,
-      "namespace": "/intel/mock/foo",
-      "version": 2,
-      "policy": [
-        {
-          "name": "name",
-          "type": "string",
-          "default": "bob",
-          "required": false
-        },
-        {
-          "name": "password",
-          "type": "string",
-          "required": true
-        }
-      ]
-    }
-  ]
+"body": {
+    "metrics": [
+      {
+        "last_advertised_timestamp": 1472667089,
+        "namespace": "/intel/anothermock/*/baz",
+        "version": 1,
+        "dynamic": true,
+        "dynamic_elements": [
+          {
+            "index": 2,
+            "name": "host",
+            "description": "name of the host"
+          }
+        ],
+        "description": "anothermock description",
+        "unit": "anothermock unit",
+        "href": "http://localhost:8181/v1/metrics?ns=%2Fintel%2Fanothermock%2F%2A%2Fbaz&ver=1"
+      },
+      {
+        "last_advertised_timestamp": 1472667089,
+        "namespace": "/intel/anothermock/bar",
+        "version": 1,
+        "dynamic": false,
+        "description": "anothermock description",
+        "unit": "anothermock unit",
+        "href": "http://localhost:8181/v1/metrics?ns=%2Fintel%2Fanothermock%2Fbar&ver=1"
+      }
+    ]
+  }
 }
 ```
 **GET /v1/metrics/:namespace**:

--- a/mgmt/rest/client/metric.go
+++ b/mgmt/rest/client/metric.go
@@ -68,7 +68,7 @@ func (c *Client) FetchMetrics(ns string, ver int) *GetMetricsResult {
 		r.Catalog = convertCatalog(mc)
 	case rbody.MetricReturnedType:
 		mc := resp.Body.(*rbody.MetricReturned)
-		r.Catalog = []*rbody.Metric{mc.Metric}
+		r.Catalog = []rbody.Metric{*mc.Metric}
 	case rbody.ErrorType:
 		r.Err = resp.Body.(*rbody.Error)
 	default:
@@ -129,7 +129,7 @@ func (c *Client) GetMetric(ns string, ver int) interface{} {
 
 // GetMetricsResult is the response from snap/client on a GetMetricCatalog call.
 type GetMetricsResult struct {
-	Catalog []*rbody.Metric
+	Catalog []rbody.Metric
 	Err     error
 }
 
@@ -144,19 +144,19 @@ func (g *GetMetricsResult) Len() int {
 	return len(g.Catalog)
 }
 
-func convertCatalog(c *rbody.MetricsReturned) []*rbody.Metric {
-	mci := make([]*rbody.Metric, len(*c))
-	for i := range *c {
-		mci[i] = &(*c)[i]
+func convertCatalog(c *rbody.MetricsReturned) []rbody.Metric {
+	mci := rbody.MetricList{Metrics: make([]rbody.Metric, len(c.Metrics))}
+	for i := range c.Metrics {
+		mci.Metrics[i] = c.Metrics[i]
 	}
-	return mci
+	return mci.Metrics
 }
 
-func convertMetrics(c *rbody.MetricsReturned) []*GetMetricResult {
-	mci := make([]*GetMetricResult, len(*c))
-	for i, _ := range *c {
-		r := &GetMetricResult{Metric: &(*c)[i]}
-		mci[i] = r
+func convertMetrics(c *rbody.MetricsReturned) []GetMetricResult {
+	mci := make([]GetMetricResult, len(c.Metrics))
+	for i, _ := range c.Metrics {
+		r := &GetMetricResult{Metric: &c.Metrics[i]}
+		mci[i] = *r
 	}
 	return mci
 }

--- a/mgmt/rest/metric.go
+++ b/mgmt/rest/metric.go
@@ -192,7 +192,7 @@ func respondWithMetrics(host string, mets []core.CatalogedMetric, w http.Respons
 		if dyn {
 			dynamicElements = getDynamicElements(met.Namespace(), indexes)
 		}
-		b = append(b, rbody.Metric{
+		b.Metrics = append(b.Metrics, rbody.Metric{
 			Namespace:               met.Namespace().String(),
 			Version:                 met.Version(),
 			LastAdvertisedTimestamp: met.LastAdvertisedTime().Unix(),

--- a/mgmt/rest/rbody/metric.go
+++ b/mgmt/rest/rbody/metric.go
@@ -47,6 +47,10 @@ type Metric struct {
 	Href                    string           `json:"href"`
 }
 
+type MetricList struct {
+	Metrics []Metric `json:"metrics,omitempty"`
+}
+
 type DynamicElement struct {
 	Index       int    `json:"index,omitempty"`
 	Name        string `json:"name,omitempty"`
@@ -65,22 +69,22 @@ func (m *MetricReturned) ResponseBodyType() string {
 	return MetricReturnedType
 }
 
-type MetricsReturned []Metric
+type MetricsReturned MetricList
 
 func (m MetricsReturned) Len() int {
-	return len(m)
+	return len(m.Metrics)
 }
 
 func (m MetricsReturned) Less(i, j int) bool {
-	return (fmt.Sprintf("%s:%d", m[i].Namespace, m[i].Version)) < (fmt.Sprintf("%s:%d", m[j].Namespace, m[j].Version))
+	return (fmt.Sprintf("%s:%d", m.Metrics[i].Namespace, m.Metrics[i].Version)) < (fmt.Sprintf("%s:%d", m.Metrics[j].Namespace, m.Metrics[j].Version))
 }
 
 func (m MetricsReturned) Swap(i, j int) {
-	m[i], m[j] = m[j], m[i]
+	m.Metrics[i], m.Metrics[j] = m.Metrics[j], m.Metrics[i]
 }
 
 func NewMetricsReturned() MetricsReturned {
-	return make([]Metric, 0)
+	return MetricsReturned{Metrics: []Metric{}}
 }
 
 func (m MetricsReturned) ResponseBodyMessage() string {


### PR DESCRIPTION
Fixes #730 

Summary of changes:
- Added MetricList struct to rbody/metric.go
- Updated the return for “GET /v1/metrics” call so that it follows same format as other calls such as "/v1/plugins" and "/v1/tasks". 

**"GET /v1/plugins"**
```
“body”: {
    “loaded_plugins”: [...]
}
```
**"GET /v1/tasks"**
```
“body”: {
    “ScheduledTasks”: [...]
}
```
**Before: "GET /v1/plugins"**
```
“body”: {
    [
    {
      "last_advertised_timestamp": 1447977606,
      "namespace": "/intel/mock/*/baz",
      "version": 1
    },
    {
      "last_advertised_timestamp": 1447977606,
      "namespace": "/intel/mock/*/baz",
      "version": 2
    },...
   ]
}
```


**After: "GET /v1/metrics"**
```
“body”: {
    “metrics”: [
        {
        "last_advertised_timestamp": 1472667089,
        "namespace": "/intel/anothermock/*/baz",
        "version": 1,
        "dynamic": true,
        "dynamic_elements": [
          {
            "index": 2,
            "name": "host",
            "description": "name of the host"
          }
        ],
        "description": "anothermock description",
        "unit": "anothermock unit",
        "href": "http://localhost:8181/v1/metrics?ns=%2Fintel%2Fanothermock%2F%2A%2Fbaz&ver=1"
      },...
   ]
}
```

 

Testing done:
- Manual and unit tests

Note:
- Identified additional inconsistencies in API related to naming and I am opening another [issue](https://github.com/intelsdi-x/snap/issues/1172) to address this.

@intelsdi-x/snap-maintainers

-Added MetricList struct to rbody
-fixed returned body of "metrics_returned" in REST_API.md