### PR TITLE
Properly logs reason for killing a plugin.

### DIFF
--- a/control/plugin/session.go
+++ b/control/plugin/session.go
@@ -134,7 +134,7 @@ func (s *SessionState) Kill(args []byte, reply *[]byte) error {
 	if err != nil {
 		return err
 	}
-	s.logger.Debug("Kill called by agent, reason: %s\n", a.Reason)
+	s.logger.Debugf("Kill called by agent, reason: %s\n", a.Reason)
 	go func() {
 		time.Sleep(time.Second * 2)
 		s.killChan <- 0


### PR DESCRIPTION
Summary of changes:
- Change `Debug` to `Debugf` to properly print out kill reason. Example output change:

Before:
```
DEBU[2016-09-09T15:34:10-07:00] Kill called by agent, reason: %s              _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
```

After:
```
DEBU[2016-09-09T15:39:34-07:00] Kill called by agent, reason: Retrieved necessary plugin info  _module=plugin-exec io=stderr plugin=snap-plugin-publisher-mock-file
```
 

Testing done:
- Manual testing

@intelsdi-x/snap-maintainers

