### PR TITLE
gRPC version of passthru processor plugin

### DIFF
--- a/plugin/processor/snap-plugin-processor-passthru-grpc/main.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/main.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/main.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/main.go
@@ -1,0 +1,34 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+	"github.com/intelsdi-x/snap/plugin/processor/snap-plugin-processor-passthru-grpc/passthru"
+)
+
+const (
+	pluginName    = "passthru-grpc"
+	pluginVersion = 1
+)
+
+func main() {
+	plugin.StartProcessor(passthru.NewPassthruProcessor(), pluginName, pluginVersion)
+}

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
@@ -4,7 +4,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
@@ -1,0 +1,34 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
@@ -1,0 +1,69 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package passthru
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+)
+
+const (
+	debug = "debug"
+)
+
+func NewPassthruProcessor() *passthruProcessor {
+	return &passthruProcessor{}
+}
+
+type passthruProcessor struct{}
+
+func (p *passthruProcessor) GetConfigPolicy() (plugin.ConfigPolicy, error) {
+	policy := plugin.NewConfigPolicy()
+	rule, err := plugin.NewBoolRule(debug, false)
+	if err != nil {
+		panic(err)
+	}
+	policy.AddBoolRule([]string{""}, rule)
+	return *policy, nil
+}
+
+func (p *passthruProcessor) Process(metrics []plugin.Metric, config plugin.Config) ([]plugin.Metric, error) {
+	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
+	if _, err := config.GetBool(debug); err == nil {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
+
+	log.Debug("processing started")
+
+	if _, err := config.GetBool("test"); err == nil {
+		log.Debug("test configuration found")
+		for idx, m := range metrics {
+			if m.Namespace.Strings()[0] == "foo" {
+				log.Print("found foo metric")
+				metrics[idx].Data = 2
+			}
+		}
+	}
+
+	return metrics, nil
+}

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
@@ -39,7 +39,7 @@ func (p *passthruProcessor) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
 	rule, err := plugin.NewBoolRule(debug, false)
 	if err != nil {
-		panic(err)
+		return *policy, err
 	}
 	policy.AddBoolRule([]string{""}, rule)
 	return *policy, nil


### PR DESCRIPTION
Introduces passhthru processor implemented with usage of snap-plugin-lib-go

Summary of changes:
- full passthru processor

Testing done:
- unit
- manual@intelsdi-x/snap-maintainers

