### PR TITLE
Changed mock1 collector RPC Type: from JSONRPC to default NativeRPC

### DIFF
--- a/control/control_test.go
+++ b/control/control_test.go
@@ -1777,9 +1777,7 @@ func TestDynamicMetricSubscriptionLoad(t *testing.T) {
 				So(m.Version(), ShouldEqual, 1)
 				if ok, _ := m.Namespace().IsDynamic(); ok {
 					// V1's data for no dynamic metric
-					// Because mock1 uses jsonrpc, all number typers are interpreted
-					// as float64
-					val, ok := m.Data().(float64)
+					val, ok := m.Data().(int)
 					So(ok, ShouldEqual, true)
 					So(val, ShouldBeLessThan, 100)
 				} else {
@@ -1961,9 +1959,7 @@ func TestDynamicMetricSubscriptionLoadLessMetrics(t *testing.T) {
 		Convey("metrics are collected from mock1", func() {
 			for _, m := range mts1 {
 				if strings.Contains(m.Namespace().String(), "host") {
-					// Because mock1 uses jsonrpc, all number typers are interpreted
-					// as float64
-					val, ok := m.Data().(float64)
+					val, ok := m.Data().(int)
 					So(ok, ShouldEqual, true)
 					So(val, ShouldBeLessThan, 100)
 				} else {

--- a/plugin/collector/snap-plugin-collector-mock1/main.go
+++ b/plugin/collector/snap-plugin-collector-mock1/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Define metadata about Plugin
 	meta := mock.Meta()
-	meta.RPCType = plugin.JSONRPC
+	meta.RPCType = plugin.NativeRPC
 	// Start a collector
 	plugin.Start(meta, new(mock.Mock), os.Args[1])
 }


### PR DESCRIPTION
Summary of changes:
- collector mock1 has been changed: its meta RPC Type converted from `JSONRPC` (depracated) to default RPC type which is `NativeRPC`

Testing done:
- small, medium, legacy tests

@intelsdi-x/snap-maintainers

