### PR TITLE
Added version of snap-plugin-lib-go to glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -52,3 +52,4 @@ import:
 - package: gopkg.in/yaml.v2
   version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
 - package: github.com/intelsdi-x/snap-plugin-lib-go
+  version: 55956e53732655f4875708b15c25904090af41ec


### PR DESCRIPTION
I had such issue related with snap-plugin-lib-go (with the latest snap master 32e53562ed2c242c2d8aa83e574a08ea5feef0bd)
```
2016-09-19 17:23:20 UTC [     info] building snap-plugin-collector-mock2-grpc
# github.com/intelsdi-x/snap/plugin/collector/snap-plugin-collector-mock2-grpc/mock
mock/mock.go:85: undefined: plugin.CopyNamespace
```

Details:
![image](https://cloud.githubusercontent.com/assets/11335874/18642784/5a4573f2-7ea2-11e6-9d76-d3ae55f8ff82.png)

Summary of changes:
- added 1 line with version of snap-plugin-lib-go to glide.yaml which resolves that

Testing done:
- build successfull


Notice, that my issue could be also related by glide caching. In spite of all, adding this line helps.

@intelsdi-x/snap-maintainers

