### PR TITLE
Enforce timeouts in plugin clients

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	// DefaultClientTimeout - default timeout for a client connection attempt
-	DefaultClientTimeout = time.Second * 3
+	DefaultClientTimeout = time.Second * 10
 	// DefaultHealthCheckTimeout - default timeout for a health check
 	DefaultHealthCheckTimeout = time.Second * 1
 	// DefaultHealthCheckFailureLimit - how any consecutive health check timeouts must occur to trigger a failure

--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -168,7 +168,6 @@ func (p *PluginNativeClient) Publish(metrics []core.Metric, config map[string]ct
 	err = p.connection.Call("Publisher.Publish", out, &reply)
 	close(done)
 	return err
-	return nil
 }
 
 func (p *PluginNativeClient) Process(metrics []core.Metric, config map[string]ctypes.ConfigValue) ([]core.Metric, error) {

--- a/control/runner.go
+++ b/control/runner.go
@@ -57,7 +57,6 @@ const (
 	MaxPluginRestartCount = 3
 )
 
-// TBD
 type executablePlugin interface {
 	Run(time.Duration) (plugin.Response, error)
 	Kill() error

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/main_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	PluginName = "snap-plugin-publisher-mock-file"
+	PluginName = "snap-plugin-publisher-mock-file-grpc"
 	PluginType = "publisher"
 	SnapPath   = os.ExpandEnv(os.Getenv("SNAP_PATH"))
 	PluginPath = path.Join(SnapPath, "plugin", PluginName)


### PR DESCRIPTION
Fixes #1142

Summary of changes:
- Adds handling of the timeout to the native go client which enforces that each
request for {collect, process, publish} finishes in this amount of time.
- Ups the default client timeout to 10 seconds.
- General code cleanup on some things I noticed while making the other changes. Put as separate commit for easier review.

Testing done:
- make test-{legacy,medium, small}
- Manual testing to ensure that a hanging plugin is eventually killed

Future plans:
- The client timeout probably needs to be configurable per-plugin since any value we pick is going to be incorrect for some plugins. (https://github.com/intelsdi-x/snap/issues/1208)

@intelsdi-x/snap-maintainers
