### PR TITLE
Created V2 REST API Routes in feature branch snap/v2_rest_api

### DIFF
--- a/control/plugin/cpolicy/node.go
+++ b/control/plugin/cpolicy/node.go
@@ -119,16 +119,18 @@ func (p *ConfigPolicyNode) Add(rules ...Rule) {
 	}
 }
 
+type RuleTableSlice []RuleTable
+
 type RuleTable struct {
-	Name     string
-	Type     string
-	Default  interface{}
-	Required bool
-	Minimum  interface{}
-	Maximum  interface{}
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Default  interface{} `json:"default,omitempty"`
+	Required bool        `json:"required"`
+	Minimum  interface{} `json:"minimum,omitempty"`
+	Maximum  interface{} `json:"maximum,omitempty"`
 }
 
-func (p *ConfigPolicyNode) RulesAsTable() []RuleTable {
+func (p *ConfigPolicyNode) RulesAsTable() RuleTableSlice {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 

--- a/mgmt/rest/fixtures/mock_tribe_manager.go
+++ b/mgmt/rest/fixtures/mock_tribe_manager.go
@@ -35,6 +35,19 @@ var (
 )
 
 func init() {
+	mockTribeMember = agreement.NewMember(&memberlist.Node{
+		Name: "Imma_Mock",
+		Addr: net.ParseIP("193.11.22.11"),
+		Port: uint16(0),
+		Meta: []byte("meta"), // Metadata from the delegate for this node.
+		PMin: uint8(0),       // Minimum protocol version this understands
+		PMax: uint8(0),       // Maximum protocol version this understands
+		PCur: uint8(0),       // Current version node is speaking
+		DMin: uint8(0),       // Min protocol version for the delegate to understand
+		DMax: uint8(0),       // Max protocol version for the delegate to understand
+		DCur: uint8(0),       // Current version delegate is speaking
+	})
+
 	mockTribeAgreement = agreement.New("Agree1")
 	mockTribeAgreement.PluginAgreement.Add(
 		agreement.Plugin{Name_: "mockVersion", Version_: 1, Type_: core.CollectorPluginType})
@@ -80,7 +93,7 @@ func (m *MockTribeManager) GetMembers() []string {
 	return []string{"one", "two", "three"}
 }
 func (m *MockTribeManager) GetMember(name string) *agreement.Member {
-	return &agreement.Member{}
+	return mockTribeMember
 }
 
 // These constants are the expected tribe responses from running
@@ -209,7 +222,7 @@ const (
     "version": 1
   },
   "body": {
-    "name": "",
+    "name": "Imma_Mock",
     "plugin_agreement": "",
     "tags": null,
     "task_agreements": null

--- a/mgmt/rest/rbody/metric.go
+++ b/mgmt/rest/rbody/metric.go
@@ -19,21 +19,20 @@ limitations under the License.
 
 package rbody
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+)
 
 const (
 	MetricsReturnedType = "metrics_returned"
 	MetricReturnedType  = "metric_returned"
 )
 
-type PolicyTable struct {
-	Name     string      `json:"name"`
-	Type     string      `json:"type"`
-	Default  interface{} `json:"default,omitempty"`
-	Required bool        `json:"required"`
-	Minimum  interface{} `json:"minimum,omitempty"`
-	Maximum  interface{} `json:"maximum,omitempty"`
-}
+type PolicyTable cpolicy.RuleTable
+
+type PolicyTableSlice []cpolicy.RuleTable
 
 type Metric struct {
 	LastAdvertisedTimestamp int64            `json:"last_advertised_timestamp,omitempty"`
@@ -43,7 +42,7 @@ type Metric struct {
 	DynamicElements         []DynamicElement `json:"dynamic_elements,omitempty"`
 	Description             string           `json:"description,omitempty"`
 	Unit                    string           `json:"unit,omitempty"`
-	Policy                  []PolicyTable    `json:"policy,omitempty"`
+	Policy                  PolicyTableSlice `json:"policy,omitempty"`
 	Href                    string           `json:"href"`
 }
 

--- a/mgmt/rest/rbody/v2/metric.go
+++ b/mgmt/rest/rbody/v2/metric.go
@@ -1,0 +1,49 @@
+package v2
+
+import (
+	"fmt"
+
+	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+)
+
+type MetricList struct {
+	Metrics []rbody.Metric `json:"metrics,omitempty"`
+}
+
+type MetricReturned struct {
+	Metric *rbody.Metric `json:"metric,omitempty"`
+}
+
+func (m *MetricReturned) ResponseBodyMessage() string {
+	return "Metric returned"
+}
+
+func (m *MetricReturned) ResponseBodyType() string {
+	return "metric_returned"
+}
+
+type MetricsReturned MetricList
+
+func (m MetricsReturned) Len() int {
+	return len(m.Metrics)
+}
+
+func (m MetricsReturned) Less(i, j int) bool {
+	return (fmt.Sprintf("%s:%d", m.Metrics[i].Namespace, m.Metrics[i].Version)) < (fmt.Sprintf("%s:%d", m.Metrics[j].Namespace, m.Metrics[j].Version))
+}
+
+func (m MetricsReturned) Swap(i, j int) {
+	m.Metrics[i], m.Metrics[j] = m.Metrics[j], m.Metrics[i]
+}
+
+func NewMetricsReturned() MetricsReturned {
+	return MetricsReturned{Metrics: []rbody.Metric{}}
+}
+
+func (m MetricsReturned) ResponseBodyMessage() string {
+	return "Metrics returned"
+}
+
+func (m MetricsReturned) ResponseBodyType() string {
+	return rbody.MetricsReturnedType
+}

--- a/mgmt/rest/rbody/v2/task.go
+++ b/mgmt/rest/rbody/v2/task.go
@@ -1,0 +1,27 @@
+package v2
+
+import "github.com/intelsdi-x/snap/mgmt/rest/rbody"
+
+type ScheduledTaskListReturned struct {
+	ScheduledTasks []rbody.ScheduledTask `json:"scheduled_task,omitempty"`
+}
+
+func (s *ScheduledTaskListReturned) Len() int {
+	return len(s.ScheduledTasks)
+}
+
+func (s *ScheduledTaskListReturned) Less(i, j int) bool {
+	return s.ScheduledTasks[j].CreationTime().After(s.ScheduledTasks[i].CreationTime())
+}
+
+func (s *ScheduledTaskListReturned) Swap(i, j int) {
+	s.ScheduledTasks[i], s.ScheduledTasks[j] = s.ScheduledTasks[j], s.ScheduledTasks[i]
+}
+
+func (s *ScheduledTaskListReturned) ResponseBodyMessage() string {
+	return "Scheduled tasks retrieved"
+}
+
+func (s *ScheduledTaskListReturned) ResponseBodyType() string {
+	return "scheduled_task_list_returned"
+}

--- a/mgmt/rest/rest_v1_test.go
+++ b/mgmt/rest/rest_v1_test.go
@@ -74,7 +74,6 @@ func startV1API(cfg *mockConfig, testType string) *restAPIInstance {
 		mockTaskManager := &fixtures.MockTaskManager{}
 		r.BindTaskManager(mockTaskManager)
 	}
-
 	go func(ch <-chan error) {
 		// Block on the error channel. Will return exit status 1 for an error or
 		// just return if the channel closes.

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -468,9 +468,9 @@ func (s *Server) addRoutes() {
 
 	// metric routes
 	s.r.GET("/v1/metrics", s.getMetrics)
-	s.r.GET("/v1/metrics/*namespace", s.getMetricsFromTree)
-
 	s.r.GET("/v2/metrics", s.getMetrics)
+
+	s.r.GET("/v1/metrics/*namespace", s.getMetricsFromTree)
 	s.r.GET("/v2/metrics/*namespace", s.getMetricsFromTree)
 
 	// task routes
@@ -488,13 +488,28 @@ func (s *Server) addRoutes() {
 	// tribe routes
 	if s.tr != nil {
 		s.r.GET("/v1/tribe/agreements", s.getAgreements)
+		s.r.GET("/v2/tribes/agreements", s.getAgreements)
+
 		s.r.POST("/v1/tribe/agreements", s.addAgreement)
+		s.r.POST("/v2/tribes/agreements", s.addAgreement)
+
 		s.r.GET("/v1/tribe/agreements/:name", s.getAgreement)
+		s.r.GET("/v2/tribes/agreements/:name", s.getAgreement)
+
 		s.r.DELETE("/v1/tribe/agreements/:name", s.deleteAgreement)
+		s.r.DELETE("/v2/tribes/agreements/:name", s.deleteAgreement)
+
 		s.r.PUT("/v1/tribe/agreements/:name/join", s.joinAgreement)
+		s.r.PUT("/v2/tribes/agreements/:name/join", s.joinAgreement)
+
 		s.r.DELETE("/v1/tribe/agreements/:name/leave", s.leaveAgreement)
+		s.r.DELETE("/v2/tribes/agreements/:name/leave", s.leaveAgreement)
+
 		s.r.GET("/v1/tribe/members", s.getMembers)
+		s.r.GET("/v2/tribes/members", s.getMembers)
+
 		s.r.GET("/v1/tribe/member/:name", s.getMember)
+		s.r.GET("/v2/tribes/members/:name", s.getMember)
 	}
 }
 

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -470,8 +470,13 @@ func (s *Server) addRoutes() {
 	s.r.GET("/v1/metrics", s.getMetrics)
 	s.r.GET("/v1/metrics/*namespace", s.getMetricsFromTree)
 
+	s.r.GET("/v2/metrics", s.getMetrics)
+	s.r.GET("/v2/metrics/*namespace", s.getMetricsFromTree)
+
 	// task routes
 	s.r.GET("/v1/tasks", s.getTasks)
+	s.r.GET("/v2/tasks", s.getTasks)
+
 	s.r.GET("/v1/tasks/:id", s.getTask)
 	s.r.GET("/v1/tasks/:id/watch", s.watchTask)
 	s.r.POST("/v1/tasks", s.addTask)

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	apiV2 "github.com/intelsdi-x/snap/mgmt/rest/v2"
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/intelsdi-x/snap/core"
@@ -56,6 +57,11 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 
 func (s *Server) getTasks(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	sts := s.mt.GetTasks()
+	apiVersion := r.URL.Path[1:3]
+	if apiVersion == "v2" {
+		apiV2.GetTasks(w, r, sts)
+		return
+	}
 
 	tasks := &rbody.ScheduledTaskListReturned{}
 	tasks.ScheduledTasks = make([]rbody.ScheduledTask, len(sts))

--- a/mgmt/rest/task.go
+++ b/mgmt/rest/task.go
@@ -57,6 +57,8 @@ func (s *Server) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 
 func (s *Server) getTasks(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	sts := s.mt.GetTasks()
+	// apiVersion should be "v1" or "v2".
+	// If apiVersion != "v2" calls default to V1 functionality
 	apiVersion := r.URL.Path[1:3]
 	if apiVersion == "v2" {
 		apiV2.GetTasks(w, r, sts)

--- a/mgmt/rest/v2/metric.go
+++ b/mgmt/rest/v2/metric.go
@@ -1,0 +1,92 @@
+package v2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"github.com/codegangsta/negroni"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+	"github.com/intelsdi-x/snap/mgmt/rest/rbody/v2"
+)
+
+func RespondWithMetrics(host string, mets []core.CatalogedMetric, w http.ResponseWriter) {
+	b := v2.NewMetricsReturned()
+
+	for _, met := range mets {
+		rt := met.Policy().RulesAsTable()
+		policies := make([]rbody.PolicyTable, 0, len(rt))
+		for _, r := range rt {
+			policies = append(policies, rbody.PolicyTable{
+				Name:     r.Name,
+				Type:     r.Type,
+				Default:  r.Default,
+				Required: r.Required,
+				Minimum:  r.Minimum,
+				Maximum:  r.Maximum,
+			})
+		}
+		dyn, indexes := met.Namespace().IsDynamic()
+		var dynamicElements []rbody.DynamicElement
+		if dyn {
+			dynamicElements = getDynamicElements(met.Namespace(), indexes)
+		}
+
+		b.Metrics = append(b.Metrics, rbody.Metric{
+			Namespace:               met.Namespace().String(),
+			Version:                 met.Version(),
+			LastAdvertisedTimestamp: met.LastAdvertisedTime().Unix(),
+			Description:             met.Description(),
+			Dynamic:                 dyn,
+			DynamicElements:         dynamicElements,
+			Unit:                    met.Unit(),
+			Policy:                  policies,
+			Href:                    catalogedMetricURI(host, met),
+		})
+	}
+	sort.Sort(b)
+	respond(200, b, w)
+}
+
+func catalogedMetricURI(host string, mt core.CatalogedMetric) string {
+	return fmt.Sprintf("%s://%s/v1/metrics?ns=%s&ver=%d", "http", host, url.QueryEscape(mt.Namespace().String()), mt.Version())
+}
+
+func getDynamicElements(ns core.Namespace, indexes []int) []rbody.DynamicElement {
+	elements := make([]rbody.DynamicElement, 0, len(indexes))
+	for _, v := range indexes {
+		e := ns.Element(v)
+		elements = append(elements, rbody.DynamicElement{
+			Index:       v,
+			Name:        e.Name,
+			Description: e.Description,
+		})
+	}
+	return elements
+}
+
+func respond(code int, b rbody.Body, w http.ResponseWriter) {
+	resp := &rbody.APIResponse{
+		Meta: &rbody.APIResponseMeta{
+			Code:    code,
+			Message: b.ResponseBodyMessage(),
+			Type:    b.ResponseBodyType(),
+			Version: 2,
+		},
+		Body: b,
+	}
+	if !w.(negroni.ResponseWriter).Written() {
+		w.WriteHeader(code)
+	}
+
+	j, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	j = bytes.Replace(j, []byte("\\u0026"), []byte("&"), -1)
+	fmt.Fprint(w, string(j))
+}

--- a/mgmt/rest/v2/task.go
+++ b/mgmt/rest/v2/task.go
@@ -1,0 +1,29 @@
+package v2
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+	"github.com/intelsdi-x/snap/mgmt/rest/rbody/v2"
+)
+
+func GetTasks(w http.ResponseWriter, r *http.Request, sts map[string]core.Task) {
+	tasks := &v2.ScheduledTaskListReturned{}
+	tasks.ScheduledTasks = make([]rbody.ScheduledTask, len(sts))
+
+	i := 0
+	for _, t := range sts {
+		tasks.ScheduledTasks[i] = *rbody.SchedulerTaskFromTask(t)
+		tasks.ScheduledTasks[i].Href = taskURI(r.Host, t)
+		i++
+	}
+	sort.Sort(tasks)
+	respond(200, tasks, w)
+}
+
+func taskURI(host string, t core.Task) string {
+	return fmt.Sprintf("%s://%s/v1/tasks/%s", "http", host, t.ID())
+}


### PR DESCRIPTION
Fixes #634 and #730 as well as other V2 API changes 
This PR copies #1255 to put the V2 changes in their own feature branch on Snap

Summary of changes:
- Fixed named list returned by metric API
- Fixed text case in V2/tests from "ScheduledTasks" to "scheduled_tasks"
- Made all V2 tribe routes to be /V2/tribes (made tribe plural)
- Changed V2/tribes/member/:name to be V2/tribes/members/:name (made member plural)
- Added V2 folders in rest and in rbody to hold V2 methods

Note:
- Additional issues for updating documentation and writing V2 tests will need to be added.

Testing done:
- Unit tests

@intelsdi-x/snap-maintainers
