### PR TITLE
Added a warning when plugin name is uppercase

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -85,6 +85,14 @@ func newLoadedPlugins() *loadedPlugins {
 
 // add adds a loadedPlugin pointer to the table
 func (l *loadedPlugins) add(lp *loadedPlugin) serror.SnapError {
+	lowerName := strings.ToLower(lp.Meta.Name)
+	if lowerName != lp.Meta.Name {
+		controlLogger.WithFields(log.Fields{
+			"plugin-name":    lp.Meta.Name,
+			"plugin-version": lp.Meta.Version,
+			"plugin-type":    lp.Type.String(),
+		}).Warning("DEPRECATED: the name of the plugin is in uppercase, the next version of Snap will not support it anymore.")
+	}
 	l.Lock()
 	defer l.Unlock()
 


### PR DESCRIPTION
Fixes #1178 

Summary of changes:
- Added a warning when a a plugin with uppercase characters is added.

Testing done:
- Renamed a plugin name (e.g. the Snap publisher) and load it.
```bash
$ snapctl plugin load snap-plugin-publisher-file
WARN[2016-09-09T10:20:25-07:00] DEPRECATED: the name of the plugin is in uppercase, the next version of Snap will not support it anymore.  _module=control plugin-name=filE plugin-type=publisher plugin-version=2
```

@intelsdi-x/snap-maintainers

