### PR TITLE
(SDI-2036) Fix s3 output path to snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ deploy:
   bucket: snap.ci.snap-telemetry.io
   region: us-west-2
   skip_cleanup: true
-  local-dir: s3
+  local-dir: s3/snap
   upload-dir: snap
   acl: public_read
   on:

--- a/mgmt/rest/rest_v1_test.go
+++ b/mgmt/rest/rest_v1_test.go
@@ -41,13 +41,12 @@ import (
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/mgmt/rest/fixtures"
+	"github.com/intelsdi-x/snap/plugin/helper"
 )
 
 var (
 	LOG_LEVEL         = log.WarnLevel
-	SNAP_PATH         = os.ExpandEnv(os.Getenv("SNAP_PATH"))
-	MOCK_PLUGIN_PATH1 = SNAP_PATH + "/plugin/snap-plugin-collector-mock1"
-	MOCK_TASK_PATH1   = SNAP_PATH + "/tasks/snap-task-collector-mock1"
+	MOCK_PLUGIN_PATH1 = helper.PluginFilePath("snap-plugin-collector-mock1")
 )
 
 type restAPIInstance struct {


### PR DESCRIPTION
We need a minor change so the s3 sub directory is snap instead of
snap/snap.