### PR TITLE
Add glide.lock to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ gin-bin
 tags
 .vscode/
 vendor/
-glide.lock
 
 # we don't vendor godep _workspace
 **/Godeps/_workspace/**

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,142 @@
+hash: 8fe2627eadf03d4c3aa9f8fac38b26a29340921c25ccc5b62490f91824014ace
+updated: 2016-09-16T15:09:24.221590931-07:00
+imports:
+- name: github.com/appc/spec
+  version: db96f94ae6b227fe4d8288527ead8927181620f6
+  subpackages:
+  - aci
+  - pkg/device
+  - pkg/tarheader
+  - schema
+  - schema/common
+  - schema/types
+- name: github.com/armon/go-metrics
+  version: 3df31a1ada83e310c2e24b267c8e8b68836547b4
+- name: github.com/asaskevich/govalidator
+  version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
+- name: github.com/codegangsta/cli
+  version: 01857ac33766ce0c93856370626f9799281c14f4
+- name: github.com/codegangsta/negroni
+  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
+- name: github.com/coreos/go-semver
+  version: 6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa
+  subpackages:
+  - semver
+- name: github.com/dnsimple/dnsimple-go
+  version: a68f2550482a24820c47c7046bb87402a94ea299
+  subpackages:
+  - dnsimple
+- name: github.com/ghodss/yaml
+  version: c3eb24aeea63668ebdac08d2e252f20df8b6b1ae
+- name: github.com/gogo/protobuf
+  version: 82d16f734d6d871204a3feb1a73cb220cc92574c
+  subpackages:
+  - proto
+- name: github.com/golang/protobuf
+  version: 888eb0692c857ec880338addf316bd662d5e630e
+  subpackages:
+  - proto
+- name: github.com/google/go-querystring
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  subpackages:
+  - query
+- name: github.com/hashicorp/go-msgpack
+  version: fa3f63826f7c23912c15263591e65d54d080b458
+  subpackages:
+  - codec
+- name: github.com/hashicorp/memberlist
+  version: a93fbd426dd831f5a66db3adc6a5ffa6f44cc60a
+- name: github.com/intelsdi-x/gomit
+  version: db68f6fda248706a71980abc58e969fcd63f5ea6
+- name: github.com/intelsdi-x/snap-plugin-lib-go
+  version: 55956e53732655f4875708b15c25904090af41ec
+  subpackages:
+  - v1/plugin
+  - v1/plugin/rpc
+- name: github.com/intelsdi-x/snap-plugin-utilities
+  version: 925bafffac36edcfaf4aff937dcb7d3d5659782d
+- name: github.com/julienschmidt/httprouter
+  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/robfig/cron
+  version: 32d9c273155a0506d27cf73dd1246e86a470997e
+- name: github.com/Sirupsen/logrus
+  version: be52937128b38f1d99787bb476c789e2af1147f1
+- name: github.com/spf13/pflag
+  version: 94e98a55fb412fcbcfc302555cb990f5e1590627
+- name: github.com/vrischmann/jsonutil
+  version: 694784f9315ee9fc763c1d30f28753cba21307aa
+- name: github.com/xeipuuv/gojsonpointer
+  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
+- name: github.com/xeipuuv/gojsonreference
+  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+- name: github.com/xeipuuv/gojsonschema
+  version: d3178baac32433047aa76f07317f84fbe2be6cda
+- name: go4.org
+  version: 03efcb870d84809319ea509714dd6d19a1498483
+  subpackages:
+  - errorutil
+- name: golang.org/x/crypto
+  version: aedad9a179ec1ea11b7064c57cbc6dc30d7724ec
+  subpackages:
+  - cast5
+  - openpgp
+  - openpgp/armor
+  - openpgp/elgamal
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
+  - ssh/terminal
+- name: golang.org/x/net
+  version: 04557861f124410b768b1ba5bb3a91b705afbfc6
+  subpackages:
+  - context
+  - http2
+  - http2/hpack
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/sys
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  subpackages:
+  - unix
+- name: google.golang.org/grpc
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
+- name: k8s.io/kubernetes
+  version: 9625926852e215caa35e278c2cd7926744532291
+  subpackages:
+  - pkg/api/resource
+  - pkg/conversion
+  - third_party/forked/reflect
+testImports:
+- name: github.com/gopherjs/gopherjs
+  version: 4b53e1bddba0e2f734514aeb6c02db652f4c6fe8
+  subpackages:
+  - js
+- name: github.com/jtolds/gls
+  version: 8ddce2a84170772b95dd5d576c48d517b22cac63
+- name: github.com/smartystreets/assertions
+  version: 443d812296a84445c202c085f19e18fc238f8250
+  subpackages:
+  - internal/go-render/render
+  - internal/oglematchers
+- name: github.com/smartystreets/goconvey
+  version: 995f5b2e021c69b8b028ba6d0b05c1dd500783db
+  subpackages:
+  - convey
+  - convey/gotest
+  - convey/reporting

--- a/glide.yaml
+++ b/glide.yaml
@@ -52,3 +52,4 @@ import:
 - package: gopkg.in/yaml.v2
   version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
 - package: github.com/intelsdi-x/snap-plugin-lib-go
+- package: github.com/intelsdi-x/snap-plugin-utilities


### PR DESCRIPTION
Adds glide.lock file to the repository. `glide install` should now just look at this file for dependencies and load dependencies at the versions specified in the lock file.

@intelsdi-x/snap-maintainers

