### PR TITLE
Added functionality for environment variables in SNAP_PATH

### DIFF
--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	PluginName = "snap-plugin-collector-mock2"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 
 	JSONRPCPluginName = "snap-plugin-collector-mock1"

--- a/control/subscription_group_medium_test.go
+++ b/control/subscription_group_medium_test.go
@@ -128,7 +128,7 @@ func TestSubscriptionGroups_ProcessStaticNegative(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -162,7 +162,7 @@ func TestSubscriptionGroups_ProcessStaticNegative(t *testing.T) {
 					config:   cdata.NewNode(),
 				}
 
-				_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-anothermock1"))
+				_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-anothermock1"))
 				So(err, ShouldBeNil)
 				<-lpe.load
 				serrs := sg.Process()
@@ -191,7 +191,7 @@ func TestSubscriptionGroups_ProcessStaticPositive(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -224,7 +224,7 @@ func TestSubscriptionGroups_ProcessStaticPositive(t *testing.T) {
 					version:  2,
 					config:   cdata.NewNode(),
 				}
-				_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock2"))
+				_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock2"))
 				So(err, ShouldBeNil)
 				<-lpe.load
 				serrs := sg.Process()
@@ -253,7 +253,7 @@ func TestSubscriptionGroups_ProcessDynamicPositive(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -287,7 +287,7 @@ func TestSubscriptionGroups_ProcessDynamicPositive(t *testing.T) {
 					version:  1,
 					config:   cdata.NewNode(),
 				}
-				_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-anothermock1"))
+				_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-anothermock1"))
 				So(err, ShouldBeNil)
 				<-lpe.load
 				serrs := sg.Process()
@@ -318,7 +318,7 @@ func TestSubscriptionGroups_ProcessDynamicNegative(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -352,7 +352,7 @@ func TestSubscriptionGroups_ProcessDynamicNegative(t *testing.T) {
 					version:  1,
 					config:   cdata.NewNode(),
 				}
-				_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-anothermock1"))
+				_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-anothermock1"))
 				So(err, ShouldBeNil)
 				<-lpe.load
 				serrs := sg.Process()
@@ -383,7 +383,7 @@ func TestSubscriptionGroups_AddRemoveStatic(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -422,7 +422,7 @@ func TestSubscriptionGroups_AddRemoveDynamic(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -464,7 +464,7 @@ func TestSubscriptionGroups_GetStatic(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 
@@ -509,7 +509,7 @@ func TestSubscriptionGroups_GetDynamic(t *testing.T) {
 	c.Start()
 
 	Convey("Loading a mock collector plugn", t, func() {
-		_, err := loadPlg(c, path.Join(os.Getenv("SNAP_PATH"), "plugin", "snap-plugin-collector-mock1"))
+		_, err := loadPlg(c, path.Join(os.ExpandEnv(os.Getenv("SNAP_PATH")), "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		<-lpe.load
 

--- a/core/plugin_test.go
+++ b/core/plugin_test.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	PluginName    = "snap-plugin-collector-mock1"
-	SnapPath      = os.Getenv("SNAP_PATH")
+	SnapPath      = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath    = path.Join(SnapPath, "plugin", PluginName)
 	SignatureFile = path.Join(SnapPath, "../pkg/psigning", "snap-plugin-collector-mock1.asc")
 )

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -45,7 +45,7 @@ var (
 	// Change to set the REST API logging to debug
 	LOG_LEVEL = log.FatalLevel
 
-	SNAP_PATH               = os.Getenv("SNAP_PATH")
+	SNAP_PATH               = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	MOCK_PLUGIN_PATH1       = []string{SNAP_PATH + "/plugin/snap-plugin-collector-mock1"}
 	MOCK_PLUGIN_PATH2       = []string{SNAP_PATH + "/plugin/snap-plugin-collector-mock2"}
 	ANOTHERMOCK_PLUGIN_PATH = []string{SNAP_PATH + "/plugin/snap-plugin-collector-anothermock1"}

--- a/mgmt/rest/rest_func_test.go
+++ b/mgmt/rest/rest_func_test.go
@@ -55,7 +55,7 @@ var (
 	// Switching this turns on logging for all the REST API calls
 	LOG_LEVEL = log.WarnLevel
 
-	SNAP_PATH              = os.Getenv("SNAP_PATH")
+	SNAP_PATH              = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	SNAP_AUTODISCOVER_PATH = os.Getenv("SNAP_AUTODISCOVER_PATH")
 	MOCK_PLUGIN_PATH1      = SNAP_PATH + "/plugin/snap-plugin-collector-mock1"
 	MOCK_PLUGIN_PATH2      = SNAP_PATH + "/plugin/snap-plugin-collector-mock2"

--- a/pkg/psigning/psigning_test.go
+++ b/pkg/psigning/psigning_test.go
@@ -34,7 +34,7 @@ func TestValidateSignature(t *testing.T) {
 	keyringFile := []string{"pubring.gpg"}
 	signedFile := "snap-plugin-collector-mock1"
 	signatureFile := signedFile + ".asc"
-	snapPath := os.Getenv("SNAP_PATH")
+	snapPath := os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	unsignedFile := path.Join(snapPath, "plugin", "snap-plugin-collector-mock2")
 	s := SigningManager{}
 

--- a/plugin/collector/snap-plugin-collector-anothermock1/main_test.go
+++ b/plugin/collector/snap-plugin-collector-anothermock1/main_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	PluginName = "snap-plugin-collector-anothermock1"
 	PluginType = "collector"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/collector/snap-plugin-collector-mock1/main_test.go
+++ b/plugin/collector/snap-plugin-collector-mock1/main_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	PluginName = "snap-plugin-collector-mock1"
 	PluginType = "collector"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/collector/snap-plugin-collector-mock2/main_test.go
+++ b/plugin/collector/snap-plugin-collector-mock2/main_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	PluginName = "snap-plugin-collector-mock2"
 	PluginType = "collector"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	PluginName = "snap-plugin-publisher-mock-file"
 	PluginType = "publisher"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/plugin/publisher/snap-plugin-publisher-mock-file/main_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file/main_test.go
@@ -35,7 +35,7 @@ import (
 var (
 	PluginName = "snap-plugin-publisher-mock-file"
 	PluginType = "publisher"
-	SnapPath   = os.Getenv("SNAP_PATH")
+	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)
 )
 

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -47,7 +47,7 @@ import (
 )
 
 var (
-	SnapPath                     = os.Getenv("SNAP_PATH")
+	SnapPath                     = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	snap_collector_mock1_path    = path.Join(SnapPath, "plugin", "snap-plugin-collector-mock1")
 	snap_collector_mock2_path    = path.Join(SnapPath, "plugin", "snap-plugin-collector-mock2")
 	snap_processor_passthru_path = path.Join(SnapPath, "plugin", "snap-plugin-processor-passthru")


### PR DESCRIPTION
Fixes #1184 

Summary of changes:
- Wrapped each call to `os.Getenv("SNAP_PATH")` with `os.ExpandEnv(..)`
- Now Snap_Paths that have variables such as the one below are interpreted correctly.
`\$GVM_ROOT/pkgsets/\$gvm_go_name/\$gvm_pkgset_name/src/github.com/intelsdi-x/snap/build`


Testing done:
- Unit testing

@intelsdi-x/snap-maintainers

