### PR TITLE
(SDI-2101) Fix #1273 update parseNamespace to allow an arbitary separator

### DIFF
--- a/cmd/snapctl/metric.go
+++ b/cmd/snapctl/metric.go
@@ -31,6 +31,8 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+
+	"github.com/intelsdi-x/snap/pkg/stringutils"
 )
 
 func listMetrics(ctx *cli.Context) error {
@@ -189,11 +191,12 @@ func getMetric(ctx *cli.Context) error {
 func getNamespace(mt *rbody.Metric) string {
 	ns := mt.Namespace
 	if mt.Dynamic {
-		slice := strings.Split(ns, "/")
+		fc := stringutils.GetFirstChar(ns)
+		slice := strings.Split(ns, fc)
 		for _, v := range mt.DynamicElements {
 			slice[v.Index+1] = "[" + v.Name + "]"
 		}
-		ns = strings.Join(slice, "/")
+		ns = strings.Join(slice, fc)
 	}
 	return ns
 }

--- a/core/metric_test.go
+++ b/core/metric_test.go
@@ -3,9 +3,9 @@
 package core
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/intelsdi-x/snap/pkg/stringutils"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -14,21 +14,11 @@ func TestMetricSeparator(t *testing.T) {
 	Convey("Test namespace separator", t, func() {
 		for _, c := range tc {
 			Convey("namespace "+c.input.String(), func() {
-				firstChar := getFirstChar(c.input.String())
+				firstChar := stringutils.GetFirstChar(c.input.String())
 				So(firstChar, ShouldEqual, c.expected)
 			})
 		}
 	})
-}
-
-// GetFirstChar returns the first character from the input string.
-func getFirstChar(s string) string {
-	firstChar := ""
-	for _, r := range s {
-		firstChar = fmt.Sprintf("%c", r)
-		break
-	}
-	return firstChar
 }
 
 type testCase struct {

--- a/mgmt/rest/metric.go
+++ b/mgmt/rest/metric.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+	"github.com/intelsdi-x/snap/pkg/stringutils"
 )
 
 func (s *Server) getMetrics(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -51,8 +52,9 @@ func (s *Server) getMetrics(w http.ResponseWriter, r *http.Request, _ httprouter
 				return
 			}
 		}
-		// strip the leading '/' and split on the remaining '/'
-		ns := strings.Split(strings.TrimLeft(ns_query, "/"), "/")
+		// strip the leading char and split on the remaining.
+		fc := stringutils.GetFirstChar(ns_query)
+		ns := strings.Split(strings.TrimLeft(ns_query, fc), fc)
 		if ns[len(ns)-1] == "*" {
 			ns = ns[:len(ns)-1]
 		}

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -516,11 +516,17 @@ func respond(code int, b rbody.Body, w http.ResponseWriter) {
 }
 
 func parseNamespace(ns string) []string {
-	if strings.Index(ns, "/") == 0 {
-		ns = ns[1:]
+	fc := getFirstChar(ns)
+	ns = strings.Trim(ns, fc)
+	return strings.Split(ns, fc)
+}
+
+// GetFirstChar returns the first character from the input string.
+func getFirstChar(s string) string {
+	firstChar := ""
+	for _, r := range s {
+		firstChar = fmt.Sprintf("%c", r)
+		break
 	}
-	if ns[len(ns)-1] == '/' {
-		ns = ns[:len(ns)-1]
-	}
-	return strings.Split(ns, "/")
+	return firstChar
 }

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 	cschedule "github.com/intelsdi-x/snap/pkg/schedule"
+	"github.com/intelsdi-x/snap/pkg/stringutils"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 )
 
@@ -516,17 +517,7 @@ func respond(code int, b rbody.Body, w http.ResponseWriter) {
 }
 
 func parseNamespace(ns string) []string {
-	fc := getFirstChar(ns)
+	fc := stringutils.GetFirstChar(ns)
 	ns = strings.Trim(ns, fc)
 	return strings.Split(ns, fc)
-}
-
-// GetFirstChar returns the first character from the input string.
-func getFirstChar(s string) string {
-	firstChar := ""
-	for _, r := range s {
-		firstChar = fmt.Sprintf("%c", r)
-		break
-	}
-	return firstChar
 }

--- a/mgmt/rest/server_test.go
+++ b/mgmt/rest/server_test.go
@@ -145,3 +145,44 @@ func TestRestAPIDefaultConfig(t *testing.T) {
 		})
 	})
 }
+
+func TestParseNamespace(t *testing.T) {
+	tcs := getNsTestCases()
+
+	Convey("Test parseNamespace", t, func() {
+		for _, c := range tcs {
+			Convey("Test parseNamespace "+c.input, func() {
+				So(c.output, ShouldResemble, parseNamespace(c.input))
+			})
+		}
+	})
+}
+
+type nsTestCase struct {
+	input  string
+	output []string
+}
+
+func getNsTestCases() []nsTestCase {
+	tcs := []nsTestCase{
+		{
+			input:  "小a小b小c",
+			output: []string{"a", "b", "c"}},
+		{
+			input:  "%a%b%c",
+			output: []string{"a", "b", "c"}},
+		{
+			input:  "-aヒ-b/-c|",
+			output: []string{"aヒ", "b/", "c|"}},
+		{
+			input:  ">a>b=>c=",
+			output: []string{"a", "b=", "c="}},
+		{
+			input:  ">a>b<>c<",
+			output: []string{"a", "b<", "c<"}},
+		{
+			input:  "㊽a㊽b%㊽c/|",
+			output: []string{"a", "b%", "c/|"}},
+	}
+	return tcs
+}

--- a/pkg/stringutils/string.go
+++ b/pkg/stringutils/string.go
@@ -1,0 +1,13 @@
+package stringutils
+
+import "fmt"
+
+// GetFirstChar returns the first character from the input string.
+func GetFirstChar(s string) string {
+	firstChar := ""
+	for _, r := range s {
+		firstChar = fmt.Sprintf("%c", r)
+		break
+	}
+	return firstChar
+}

--- a/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
@@ -113,30 +113,45 @@ func (f *Mock) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) {
 	}
 	if _, err := cfg.GetBool("test"); err == nil {
 		mts = append(mts, plugin.Metric{
-			Namespace:   plugin.NewNamespace("intel", "mock", "test"),
+			Namespace:   plugin.NewNamespace("intel", "mock", "test%>"),
 			Description: "mock description",
 			Unit:        "mock unit",
 		})
 	}
 	if _, err := cfg.GetBool("test-less"); err != nil {
 		mts = append(mts, plugin.Metric{
-			Namespace:   plugin.NewNamespace("intel", "mock", "foo"),
+			Namespace:   plugin.NewNamespace("intel", "mock", "/foo=㊽"),
 			Description: "mock description",
 			Unit:        "mock unit",
 		})
 	}
 	mts = append(mts, plugin.Metric{
-		Namespace:   plugin.NewNamespace("intel", "mock", "bar"),
+		Namespace:   plugin.NewNamespace("intel", "mock", "/bar⽔"),
 		Description: "mock description",
 		Unit:        "mock unit",
 	})
 	mts = append(mts, plugin.Metric{
 		Namespace: plugin.NewNamespace("intel", "mock").
 			AddDynamicElement("host", "name of the host").
-			AddStaticElement("baz"),
+			AddStaticElement("/baz⽔"),
 		Description: "mock description",
 		Unit:        "mock unit",
 	})
+	mts = append(mts, plugin.Metric{
+		Namespace: plugin.NewNamespace("intel", "mock").
+			AddDynamicElement("host", "name of the host").
+			AddStaticElements("baz㊽", "/bar⽔"),
+		Description: "mock description",
+		Unit:        "mock unit",
+	})
+	mts = append(mts, plugin.Metric{
+		Namespace: plugin.NewNamespace("intel", "mock").
+			AddDynamicElement("host", "name of the host").
+			AddStaticElements("baz㊽", "|barᵹÄ☍"),
+		Description: "mock description",
+		Unit:        "mock unit",
+	})
+
 	return mts, nil
 }
 

--- a/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock_medium_test.go
+++ b/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock_medium_test.go
@@ -189,7 +189,7 @@ func TestGetMetricTypes(t *testing.T) {
 			mts, err := newPlg.GetMetricTypes(cfg)
 
 			So(err, ShouldBeNil)
-			So(len(mts), ShouldEqual, 4)
+			So(len(mts), ShouldEqual, 6)
 
 			Convey("checking namespaces", func() {
 				metricNames := []string{}
@@ -197,16 +197,16 @@ func TestGetMetricTypes(t *testing.T) {
 					metricNames = append(metricNames, m.Namespace.String())
 				}
 
-				ns := plugin.NewNamespace("intel", "mock", "test")
+				ns := plugin.NewNamespace("intel", "mock", "test%>")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 
-				ns = plugin.NewNamespace("intel", "mock", "foo")
+				ns = plugin.NewNamespace("intel", "mock", "/foo=㊽")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 
-				ns = plugin.NewNamespace("intel", "mock", "bar")
+				ns = plugin.NewNamespace("intel", "mock", "/bar⽔")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 
-				ns = plugin.NewNamespace("intel", "mock").AddDynamicElement("host", "name of the host").AddStaticElement("baz")
+				ns = plugin.NewNamespace("intel", "mock").AddDynamicElement("host", "name of the host").AddStaticElements("baz㊽", "/bar⽔")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 			})
 		})
@@ -215,7 +215,7 @@ func TestGetMetricTypes(t *testing.T) {
 			mts, err := newPlg.GetMetricTypes(plugin.Config{})
 
 			So(err, ShouldBeNil)
-			So(len(mts), ShouldEqual, 3)
+			So(len(mts), ShouldEqual, 5)
 
 			Convey("checking namespaces", func() {
 				metricNames := []string{}
@@ -223,13 +223,13 @@ func TestGetMetricTypes(t *testing.T) {
 					metricNames = append(metricNames, m.Namespace.String())
 				}
 
-				ns := plugin.NewNamespace("intel", "mock", "foo")
+				ns := plugin.NewNamespace("intel", "mock", "/foo=㊽")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 
-				ns = plugin.NewNamespace("intel", "mock", "bar")
+				ns = plugin.NewNamespace("intel", "mock", "/bar⽔")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 
-				ns = plugin.NewNamespace("intel", "mock").AddDynamicElement("host", "name of the host").AddStaticElement("baz")
+				ns = plugin.NewNamespace("intel", "mock").AddDynamicElement("host", "name of the host").AddStaticElements("baz㊽", "|barᵹÄ☍")
 				So(str.Contains(metricNames, ns.String()), ShouldBeTrue)
 			})
 		})

--- a/scheduler/wmap/wmap.go
+++ b/scheduler/wmap/wmap.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
+	"github.com/intelsdi-x/snap/pkg/stringutils"
 )
 
 var (
@@ -216,7 +217,7 @@ func (c *CollectWorkflowMapNode) GetMetrics() []Metric {
 	for k, v := range c.Metrics {
 		// Identify the character to split on by peaking
 		// at the first character of each metric.
-		firstChar := getFirstChar(k)
+		firstChar := stringutils.GetFirstChar(k)
 		ns := strings.Trim(k, firstChar)
 		metrics[i] = Metric{
 			namespace: strings.Split(ns, firstChar),
@@ -225,16 +226,6 @@ func (c *CollectWorkflowMapNode) GetMetrics() []Metric {
 		i++
 	}
 	return metrics
-}
-
-// GetFirstChar returns the first character from the input string.
-func getFirstChar(s string) string {
-	firstChar := ""
-	for _, r := range s {
-		firstChar = fmt.Sprintf("%c", r)
-		break
-	}
-	return firstChar
 }
 
 func (c *CollectWorkflowMapNode) GetTags() map[string]map[string]string {


### PR DESCRIPTION
Fixes #1273 

#### Summary of changes:
- Removed hardcoded "/" separator implementation
- parse namespace on its first character.

**Note**
- curl has to urlencode URL if special character presents


#### Testing done:
- unit test
- integration test
- CLI

##### Metric Catalog tested:
```
▶ $SNAP_PATH/darwin/x86_64/snapctl metric list
NAMESPACE 			 VERSIONS
/intel/mock/*/baz㊽/|barᵹÄ☍ 	 1
|intel|mock|*|/baz⽔ 		 1
|intel|mock|*|baz㊽|/bar⽔ 	 1
|intel|mock|/bar⽔ 		 1
|intel|mock|/foo㊽ 		 1
```

##### CLI tested
```
▶ curl http://localhost:8181/v1/metrics
{
  "meta": {
    "code": 200,
    "message": "Metrics returned",
    "type": "metrics_returned",
    "version": 1
  },
  "body": [
    {
      "last_advertised_timestamp": 27,
      "namespace": "/intel/mock/*/baz㊽/|barᵹÄ☍",
      "version": 1,
      "dynamic": true,
      "dynamic_elements": [
        {
          "index": 2,
          "name": "host",
          "description": "name of the host"
        }
      ],
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%2Fintel%2Fmock%2F%2A%2Fbaz%E3%8A%BD%2F%7Cbar%E1%B5%B9%C3%84%E2%98%8D&ver=1"
    },
    {
      "last_advertised_timestamp": 27,
      "namespace": "|intel|mock|*|/baz⽔",
      "version": 1,
      "dynamic": true,
      "dynamic_elements": [
        {
          "index": 2,
          "name": "host",
          "description": "name of the host"
        }
      ],
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%7Cintel%7Cmock%7C%2A%7C%2Fbaz%E2%BD%94&ver=1"
    },
    {
      "last_advertised_timestamp": 27,
      "namespace": "|intel|mock|*|baz㊽|/bar⽔",
      "version": 1,
      "dynamic": true,
      "dynamic_elements": [
        {
          "index": 2,
          "name": "host",
          "description": "name of the host"
        }
      ],
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%7Cintel%7Cmock%7C%2A%7Cbaz%E3%8A%BD%7C%2Fbar%E2%BD%94&ver=1"
    },
    {
      "last_advertised_timestamp": 27,
      "namespace": "|intel|mock|/bar⽔",
      "version": 1,
      "dynamic": false,
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%7Cintel%7Cmock%7C%2Fbar%E2%BD%94&ver=1"
    },
    {
      "last_advertised_timestamp": 27,
      "namespace": "|intel|mock|/foo㊽",
      "version": 1,
      "dynamic": false,
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%7Cintel%7Cmock%7C%2Ffoo%E3%8A%BD&ver=1"
    }
  ]
}
```

##### Curl individual metric:
```▶ curl http://localhost:8181/v1/metrics\?ns\=%2Fintel%2Fmock%2F%2A%2Fbaz%E3%8A%BD%2F%7Cbar%E1%B5%B9%C3%84%E2%98%8D\&ver\=1
{
  "meta": {
    "code": 200,
    "message": "Metrics returned",
    "type": "metrics_returned",
    "version": 1
  },
  "body": [
    {
      "last_advertised_timestamp": 27,
      "namespace": "/intel/mock/*/baz㊽/|barᵹÄ☍",
      "version": 1,
      "dynamic": true,
      "dynamic_elements": [
        {
          "index": 2,
          "name": "host",
          "description": "name of the host"
        }
      ],
      "description": "mock description",
      "unit": "mock unit",
      "href": "http://localhost:8181/v1/metrics?ns=%2Fintel%2Fmock%2F%2A%2Fbaz%E3%8A%BD%2F%7Cbar%E1%B5%B9%C3%84%E2%98%8D&ver=1"
    }
  ]
}
```

SNAPCTL

```
▶ $SNAP_PATH/darwin/x86_64/snapctl metric get -m "/intel/mock/*/baz㊽/|bar<1d79>Ä☍"
NAMESPACE 				 VERSION 	 UNIT 		 LAST ADVERTISED TIME 		 DESCRIPTION
/intel/mock/[host]/baz㊽/|barᵹÄ☍ 	 1 		 mock unit 	 Wed, 31 Dec 1969 16:00:27 PST 	 mock description

  Dynamic elements of namespace: /intel/mock/[host]/baz㊽/|barᵹÄ☍

       NAME 	 DESCRIPTION
       host 	 name of the host

  Rules for collecting /intel/mock/[host]/baz㊽/|barᵹÄ☍:

       NAME 	 TYPE 	 DEFAULT 	 REQUIRED 	 MINIMUM 	 MAXIMUM
```

TASK WATCH

![Task Watch](https://cloud.githubusercontent.com/assets/13841563/19369133/705f2962-9158-11e6-8c64-47b9b8548142.png)

@intelsdi-x/snap-maintainers

