### PR TITLE
Add an arbitrary separator for plugin keys

### DIFF
--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/intelsdi-x/snap/control/fixtures"
 	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -84,7 +85,7 @@ func TestAvailablePlugins(t *testing.T) {
 			err := aps.insert(ap)
 			So(err, ShouldBeNil)
 
-			pool, err := aps.getPool("collector:test:1")
+			pool, err := aps.getPool("collector" + core.Separator + "test" + core.Separator + "1")
 			So(err, ShouldBeNil)
 			nap, ok := pool.Plugins()[ap.id]
 			So(ok, ShouldBeTrue)

--- a/control/config.go
+++ b/control/config.go
@@ -433,7 +433,7 @@ func (p *pluginConfig) deletePluginConfigDataNodeField(pluginType core.PluginTyp
 
 func (p *pluginConfig) getPluginConfigDataNode(pluginType core.PluginType, name string, ver int) *cdata.ConfigDataNode {
 	// check cache
-	key := fmt.Sprintf("%d:%s:%d", pluginType, name, ver)
+	key := fmt.Sprintf("%d"+core.Separator+"%s"+core.Separator+"%d", pluginType, name, ver)
 	if res, ok := p.pluginCache[key]; ok {
 		return res
 	}

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -812,7 +812,7 @@ func TestMetricConfig(t *testing.T) {
 			So(errs, ShouldBeNil)
 		})
 		Convey("So mock should have name: bob config from defaults", func() {
-			So(c.Config.Plugins.pluginCache["0:mock:1"].Table()["name"], ShouldResemble, ctypes.ConfigValueStr{Value: "bob"})
+			So(c.Config.Plugins.pluginCache["0"+core.Separator+"mock"+core.Separator+"1"].Table()["name"], ShouldResemble, ctypes.ConfigValueStr{Value: "bob"})
 		})
 
 		c.Stop()
@@ -892,10 +892,10 @@ func TestRoutingCachingStrategy(t *testing.T) {
 		cdt.Add([]string{"intel", "mock"}, node)
 
 		Convey("Start the plugins", func() {
-			lp, err := c.pluginManager.get("collector:mock:2")
+			lp, err := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(err, ShouldBeNil)
 			So(lp, ShouldNotBeNil)
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			So(pool, ShouldNotBeNil)
 			tasks := []string{
@@ -964,10 +964,10 @@ func TestRoutingCachingStrategy(t *testing.T) {
 		cdt.Add([]string{"intel", "mock"}, node)
 
 		Convey("Start the plugins", func() {
-			lp, err := c.pluginManager.get("collector:mock:1")
+			lp, err := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(err, ShouldBeNil)
 			So(lp, ShouldNotBeNil)
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			time.Sleep(1 * time.Second)
 			So(errp, ShouldBeNil)
 			So(pool, ShouldNotBeNil)
@@ -1055,10 +1055,10 @@ func TestCollectDynamicMetrics(t *testing.T) {
 		cdt := cdata.NewTree()
 
 		Convey("collects metrics from plugin using native client", func() {
-			lp, err := c.pluginManager.get("collector:mock:2")
+			lp, err := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(err, ShouldBeNil)
 			So(lp, ShouldNotBeNil)
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			So(pool, ShouldNotBeNil)
 			taskID := uuid.New()
@@ -1149,12 +1149,12 @@ func TestFailedPlugin(t *testing.T) {
 		So(serrs, ShouldBeNil)
 
 		// retrieve loaded plugin
-		lp, err := c.pluginManager.get("collector:mock:2")
+		lp, err := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "2")
 		So(err, ShouldBeNil)
 		So(lp, ShouldNotBeNil)
 
 		Convey("create a pool, add subscriptions and start plugins", func() {
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			Convey("collect metrics against a plugin that will panic", func() {
 				So(pool.Count(), ShouldEqual, 1)
@@ -1230,7 +1230,7 @@ func TestCollectMetrics(t *testing.T) {
 		}
 
 		// retrieve loaded plugin
-		lp, err := c.pluginManager.get("collector:mock:1")
+		lp, err := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err, ShouldBeNil)
 		So(lp, ShouldNotBeNil)
 
@@ -1250,7 +1250,7 @@ func TestCollectMetrics(t *testing.T) {
 			serrs = c.SubscribeDeps(taskNonHit, r, []core.SubscribedPlugin{subscribedPlugin{typeName: "collector", name: "mock", version: 1}}, cdt)
 			So(serrs, ShouldBeNil)
 
-			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 
 			Convey("collect metrics", func() {
@@ -1298,7 +1298,7 @@ func TestPublishMetrics(t *testing.T) {
 		So(err, ShouldBeNil)
 		<-lpe.done
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("publisher:mock-file:3")
+		lp, err2 := c.pluginManager.get("publisher" + core.Separator + "mock-file" + core.Separator + "3")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "mock-file")
 		So(lp.ConfigPolicy, ShouldNotBeNil)
@@ -1345,7 +1345,7 @@ func TestProcessMetrics(t *testing.T) {
 		So(err, ShouldBeNil)
 		<-lpe.done
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("processor:passthru:1")
+		lp, err2 := c.pluginManager.get("processor" + core.Separator + "passthru" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "passthru")
 		So(lp.ConfigPolicy, ShouldNotBeNil)
@@ -1427,7 +1427,7 @@ func TestMetricSubscriptionToNewVersion(t *testing.T) {
 		<-lpe.load
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("collector:mock:1")
+		lp, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "mock")
 		//Subscribe deps to create pools.
@@ -1464,11 +1464,11 @@ func TestMetricSubscriptionToNewVersion(t *testing.T) {
 				So(false, ShouldEqual, true)
 			}
 
-			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool1.SubscriptionCount(), ShouldEqual, 0)
 
-			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			So(pool2.SubscriptionCount(), ShouldEqual, 1)
 
@@ -1493,7 +1493,7 @@ func TestMetricSubscriptionToOlderVersion(t *testing.T) {
 		<-lpe.load
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("collector:mock:2")
+		lp, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "2")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "mock")
 		requestedMetric := fixtures.NewMockRequestedMetric(
@@ -1539,11 +1539,11 @@ func TestMetricSubscriptionToOlderVersion(t *testing.T) {
 			var pool1 strategy.Pool
 			var errp error
 			ap := c.pluginRunner.AvailablePlugins()
-			pool1, errp = ap.getOrCreatePool("collector:mock:2")
+			pool1, errp = ap.getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			So(pool1.SubscriptionCount(), ShouldEqual, 0)
 
-			pool2, errp := ap.getOrCreatePool("collector:mock:1")
+			pool2, errp := ap.getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool2.SubscriptionCount(), ShouldEqual, 1)
 
@@ -1570,7 +1570,7 @@ func TestDynamicMetricSubscriptionLoad(t *testing.T) {
 		_, err := load(c, path.Join(fixtures.SnapPath, "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("collector:mock:1")
+		lp, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "mock")
 		//Subscribe deps to create pools.
@@ -1599,11 +1599,11 @@ func TestDynamicMetricSubscriptionLoad(t *testing.T) {
 			<-lpe.load // wait for load event
 			<-lpe.sub  // wait for subscription event
 
-			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool1.SubscriptionCount(), ShouldEqual, 1)
 
-			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:anothermock:1")
+			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "anothermock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool2.SubscriptionCount(), ShouldEqual, 1)
 
@@ -1627,10 +1627,10 @@ func TestDynamicMetricSubscriptionUnload(t *testing.T) {
 		_, err = load(c, path.Join(fixtures.SnapPath, "plugin", "snap-plugin-collector-anothermock1"))
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 2)
-		lpMock, err2 := c.pluginManager.get("collector:mock:1")
+		lpMock, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lpMock.Name(), ShouldResemble, "mock")
-		lpAMock, err3 := c.pluginManager.get("collector:anothermock:1")
+		lpAMock, err3 := c.pluginManager.get("collector" + core.Separator + "anothermock" + core.Separator + "1")
 		So(err3, ShouldBeNil)
 		So(lpAMock.Name(), ShouldResemble, "anothermock")
 
@@ -1665,7 +1665,7 @@ func TestDynamicMetricSubscriptionUnload(t *testing.T) {
 		So(errs, ShouldBeNil)
 		So(len(mts1), ShouldBeGreaterThan, 1)
 		Convey("Unloading mock plugin should remove its subscriptions", func() {
-			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool1.SubscriptionCount(), ShouldEqual, 1)
 			_, err = c.Unload(lpMock)
@@ -1673,7 +1673,7 @@ func TestDynamicMetricSubscriptionUnload(t *testing.T) {
 			<-lpe.unsub
 			<-lpe.sub
 			So(pool1.SubscriptionCount(), ShouldEqual, 0)
-			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:anothermock:1")
+			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "anothermock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool2.SubscriptionCount(), ShouldEqual, 1)
 			mts2, errs := c.CollectMetrics("testTaskID", nil)
@@ -1703,7 +1703,7 @@ func TestDynamicMetricSubscriptionLoadLessMetrics(t *testing.T) {
 		_, err := load(c, path.Join(fixtures.SnapPath, "plugin", "snap-plugin-collector-mock1"))
 		So(err, ShouldBeNil)
 		So(len(c.pluginManager.all()), ShouldEqual, 1)
-		lp, err2 := c.pluginManager.get("collector:mock:1")
+		lp, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lp.Name(), ShouldResemble, "mock")
 		//Subscribe deps to create pools.
@@ -1719,7 +1719,7 @@ func TestDynamicMetricSubscriptionLoadLessMetrics(t *testing.T) {
 		<-lpe.load // wait for load event
 		<-lpe.sub  // wait for subscription event
 		So(serr, ShouldBeNil)
-		lpMock, err2 := c.pluginManager.get("collector:mock:1")
+		lpMock, err2 := c.pluginManager.get("collector" + core.Separator + "mock" + core.Separator + "1")
 		So(err2, ShouldBeNil)
 		So(lpMock.Name(), ShouldResemble, "mock")
 		// collect metrics as a sanity check that everything is setup correctly
@@ -1747,11 +1747,11 @@ func TestDynamicMetricSubscriptionLoadLessMetrics(t *testing.T) {
 			<-lpe.load // wait for load event
 			<-lpe.sub  // wait for subscription event
 
-			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+			pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 			So(errp, ShouldBeNil)
 			So(pool1.SubscriptionCount(), ShouldEqual, 1)
 
-			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+			pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 			So(errp, ShouldBeNil)
 			So(pool2.SubscriptionCount(), ShouldEqual, 1)
 
@@ -1778,11 +1778,11 @@ func TestDynamicMetricSubscriptionLoadLessMetrics(t *testing.T) {
 				So(err, ShouldBeNil)
 				<-lpe.unsub
 
-				pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:1")
+				pool1, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "1")
 				So(errp, ShouldBeNil)
 				So(pool1.SubscriptionCount(), ShouldEqual, 0)
 
-				pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector:mock:2")
+				pool2, errp := c.pluginRunner.AvailablePlugins().getOrCreatePool("collector" + core.Separator + "mock" + core.Separator + "2")
 				So(errp, ShouldBeNil)
 				So(pool2.SubscriptionCount(), ShouldEqual, 1)
 

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -106,7 +106,7 @@ func (l *loadedPlugins) get(key string) (*loadedPlugin, error) {
 
 	lp, ok := l.table[key]
 	if !ok {
-		tnv := strings.Split(key, ":")
+		tnv := strings.Split(key, core.Separator)
 		if len(tnv) != 3 {
 			return nil, ErrBadKey
 		}
@@ -191,7 +191,7 @@ func (lp *loadedPlugin) PluginPath() string {
 
 // Key returns plugin type, name and version
 func (lp *loadedPlugin) Key() string {
-	return fmt.Sprintf("%s:%s:%d", lp.TypeName(), lp.Name(), lp.Version())
+	return fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", lp.TypeName(), lp.Name(), lp.Version())
 }
 
 // Version returns plugin version
@@ -496,7 +496,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 
 // UnloadPlugin unloads a plugin from the LoadedPlugins table
 func (p *pluginManager) UnloadPlugin(pl core.Plugin) (*loadedPlugin, serror.SnapError) {
-	plugin, err := p.loadedPlugins.get(fmt.Sprintf("%s:%s:%d", pl.TypeName(), pl.Name(), pl.Version()))
+	plugin, err := p.loadedPlugins.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pl.TypeName(), pl.Name(), pl.Version()))
 	if err != nil {
 		se := serror.New(ErrPluginNotFound, map[string]interface{}{
 			"plugin-name":    pl.Name(),

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -58,7 +58,7 @@ func TestLoadedPlugins(t *testing.T) {
 		Convey("returns an error when index is out of range", func() {
 			lp := newLoadedPlugins()
 
-			_, err := lp.get("not:found:1")
+			_, err := lp.get("not" + core.Separator + "found" + core.Separator + "1")
 			So(err, ShouldResemble, errors.New("plugin not found"))
 
 		})
@@ -183,7 +183,7 @@ func TestUnloadPlugin(t *testing.T) {
 
 					numPluginsLoaded := len(p.all())
 					So(numPluginsLoaded, ShouldEqual, 1)
-					lp, _ := p.get("collector:mock:2")
+					lp, _ := p.get("collector" + core.Separator + "mock" + core.Separator + "2")
 					_, err = p.UnloadPlugin(lp)
 
 					So(err, ShouldBeNil)
@@ -196,7 +196,7 @@ func TestUnloadPlugin(t *testing.T) {
 					p := newPluginManager()
 					p.SetMetricCatalog(newMetricCatalog())
 					lp, err := loadPlugin(p, fixtures.PluginPath)
-					glp, err2 := p.get("collector:mock:2")
+					glp, err2 := p.get("collector" + core.Separator + "mock" + core.Separator + "2")
 					So(err2, ShouldBeNil)
 					glp.State = DetectedState
 					_, err = p.UnloadPlugin(lp)
@@ -210,7 +210,7 @@ func TestUnloadPlugin(t *testing.T) {
 					p.SetMetricCatalog(newMetricCatalog())
 					_, err := loadPlugin(p, fixtures.PluginPath)
 
-					lp, err2 := p.get("collector:mock:2")
+					lp, err2 := p.get("collector" + core.Separator + "mock" + core.Separator + "2")
 					So(err2, ShouldBeNil)
 					_, err = p.UnloadPlugin(lp)
 

--- a/control/runner.go
+++ b/control/runner.go
@@ -339,7 +339,7 @@ func (r *runner) runPlugin(details *pluginDetails) error {
 }
 
 func (r *runner) handleUnsubscription(pType, pName string, pVersion int, taskID string) error {
-	pool, err := r.availablePlugins.getPool(fmt.Sprintf("%s:%s:%d", pType, pName, pVersion))
+	pool, err := r.availablePlugins.getPool(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pType, pName, pVersion))
 	if err != nil {
 		runnerLog.WithFields(log.Fields{
 			"_block":         "handle-unsubscription",

--- a/control/strategy/fixtures/fixtures.go
+++ b/control/strategy/fixtures/fixtures.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
 )
 
 const (
@@ -133,7 +134,7 @@ func (m MockAvailablePlugin) LastHit() time.Time {
 }
 
 func (m MockAvailablePlugin) String() string {
-	return strings.Join([]string{m.pluginType.String(), m.pluginName, strconv.Itoa(m.Version())}, ":")
+	return strings.Join([]string{m.pluginType.String(), m.pluginName, strconv.Itoa(m.Version())}, core.Separator)
 }
 
 func (m MockAvailablePlugin) Kill(string) error {

--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -126,7 +126,7 @@ type pool struct {
 }
 
 func NewPool(key string, plugins ...AvailablePlugin) (Pool, error) {
-	versl := strings.Split(key, ":")
+	versl := strings.Split(key, core.Separator)
 	ver, err := strconv.Atoi(versl[len(versl)-1])
 	if err != nil {
 		return nil, err

--- a/control/strategy/pool_test.go
+++ b/control/strategy/pool_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	. "github.com/intelsdi-x/snap/control/strategy/fixtures"
+	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/core/serror"
 	. "github.com/smartystreets/goconvey/convey"
@@ -108,7 +109,7 @@ func TestPoolCreation(t *testing.T) {
 	Convey("Given available collector type plugin", t, func() {
 		plg := NewMockAvailablePlugin()
 		Convey("When new plugin pool is being created with incorrect key", func() {
-			badKey := plg.TypeName() + ":" + plg.Name()
+			badKey := plg.TypeName() + core.Separator + plg.Name()
 			pool, err := NewPool(badKey, plg)
 			Convey("Then pool is not created, error is not nil", func() {
 				So(pool, ShouldBeNil)

--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -253,7 +253,7 @@ func (p *subscriptionGroups) validatePluginSubscription(pl core.SubscribedPlugin
 		"_block": "validate-plugin-subscription",
 		"plugin": fmt.Sprintf("%s:%d", pl.Name(), pl.Version()),
 	}).Info(fmt.Sprintf("validating dependencies for plugin %s:%d", pl.Name(), pl.Version()))
-	lp, err := p.pluginManager.get(fmt.Sprintf("%s:%s:%d", pl.TypeName(), pl.Name(), pl.Version()))
+	lp, err := p.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pl.TypeName(), pl.Name(), pl.Version()))
 	if err != nil {
 		se := serror.New(fmt.Errorf("Plugin not found: type(%s) name(%s) version(%d)", pl.TypeName(), pl.Name(), pl.Version()))
 		se.SetFields(map[string]interface{}{
@@ -394,7 +394,7 @@ func (s *subscriptionGroup) subscribePlugins(id string,
 			"_block":  "subscriptionGroup.subscribePlugins",
 		}).Debug("plugin subscription")
 		if sub.Version() < 1 {
-			latest, err := s.pluginManager.get(fmt.Sprintf("%s:%s:%d", sub.TypeName(),
+			latest, err := s.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", sub.TypeName(),
 				sub.Name(), sub.Version()))
 			if err != nil {
 				serrs = append(serrs, serror.New(err))
@@ -419,7 +419,7 @@ func (s *subscriptionGroup) subscribePlugins(id string,
 				}
 			}
 		} else {
-			pool, err := s.pluginRunner.AvailablePlugins().getOrCreatePool(fmt.Sprintf("%s:%s:%d",
+			pool, err := s.pluginRunner.AvailablePlugins().getOrCreatePool(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d",
 				sub.TypeName(), sub.Name(), sub.Version()))
 			if err != nil {
 				serrs = append(serrs, serror.New(err))
@@ -427,7 +427,7 @@ func (s *subscriptionGroup) subscribePlugins(id string,
 			}
 			pool.Subscribe(id)
 			if pool.Eligible() {
-				pl, err := s.pluginManager.get(fmt.Sprintf("%s:%s:%d",
+				pl, err := s.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d",
 					sub.TypeName(), sub.Name(), sub.Version()))
 				if err != nil {
 					serrs = append(serrs, serror.New(err))
@@ -465,7 +465,7 @@ func (p *subscriptionGroup) unsubscribePlugins(id string,
 			"_block":  "subscriptionGroup.unsubscribePlugins",
 		}).Debug("plugin unsubscription")
 		pool, err := p.pluginRunner.AvailablePlugins().getPool(
-			fmt.Sprintf("%s:%s:%d", plugin.TypeName(),
+			fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", plugin.TypeName(),
 				plugin.Name(), plugin.Version()))
 		if err != nil {
 			serrs = append(serrs, err)
@@ -555,5 +555,5 @@ func comparePlugins(newPlugins,
 }
 
 func key(p core.SubscribedPlugin) string {
-	return fmt.Sprintf("%v:%v:%v", p.TypeName(), p.Name(), p.Version())
+	return fmt.Sprintf("%v"+core.Separator+"%v"+core.Separator+"%v", p.TypeName(), p.Name(), p.Version())
 }

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,6 @@
+package core
+
+const (
+	// Separator is the default separator used in strings
+	Separator = "\U0001f422"
+)


### PR DESCRIPTION
Fixes #1198 

Summary of changes:
- Created an arbitrary separator as constant in `core.Separator`.
- Every time `:` was used as a separator for the plugin keys, the character has been changer by `core.Separator`.

Testing done:
- Build Snap.
- Load a plugin with a `:` character in the name.
- Load a plugin with a normal name.
- Display the catalog `snapctl plugin list`.
- Create a task with those 2 plugins.
- Stop this task.
- Unload the normal name plugin.
- Unload the special name plugin with `snapctl plugin unload -t <type> -n <name> -v <version>`.

@intelsdi-x/snap-maintainers

This separator is arbitrary enough to be unused in a plugin name. 🐢