### PR TITLE
Update config policy rules in plugin examples

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -49,7 +49,7 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: db68f6fda248706a71980abc58e969fcd63f5ea6
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 55956e53732655f4875708b15c25904090af41ec
+  version: d7be15167858210a70ff958a5844acd93f68d989
   subpackages:
   - v1/plugin
   - v1/plugin/rpc

--- a/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
@@ -144,20 +144,14 @@ func (f *Mock) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) {
 func (f *Mock) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	p := plugin.NewConfigPolicy()
 
-	rule1, err := plugin.NewStringRule("name", false, plugin.SetDefaultString("bob"))
+	err := p.AddNewStringRule([]string{"intel", "mock", "foo"}, "name", false, plugin.SetDefaultString("bob"))
 	if err != nil {
 		return *p, err
 	}
 
-	rule2, err := plugin.NewStringRule("password", true)
-	if err != nil {
-		return *p, err
-	}
+	err = p.AddNewStringRule([]string{"intel", "mock", "foo"}, "password", true)
 
-	p.AddStringRule([]string{"intel", "mock", "foo"}, rule1)
-	p.AddStringRule([]string{"intel", "mock", "foo"}, rule2)
-
-	return *p, nil
+	return *p, err
 }
 
 // contains reports whether a given item is found in a slice

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
@@ -37,12 +37,7 @@ type passthruProcessor struct{}
 
 func (p *passthruProcessor) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
-	rule, err := plugin.NewBoolRule(debug, false)
-	if err != nil {
-		return *policy, err
-	}
-	policy.AddBoolRule([]string{""}, rule)
-	return *policy, nil
+	return *policy, policy.AddNewBoolRule([]string{""}, debug, false)
 }
 
 func (p *passthruProcessor) Process(metrics []plugin.Metric, config plugin.Config) ([]plugin.Metric, error) {

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
@@ -78,20 +78,15 @@ func (f *filePublisher) Publish(metrics []plugin.Metric, config plugin.Config) e
 
 func (f *filePublisher) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	policy := plugin.NewConfigPolicy()
-	rule1, err := plugin.NewStringRule("file", true)
+
+	err := policy.AddNewStringRule([]string{""}, "file", true)
 	if err != nil {
 		return *policy, err
 	}
 
-	rule2, err := plugin.NewBoolRule(debug, false)
-	if err != nil {
-		return *policy, err
-	}
+	err = policy.AddNewBoolRule([]string{}, debug, false)
 
-	policy.AddStringRule([]string{""}, rule1)
-	policy.AddBoolRule([]string{}, rule2)
-
-	return *policy, nil
+	return *policy, err
 }
 
 // formatMetricTagsAsString returns metric's tags as a string in the following format tagKey:tagValue where the next tags are separated by semicolon


### PR DESCRIPTION
This concern only 3 plugins that use the new Go library. It's an update after this PR was merged.
https://github.com/intelsdi-x/snap-plugin-lib-go/pull/31

Summary of changes:
- Update syntaxe for adding a rule with the new go lib.

Testing done:
- `make`

@intelsdi-x/snap-maintainers