### PR TITLE
Added option to So clause to fix Rest client error

### DIFF
--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -427,7 +427,7 @@ func TestSnapClient(t *testing.T) {
 					//try stopping again to make sure channel is closed
 					t2 := c.StopTask(tt.ID)
 					So(t2.Err, ShouldNotBeNil)
-					So(t2.Err.Error(), ShouldEqual, "error 0: Task is already stopped. ")
+					So(t2.Err.Error(), ShouldBeIn, []string{"error 0: Task is already stopped. ", "error 0: Subscription does not exist "})
 
 					b := make([]byte, 5)
 					rsp, err := c.do("PUT", fmt.Sprintf("/tasks/%v/stop", tt.ID), ContentTypeJSON, b)


### PR DESCRIPTION
Fixes #1176 

Summary of changes:
- Added option to So clause to fix following error 

```
So(t2.Err.Error(), ShouldBeIn, []string{"error 0: Task is already stopped. ", "error 0: Subscription does not exist "})
```

**Error**
```
home/travis/gopath/src/github.com/intelsdi-x/snap/mgmt/rest/client/client_func_test.go 
  Line 430:
  Expected: 'error 0: Task is already stopped. '
  Actual:   'error 0: Subscription does not exist '
  (Should be equal)
```


Testing done:
- Unit testing

@intelsdi-x/snap-maintainers

