### PR TITLE
Use positional arguments for unloading plugins

### DIFF
--- a/cmd/snapctl/commands.go
+++ b/cmd/snapctl/commands.go
@@ -108,13 +108,8 @@ var (
 				},
 				{
 					Name:   "unload",
-					Usage:  "unload <plugin_type>:<plugin_name>:<plugin_version> or unload -t <plugin_type> -n <plugin_name> -v <plugin_version>",
+					Usage:  "unload <plugin_type> <plugin_name> <plugin_version>",
 					Action: unloadPlugin,
-					Flags: []cli.Flag{
-						flPluginType,
-						flPluginName,
-						flPluginVersion,
-					},
 				},
 				{
 					Name:   "swap",

--- a/cmd/snapctl/plugin.go
+++ b/cmd/snapctl/plugin.go
@@ -64,28 +64,18 @@ func loadPlugin(ctx *cli.Context) error {
 }
 
 func unloadPlugin(ctx *cli.Context) error {
-	pDetails := filepath.SplitList(ctx.Args().First())
-	var pType, pName string
-	var pVer int
-	var err error
+	pType := ctx.Args().Get(0)
+	pName := ctx.Args().Get(1)
+	pVer, err := strconv.Atoi(ctx.Args().Get(2))
 
-	if len(pDetails) == 3 {
-		pType = pDetails[0]
-		pName = pDetails[1]
-		pVer, err = strconv.Atoi(pDetails[2])
-		if err != nil {
-			return newUsageError("Can't convert version string to integer", ctx)
-		}
-	} else {
-		pType = ctx.String("plugin-type")
-		pName = ctx.String("plugin-name")
-		pVer = ctx.Int("plugin-version")
-	}
 	if pType == "" {
 		return newUsageError("Must provide plugin type", ctx)
 	}
 	if pName == "" {
 		return newUsageError("Must provide plugin name", ctx)
+	}
+	if err != nil {
+		return newUsageError("Can't convert version string to integer", ctx)
 	}
 	if pVer < 1 {
 		return newUsageError("Must provide plugin version", ctx)


### PR DESCRIPTION
Fixes #1207 

Summary of changes:
- Change the syntax to unload plugin with snapctl to ` snapctl plugin unload <plugin_type> <plugin_name> <plugin_version>`.

Testing done:
- `snapctl plugin unload collector mock 1`
- `snapctl plugin unload collector "mock" 1`
- `snapctl plugin unload "" mock 1`
- `snapctl plugin unload collector mock abc`

@intelsdi-x/snap-maintainers

This change is to simplify and normalize the unload command for Snap 1.0. Please give your feedback as I Snap user, if you think it should be retro-compatible, if you agree with this solution, or if you see another way to do it.