### PR TITLE
Fix for issue #1167, added handling of errors which are returned by scaner

### DIFF
--- a/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
@@ -20,9 +20,11 @@ limitations under the License.
 package mock
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -57,14 +59,24 @@ func (f *Mock) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, err
 	rand.Seed(time.Now().UTC().UnixNano())
 	metrics := []plugin.MetricType{}
 	for i := range mts {
-		if c, ok := mts[i].Config().Table()["long_print"]; ok && c.(ctypes.ConfigValueBool).Value {
+		if c, ok := mts[i].Config().Table()["long_stdout_log"]; ok && c.(ctypes.ConfigValueBool).Value {
 			letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			longLine := []byte{}
-			for i := 0; i < 8193; i++ {
+			for i := 0; i < bufio.MaxScanTokenSize; i++ {
 				longLine = append(longLine, letterBytes[rand.Intn(len(letterBytes))])
 			}
-			fmt.Println(string(longLine))
+			fmt.Fprintln(os.Stdout, string(longLine))
 		}
+
+		if c, ok := mts[i].Config().Table()["long_stderr_log"]; ok && c.(ctypes.ConfigValueBool).Value {
+			letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+			longLine := []byte{}
+			for i := 0; i < bufio.MaxScanTokenSize; i++ {
+				longLine = append(longLine, letterBytes[rand.Intn(len(letterBytes))])
+			}
+			fmt.Fprintln(os.Stderr, string(longLine))
+		}
+
 		if c, ok := mts[i].Config().Table()["panic"]; ok && c.(ctypes.ConfigValueBool).Value {
 			panic("Oops!")
 		}


### PR DESCRIPTION
Fixes #1167 

Hanging of plugins during capturing of stderr and stdout were observed when log line had a significant length. It was caused by errors occured during scanning of stderr or stdout. Errors returned by Scan()  were not handled by snapd. 

To fix the issue used the method which was used before adding of log capturing from plugin [commit]( https://github.com/intelsdi-x/snap/commit/5d91b04fa8b7d398fea04f5cbbe970f21cf32bd9) so now goto procedure is in use to deal with long line of logs.

Summary of changes:
- Added handling of errors returned by Scan method in the part of code which is used to capture stdout and stderr from plugins,
- Modified mock plugin to test log lines with significant length.

Testing done:
- Verified tests pass for small, medium, and legacy.
- Manual tests with mock plugin.

@intelsdi-x/snap-maintainers
