### PR TITLE
Fix #1211: Return better error for plugin not found when starting a task

### DIFF
--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -247,13 +247,7 @@ func (p *subscriptionGroups) validatePluginSubscription(pl core.SubscribedPlugin
 	}).Info(fmt.Sprintf("validating dependencies for plugin %s:%d", pl.Name(), pl.Version()))
 	lp, err := p.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pl.TypeName(), pl.Name(), pl.Version()))
 	if err != nil {
-		se := serror.New(fmt.Errorf("Plugin not found: type(%s) name(%s) version(%d)", pl.TypeName(), pl.Name(), pl.Version()))
-		se.SetFields(map[string]interface{}{
-			"name":    pl.Name(),
-			"version": pl.Version(),
-			"type":    pl.TypeName(),
-		})
-		serrs = append(serrs, se)
+		serrs = append(serrs, pluginNotFoundError(pl))
 		return serrs
 	}
 
@@ -383,7 +377,7 @@ func (s *subscriptionGroup) subscribePlugins(id string,
 	for i, sub := range plugins {
 		plg, err := s.pluginManager.get(key(sub))
 		if err != nil {
-			serrs = append(serrs, serror.New(err))
+			serrs = append(serrs, pluginNotFoundError(sub))
 			return serrs
 		}
 		plgs[i] = plg
@@ -523,6 +517,16 @@ func comparePlugins(newPlugins,
 	}
 
 	return
+}
+
+func pluginNotFoundError(pl core.SubscribedPlugin) serror.SnapError {
+	se := serror.New(fmt.Errorf("Plugin not found: type(%s) name(%s) version(%d)", pl.TypeName(), pl.Name(), pl.Version()))
+	se.SetFields(map[string]interface{}{
+		"name":    pl.Name(),
+		"version": pl.Version(),
+		"type":    pl.TypeName(),
+	})
+	return se
 }
 
 func key(p core.SubscribedPlugin) string {

--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -245,7 +245,7 @@ func (p *subscriptionGroups) validatePluginSubscription(pl core.SubscribedPlugin
 		"_block": "validate-plugin-subscription",
 		"plugin": fmt.Sprintf("%s:%d", pl.Name(), pl.Version()),
 	}).Info(fmt.Sprintf("validating dependencies for plugin %s:%d", pl.Name(), pl.Version()))
-	lp, err := p.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pl.TypeName(), pl.Name(), pl.Version()))
+	lp, err := p.pluginManager.get(key(pl))
 	if err != nil {
 		serrs = append(serrs, pluginNotFoundError(pl))
 		return serrs
@@ -429,9 +429,7 @@ func (p *subscriptionGroup) unsubscribePlugins(id string,
 			"version": plugin.Version(),
 			"_block":  "subscriptionGroup.unsubscribePlugins",
 		}).Debug("plugin unsubscription")
-		pool, err := p.pluginRunner.AvailablePlugins().getPool(
-			fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", plugin.TypeName(),
-				plugin.Name(), plugin.Version()))
+		pool, err := p.pluginRunner.AvailablePlugins().getPool(key(plugin))
 		if err != nil {
 			serrs = append(serrs, err)
 			return serrs


### PR DESCRIPTION
Fixes #1211

Summary of changes:
- Refactor and return same plugin not found error for both validating a task and starting a task.
- Refactor code creating plugin key to use key function.

Testing done:
- Verified tests pass for small, medium, and legacy.
- Verified error returns details on a plugin when a plugin is not found while trying to start a task.

@intelsdi-x/snap-maintainers
