### PR TITLE
(maint) add default and parallel builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,13 @@ install:
 - cd $SNAP_SOURCE # change dir into source
 - make
 script:
-- make check 2>&1 # Run test suite
+- make test 2>&1 # Run test suite
 notifications:
   email: false
   slack:
     secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=
 before_deploy:
+- make all
 - "./scripts/pre_deploy.sh"
 deploy:
   provider: s3

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ ARCH = $(shell uname -m)
 
 default:
 	$(MAKE) deps
-	$(MAKE) all
+	$(MAKE) snap
+	$(MAKE) plugins
 deps:
 	bash -c "./scripts/deps.sh"
 test:
@@ -33,10 +34,19 @@ test-medium:
 	bash -c "./scripts/test.sh medium"
 test-large:
 	bash -c "./scripts/test.sh large"
-check:
-	$(MAKE) test
-all:
+# NOTE:
+# By default compiles will use all cpu cores, use BUILD_JOBS to control number
+# of parallel builds: `BUILD_JOBS=2 make plugins`
+#
+# Build only snapd/snapctl
+snap:
 	bash -c "./scripts/build_snap.sh"
+# Build only plugins
+plugins:
+	bash -c "./scripts/build_plugins.sh"
+# Build snap and plugins for all platforms
+all:
+	bash -c "./scripts/build_all.sh"
 install:
 	cp build/$(OS)/$(ARCH)/snapd /usr/local/bin/
 	cp build/$(OS)/$(ARCH)/snapctl /usr/local/bin/

--- a/plugin/helper/helper.go
+++ b/plugin/helper/helper.go
@@ -51,7 +51,7 @@ func PluginPath() string {
 		arch = runtime.GOARCH
 	}
 
-	fpath := path.Join(BuildPath, runtime.GOOS, arch)
+	fpath := path.Join(BuildPath, runtime.GOOS, arch, "plugins")
 	return fpath
 }
 

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/common.sh
+. "${__dir}/common.sh"
+
+export GOOS=linux
+export GOARCH=amd64
+"${__dir}/build_snap.sh" &
+"${__dir}/build_plugins.sh" &
+
+export GOOS=darwin
+export GOARCH=amd64
+"${__dir}/build_snap.sh" &
+"${__dir}/build_plugins.sh" &
+
+wait

--- a/scripts/build_plugin.sh
+++ b/scripts/build_plugin.sh
@@ -27,14 +27,17 @@ __proj_dir="$(dirname "$__dir")"
 # shellcheck source=scripts/common.sh
 . "${__dir}/common.sh"
 
-build_dir="${__proj_dir}/build"
-plugin_dir="${build_dir}/${GOOS}/x86_64"
+if [[ "${GOARCH}" == "amd64" ]]; then
+  build_dir="${__proj_dir}/build/${GOOS}/x86_64/plugins"
+else
+  build_dir="${__proj_dir}/build/${GOOS}/${GOARCH}/plugins"
+fi
 
 plugin_src_path=$1
 plugin_name=$(basename "${plugin_src_path}")
 go_build=(go build -a -ldflags "-w")
 
 _debug "plugin source: ${plugin_src_path}"
-_info "building ${plugin_name}"
+_info "building ${plugin_name} for ${GOOS}/${GOARCH}"
 
-(cd "${plugin_src_path}" && "${go_build[@]}" -o "${plugin_dir}/${plugin_name}" . || exit 1)
+(cd "${plugin_src_path}" && "${go_build[@]}" -o "${build_dir}/${plugin_name}" . || exit 1)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -122,3 +122,11 @@ _go_test() {
 _go_cover() {
   go tool cover -func "profile-${TEST_TYPE}.cov"
 }
+
+_git_version() {
+  git_branch=$(git symbolic-ref HEAD 2> /dev/null | cut -b 12-)
+  git_branch="${git_branch:-test}"
+  git_sha=$(git log --pretty=format:"%h" -1)
+  git_version=$(git describe --always --exact-match 2> /dev/null || echo "${git_branch}-${git_sha}")
+  echo "${git_version}"
+}


### PR DESCRIPTION
This reduces the number of builds and speed up builds by increasing number of parallel plugin builds. We only need mac and linux builds when releasing, so it is no longer the default.