### PR TITLE
Fix 1233: Removed printing of headers in snapctl

### DIFF
--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -53,7 +53,10 @@ func listMetrics(ctx *cli.Context) error {
 	if mts.Err != nil {
 		return fmt.Errorf("Error getting metrics: %v\n", mts.Err)
 	}
-
+	if mts.Len() == 0 {
+		fmt.Println("No metrics found. Have you loaded any collectors yet?")
+		return nil
+	}
 	/*
 		NAMESPACE               VERSION
 		/intel/mock/foo         1,2

--- a/cmd/snapctl/plugin.go
+++ b/cmd/snapctl/plugin.go
@@ -169,11 +169,19 @@ func listPlugins(ctx *cli.Context) error {
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	if ctx.Bool("running") {
+		if len(plugins.AvailablePlugins) == 0 {
+			fmt.Println("No running plugins found. Have you started a task?")
+			return nil
+		}
 		printFields(w, false, 0, "NAME", "HIT COUNT", "LAST HIT", "TYPE")
 		for _, rp := range plugins.AvailablePlugins {
 			printFields(w, false, 0, rp.Name, rp.HitCount, time.Unix(rp.LastHitTimestamp, 0).Format(timeFormat), rp.Type)
 		}
 	} else {
+		if len(plugins.LoadedPlugins) == 0 {
+			fmt.Println("No plugins found. Have you loaded a plugin?")
+			return nil
+		}
 		printFields(w, false, 0, "NAME", "VERSION", "TYPE", "SIGNED", "STATUS", "LOADED TIME")
 		for _, lp := range plugins.LoadedPlugins {
 			printFields(w, false, 0, lp.Name, lp.Version, lp.Type, lp.Signed, lp.Status, lp.LoadedTime().Format(timeFormat))

--- a/cmd/snapctl/task.go
+++ b/cmd/snapctl/task.go
@@ -470,6 +470,10 @@ func listTask(ctx *cli.Context) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	if tasks.Len() == 0 {
+		fmt.Println("No task found. Have you created a task?")
+		return nil
+	}
 	printFields(w, false, 0,
 		"ID",
 		"NAME",


### PR DESCRIPTION
Fixes #1233 

Summary of changes:
- Removes the printing of headers in snapctl when querying lists of
{tasks, plugins, metrics}. Instead provides `No x found` message and a
hint.

Changes:
```
% snapctl task list
ID       NAME    STATE   HIT     MISS    FAIL    CREATED         LAST FAILURE
% snapctl metric list
NAMESPACE        VERSIONS
% snapctl plugin list
NAME     VERSION         TYPE    SIGNED          STATUS          LOADED TIME
% snapctl plugin list --running
NAME     HIT COUNT       LAST HIT        TYPE
```
To:
```
% snapctl task list
No task found. Have you created a task?
% snapctl metric list
No metrics found. Have you loaded any collectors yet?
% snapctl plugin list
No plugins found. Have you loaded a plugin?
% snapctl plugin list --running
No running plugins found.
```
Testing done:
Manual testing of snapctl.


@intelsdi-x/snap-maintainers
