### PR TITLE
Fix #1130: Validate task workflow and schedule when creating task request.

### DIFF
--- a/core/task.go
+++ b/core/task.go
@@ -161,7 +161,7 @@ type TaskCreationRequest struct {
 	Version     int               `json:"version"`
 	Deadline    string            `json:"deadline"`
 	Workflow    *wmap.WorkflowMap `json:"workflow"`
-	Schedule    Schedule          `json:"schedule"`
+	Schedule    *Schedule         `json:"schedule"`
 	Start       bool              `json:"start"`
 	MaxFailures int               `json:"max-failures"`
 }
@@ -224,7 +224,11 @@ func CreateTaskFromContent(body io.ReadCloser,
 		return nil, err
 	}
 
-	sch, err := makeSchedule(tr.Schedule)
+	if err := validateTaskRequest(tr); err != nil {
+		return nil, err
+	}
+
+	sch, err := makeSchedule(*tr.Schedule)
 	if err != nil {
 		return nil, err
 	}
@@ -284,4 +288,15 @@ func UnmarshalBody(in interface{}, body io.ReadCloser) (int, error) {
 		return 400, err
 	}
 	return 0, nil
+}
+
+func validateTaskRequest(tr *TaskCreationRequest) error {
+	if tr.Schedule == nil || *tr.Schedule == (Schedule{}) {
+		return fmt.Errorf("Task must include a schedule, and the schedule must not be empty")
+	}
+
+	if tr.Workflow == nil || *tr.Workflow == (wmap.WorkflowMap{}) {
+		return fmt.Errorf("Task must include a workflow, and the workflow must not be empty")
+	}
+	return nil
 }

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -50,7 +50,7 @@ type Schedule struct {
 // A ScheduledTask is returned if it succeeds, otherwise an error is returned.
 func (c *Client) CreateTask(s *Schedule, wf *wmap.WorkflowMap, name string, deadline string, startTask bool, maxFailures int) *CreateTaskResult {
 	t := core.TaskCreationRequest{
-		Schedule: core.Schedule{
+		Schedule: &core.Schedule{
 			Type:     s.Type,
 			Interval: s.Interval,
 		},

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -252,7 +252,7 @@ func createTask(sample, name, interval string, noStart bool, port int) *rbody.AP
 	uri := fmt.Sprintf("http://localhost:%d/v1/tasks", port)
 
 	t := core.TaskCreationRequest{
-		Schedule: core.Schedule{Type: "simple", Interval: interval},
+		Schedule: &core.Schedule{Type: "simple", Interval: interval},
 		Workflow: wf,
 		Name:     name,
 		Start:    !noStart,


### PR DESCRIPTION
Fixes #1130

Summary of changes:
- Validates workflow to not be nil or empty
- Validate schedule to not be nil or empty

Testing done:
- Validated proper error was returned when trying to create a task without a workflow or schedule.
- Verified tests pass.

@intelsdi-x/snap-maintainers

request.