### PR TITLE
Make plugin name not case sensitive

### DIFF
--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os/exec"
 	"path"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -146,6 +147,16 @@ func (e *ExecutablePlugin) Run(timeout time.Duration) (Response, error) {
 		// Kill the plugin if we failed to load it.
 		e.Kill()
 	}
+	lowerName := strings.ToLower(resp.Meta.Name)
+	if lowerName != resp.Meta.Name {
+		execLogger.WithFields(log.Fields{
+			"plugin-name":    resp.Meta.Name,
+			"plugin-version": resp.Meta.Version,
+			"plugin-type":    resp.Type.String(),
+		}).Warning("uppercase plugin name")
+	}
+	resp.Meta.Name = lowerName
+
 	return resp, err
 }
 

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -21,6 +21,7 @@ package scheduler
 
 import (
 	"errors"
+	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -133,6 +134,7 @@ func convertProcessNode(pr []wmap.ProcessWorkflowMapNode) ([]*processNode, error
 		if p.Version < 1 {
 			p.Version = -1
 		}
+		p.Name = strings.ToLower(p.Name)
 		prNodes[i] = &processNode{
 			name:         p.Name,
 			version:      p.Version,
@@ -148,6 +150,7 @@ func convertProcessNode(pr []wmap.ProcessWorkflowMapNode) ([]*processNode, error
 func convertPublishNode(pu []wmap.PublishWorkflowMapNode) ([]*publishNode, error) {
 	puNodes := make([]*publishNode, len(pu))
 	for i, p := range pu {
+
 		cdn, err := p.GetConfigNode()
 		if err != nil {
 			return nil, err
@@ -158,6 +161,7 @@ func convertPublishNode(pu []wmap.PublishWorkflowMapNode) ([]*publishNode, error
 		if p.Version < 1 {
 			p.Version = -1
 		}
+		p.Name = strings.ToLower(p.Name)
 		puNodes[i] = &publishNode{
 			name:    p.Name,
 			version: p.Version,


### PR DESCRIPTION
Fixes #1178 

Summary of changes:
- Display a warning every time a plugin with uppercase characters is loaded, or used from a task.
- Convert the plugin name to lowercase when loaded in the plugin catalog.
- Convert the plugin names to lowercase when a task is created.

Testing done:
- Loaded a plugin with a correct name (e.g. "file"), and run a task with it (e.g. "file")==> no warning.
- Loaded a plugin with an incorrect name (e.g. "FILE"), and run a task with an incorrect name (e.g. "FILE")==> Warning when loading, `snapctl plugin list` shows a lowercase name, second warning when loading the task.
- Loaded a plugin with an incorrect name (e.g. "FILE"), and run a task with the correct name (e.g. "file")==> Warning when loading, `snapctl plugin list` shows a lowercase name, still display the second warning when loading the task.
- Loaded a plugin with a correct name (e.g. "file"), and run a task with an incorrect name (e.g. "FILE")==> no warning.

@intelsdi-x/snap-maintainers

All plugins names will load as lower case, even if they have an upper case in them.