### PR TITLE
gRPC version of mock-file publisher

### DIFF
--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/README.md
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/README.md
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/README.md
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/README.md
@@ -1,0 +1,18 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,10 +79,14 @@ func (f *filePublisher) Publish(metrics []plugin.Metric, config plugin.Config) e
 func (f *filePublisher) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
 	rule1, err := plugin.NewStringRule("file", true)
-	handleErr(err)
+	if err != nil {
+		return *policy, err
+	}
 
 	rule2, err := plugin.NewBoolRule(debug, false)
-	handleErr(err)
+	if err != nil {
+		return *policy, err
+	}
 
 	policy.AddStringRule([]string{""}, rule1)
 	policy.AddBoolRule([]string{}, rule2)
@@ -100,10 +104,4 @@ func formatMetricTagsAsString(metricTags map[string]string) string {
 	tags = strings.TrimSuffix(tags, "; ")
 
 	return "tags[" + tags + "]"
-}
-
-func handleErr(e error) {
-	if e != nil {
-		panic(e)
-	}
 }

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
@@ -1,0 +1,109 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+)
+
+const (
+	debug = "debug"
+)
+
+type filePublisher struct {
+}
+
+func NewFilePublisher() *filePublisher {
+	return &filePublisher{}
+}
+
+func (f *filePublisher) Publish(metrics []plugin.Metric, config plugin.Config) error {
+	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
+	if _, err := config.GetBool(debug); err == nil {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+	log.Debug("publishing started")
+
+	filename, err := config.GetString("file")
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+	defer file.Close()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	log.WithFields(log.Fields{
+		"file": filename,
+		"metrics-published-count": len(metrics),
+	}).Debug("metrics published")
+	w := bufio.NewWriter(file)
+	for _, m := range metrics {
+		formattedTags := formatMetricTagsAsString(m.Tags)
+		w.WriteString(fmt.Sprintf("%v|%v|%v|%v\n", m.Timestamp, m.Namespace, m.Data, formattedTags))
+	}
+	w.Flush()
+
+	return nil
+}
+
+func (f *filePublisher) GetConfigPolicy() (plugin.ConfigPolicy, error) {
+	policy := plugin.NewConfigPolicy()
+	rule1, err := plugin.NewStringRule("file", true)
+	handleErr(err)
+
+	rule2, err := plugin.NewBoolRule(debug, false)
+	handleErr(err)
+
+	policy.AddStringRule([]string{""}, rule1)
+	policy.AddBoolRule([]string{}, rule2)
+
+	return *policy, nil
+}
+
+// formatMetricTagsAsString returns metric's tags as a string in the following format tagKey:tagValue where the next tags are separated by semicolon
+func formatMetricTagsAsString(metricTags map[string]string) string {
+	var tags string
+	for tag, value := range metricTags {
+		tags += fmt.Sprintf("%s:%s; ", tag, value)
+	}
+	// trim the last semicolon
+	tags = strings.TrimSuffix(tags, "; ")
+
+	return "tags[" + tags + "]"
+}
+
+func handleErr(e error) {
+	if e != nil {
+		panic(e)
+	}
+}

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file_small_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file_small_test.go
@@ -1,0 +1,46 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFilePublish(t *testing.T) {
+	metrics := []plugin.Metric{plugin.Metric{Namespace: plugin.NewNamespace("foo"), Timestamp: time.Now(), Data: 99, Tags: nil}}
+	config := plugin.Config{"file": "/tmp/pub.out"}
+	Convey("TestFilePublish", t, func() {
+		fp := NewFilePublisher()
+		So(fp, ShouldNotBeNil)
+		err := fp.Publish(metrics, config)
+		So(err, ShouldBeNil)
+		filename, _ := config.GetString("file")
+		_, err = os.Stat(filename)
+		So(err, ShouldBeNil)
+	})
+}

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main.go
@@ -1,0 +1,34 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+	"github.com/intelsdi-x/snap/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file"
+)
+
+const (
+	pluginName    = "mock-file-grpc"
+	pluginVersion = 1
+)
+
+func main() {
+	plugin.StartPublisher(file.NewFilePublisher(), pluginName, pluginVersion)
+}

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_small_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_small_test.go
@@ -1,0 +1,36 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_small_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_small_test.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
@@ -1,0 +1,60 @@
+// +build legacy
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/plugin/helper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	PluginName = "snap-plugin-publisher-mock-file"
+	PluginType = "publisher"
+	SnapPath   = os.Getenv("SNAP_PATH")
+	PluginPath = path.Join(SnapPath, "plugin", PluginName)
+)
+
+func TestFilePublisherLoad(t *testing.T) {
+	// These tests only work if SNAP_PATH is known.
+	// It is the responsibility of the testing framework to
+	// build the plugins first into the build dir.
+
+	Convey("make sure plugin has been built", t, func() {
+		err := helper.CheckPluginBuilt(SnapPath, PluginName)
+		So(err, ShouldBeNil)
+
+		Convey("ensure plugin loads and responds", func() {
+			c := control.New(control.GetDefaultConfig())
+			c.Start()
+			rp, _ := core.NewRequestedPlugin(PluginPath)
+			_, err := c.Load(rp)
+
+			So(err, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
Introduces mock-file publisher implemented with usage of snap-plugin-lib-go

Summary of changes:
- full mock publisher implementation

Testing done:
- unit
- manual

@intelsdi-x/snap-maintainers

