### PR TITLE
Fixes #1229: Empty metric catalog no longer errors

### DIFF
--- a/control/metrics.go
+++ b/control/metrics.go
@@ -38,10 +38,9 @@ import (
 )
 
 var (
-	errMetricNotFound     = errors.New("metric not found")
-	errEmptyMetricCatalog = errors.New("metric catalog is empty, no plugin loaded")
-	errNegativeSubCount   = serror.New(errors.New("subscription count cannot be < 0"))
-	hostnameReader        hostnamer
+	errMetricNotFound   = errors.New("metric not found")
+	errNegativeSubCount = serror.New(errors.New("subscription count cannot be < 0"))
+	hostnameReader      hostnamer
 )
 
 // hostnameReader, hostnamer created for mocking
@@ -96,10 +95,6 @@ func errorMetricNotFound(ns string, ver ...int) error {
 }
 
 func errorMetricsNotFound(ns string, ver ...int) error {
-	if ns == "/" {
-		// when fetching all cataloged metrics failed
-		return errEmptyMetricCatalog
-	}
 	if len(ver) > 0 {
 		return fmt.Errorf("No metric found below the given namespace: %s (version: %d)", ns, ver[0])
 	}
@@ -428,9 +423,7 @@ func (mc *metricCatalog) GetMetrics(requested core.Namespace, version int) ([]*m
 			returnedmts = append(returnedmts, returnedmt)
 		}
 	}
-	if len(returnedmts) == 0 {
-		return nil, errorMetricsNotFound(requested.String(), version)
-	}
+
 	return returnedmts, nil
 }
 

--- a/control/mttrie.go
+++ b/control/mttrie.go
@@ -148,7 +148,7 @@ func (mtt *mttNode) Fetch(ns []string) ([]*metricType, error) {
 			mts = append(mts, mt)
 		}
 	}
-	if len(mts) == 0 {
+	if len(mts) == 0 && len(ns) > 0 {
 		return nil, errorMetricsNotFound("/" + strings.Join(ns, "/"))
 	}
 	return mts, nil

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -134,9 +134,8 @@ func TestSnapClient(t *testing.T) {
 			})
 			Convey("empty catalog", func() {
 				m := c.GetMetricCatalog()
-				So(m.Err, ShouldNotBeNil)
+				So(m.Err, ShouldBeNil)
 				So(m.Len(), ShouldEqual, 0)
-				So(m.Err.Error(), ShouldEqual, "metric catalog is empty, no plugin loaded")
 			})
 			Convey("load directory error", func() {
 				p := c.LoadPlugin(DIRECTORY_PATH)


### PR DESCRIPTION
Fixes #1229

Summary of changes:

Empty metric catalog no longer logs or returns an error when queried
via the rest API (or any other method). Will instead return an empty
list of metrics, leaving choice of how to display that to the caller.

Removes the empty metric catalog error and modifies client_func_test to
reflect the changes in behavior.

Testing done:
- make test-{small,medium, legacy}
- Manual verification that snapctl metric list doesn't cause error to be logged


@intelsdi-x/snap-maintainers
