### PR TITLE
(SDI-1725) Fix #1234 Add arbitrary namespace separator

### DIFF
--- a/core/metric_test.go
+++ b/core/metric_test.go
@@ -1,0 +1,64 @@
+// +build small
+
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMetricSeparator(t *testing.T) {
+	tc := getTestCases()
+	Convey("Test namespace separator", t, func() {
+		for _, c := range tc {
+			Convey("namespace "+c.input.String(), func() {
+				firstChar := getFirstChar(c.input.String())
+				So(firstChar, ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+// GetFirstChar returns the first character from the input string.
+func getFirstChar(s string) string {
+	firstChar := ""
+	for _, r := range s {
+		firstChar = fmt.Sprintf("%c", r)
+		break
+	}
+	return firstChar
+}
+
+type testCase struct {
+	input    Namespace
+	expected string
+}
+
+// getTestCases tests the namespace and nsPriorityList.
+func getTestCases() []testCase {
+	tcs := []testCase{
+		testCase{
+			input:    NewNamespace("/hello", "/world"),
+			expected: "|",
+		},
+		testCase{
+			input:    NewNamespace("/hello", "/world", "corporate-service|"),
+			expected: "%",
+		},
+		testCase{
+			input:    NewNamespace("/hello", "/world", "|corporate-service%", "monday_to_friday"),
+			expected: ":",
+		},
+		testCase{
+			input:    NewNamespace("/hello", "/world", "corporate-service/%|-_^><+=:;&", "monday_friday", "㊽ÄA小ヒ☍"),
+			expected: "大",
+		},
+		testCase{
+			input:    NewNamespace("A小ヒ☍小㊽%:;", "/hello", "/world大|", "monday_friday", "corporate-service"),
+			expected: "^",
+		},
+	}
+	return tcs
+}

--- a/scheduler/wmap/sample/2.json
+++ b/scheduler/wmap/sample/2.json
@@ -1,0 +1,35 @@
+{
+    "collect": {
+        "metrics": {
+            "㊽foo㊽bar": {
+                "version": 1
+            },
+            "大foo大baz": {},
+            "/a0/b0": {},
+            "-a1-b1": {},
+            "_a2_b2": {},
+            "㊽a3㊽b3": {},
+            "Äa4Äb4": {},
+            "大a5大b5": {},
+            "小a6小b6": {},
+            "ᵹa7ᵹb7": {},
+            "☍a8☍b8": {},
+            "ヒa9ヒb9": {}
+        },
+        "config": {
+            "%foo%bar": {
+                "password": "drowssap",
+                "user": "root"
+            }
+        },
+        "tags": {
+            "㊽foo㊽bar": {
+                "tag1": "val1",
+                "tag2": "val2"
+            },
+            "大foo大baz": {
+                "tag3": "val3"
+            }
+        }
+    }
+}

--- a/scheduler/wmap/wmap.go
+++ b/scheduler/wmap/wmap.go
@@ -215,14 +215,27 @@ func (c *CollectWorkflowMapNode) GetMetrics() []Metric {
 	metrics := make([]Metric, len(c.Metrics))
 	i := 0
 	for k, v := range c.Metrics {
-		ns := strings.Trim(k, `/`)
+		// Identify the character to split on by peaking
+		// at the first character of each metric.
+		firstChar := getFirstChar(k)
+		ns := strings.Trim(k, firstChar)
 		metrics[i] = Metric{
-			namespace: strings.Split(ns, "/"),
+			namespace: strings.Split(ns, firstChar),
 			version:   v.Version_,
 		}
 		i++
 	}
 	return metrics
+}
+
+// GetFirstChar returns the first character from the input string.
+func getFirstChar(s string) string {
+	firstChar := ""
+	for _, r := range s {
+		firstChar = fmt.Sprintf("%c", r)
+		break
+	}
+	return firstChar
 }
 
 func (c *CollectWorkflowMapNode) GetTags() map[string]map[string]string {

--- a/scheduler/wmap/wmap_small_test.go
+++ b/scheduler/wmap/wmap_small_test.go
@@ -22,6 +22,8 @@ limitations under the License.
 package wmap
 
 import (
+	"io/ioutil"
+	"strconv"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -221,5 +223,24 @@ func TestStringByteConvertion(t *testing.T) {
 		p, err = inStringBytes(1)
 		So(p, ShouldBeEmpty)
 		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestMetricSeparator(t *testing.T) {
+	jsonP, _ := ioutil.ReadFile("./sample/2.json")
+
+	Convey("Get Metric", t, func() {
+		Convey("from json", func() {
+			wmap, err := FromJson(jsonP)
+			So(err, ShouldBeNil)
+			So(wmap, ShouldNotBeNil)
+
+			mts := wmap.CollectNode.GetMetrics()
+			for i, m := range mts {
+				Convey("namespace "+strconv.Itoa(i), func() {
+					So(len(m.Namespace()), ShouldEqual, 2)
+				})
+			}
+		})
 	})
 }


### PR DESCRIPTION
Fixes #1234 

Summary of changes:
- Added the prioritySeparatorList in core.metric.go
- Uses the first available namespace separator from the priority list when verifying the namespace
- Peeks the first character from the task manifest as the namespace separator.

Testing done:
- small, medium, and large tests
- Integration tests

@intelsdi-x/snap-maintainers

We can add more separators when cases arise. 

