### PR TITLE
Make hostname a stored variable so it is not retrieved for each metri…

### DIFF
--- a/control/metrics_small_test.go
+++ b/control/metrics_small_test.go
@@ -130,8 +130,8 @@ func TestContainsTupleNegative(t *testing.T) {
 
 type mockHostnameReader struct{}
 
-func (m *mockHostnameReader) Hostname() (string, error) {
-	return "hostname", nil
+func (m *mockHostnameReader) Hostname() string {
+	return "hostname"
 }
 
 type testCase struct {
@@ -141,7 +141,7 @@ type testCase struct {
 }
 
 func prepareTestCases() []testCase {
-	hostname, _ := hostnameReader.Hostname()
+	hostname := hostnameReader.Hostname()
 	fooTags := map[string]string{
 		"foo_tag": "foo_val",
 	}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -20,7 +20,7 @@ A metric in snap has the following fields.
  * Are key value pairs that provide additional meta data about the metric
  * May be added by the framework or other plugins (processors)
   * The framework currently adds the following standard tag to all metrics
-   * `plugin_running_on` describing on which host the plugin is running
+   * `plugin_running_on` describing on which host the plugin is running. This value is updated every hour due to a TTL set internally.
  * May be added by a task manifests as described [here](https://github.com/intelsdi-x/snap/pull/941)
  * May be added by the snapd config as described [here](https://github.com/intelsdi-x/snap/issues/827)
 * Unit `string`


### PR DESCRIPTION
Fixes #

Summary of changes:
- Moved the retrieval of the hostname out the addStandardAndWorkflowTags so that it is not iterated for each metric at every collection.

Testing done:
- Checked the stack trace of a running agent to ensure calls to os.hostname() are not present

@intelsdi-x/snap-maintainers

…c when tags are applied