### PR TITLE
Removed JSON RPC from tests cases

### DIFF
--- a/control/plugin/collector_test.go
+++ b/control/plugin/collector_test.go
@@ -51,15 +51,17 @@ func TestStartCollector(t *testing.T) {
 	Convey("Collector", t, func() {
 		Convey("start with dynamic port", func() {
 			m := &PluginMeta{
-				RPCType: JSONRPC,
+				RPCType: NativeRPC,
 				Type:    CollectorPluginType,
 			}
 			c := new(MockPlugin)
+
 			err, rc := Start(m, c, "{}")
 			So(err, ShouldBeNil)
 			So(rc, ShouldEqual, 0)
-			Convey("RPC service already registered", func() {
-				So(func() { Start(m, c, "{}") }, ShouldPanic)
+
+			Convey("RPC service should not panic", func() {
+				So(func() { Start(m, c, "{}") }, ShouldNotPanic)
 			})
 		})
 	})

--- a/control/plugin/processor_test.go
+++ b/control/plugin/processor_test.go
@@ -109,13 +109,11 @@ func TestStartProcessor(t *testing.T) {
 		Convey("start with dynamic port", func() {
 			c := new(MockProcessor)
 			m := &PluginMeta{
-				RPCType: JSONRPC,
+				RPCType: NativeRPC,
 				Type:    ProcessorPluginType,
 			}
-			// we will panic since rpc.HandleHttp has already
-			// been called during TestStartCollector
-			Convey("RPC service already registered", func() {
-				So(func() { Start(m, c, "{}") }, ShouldPanic)
+			Convey("RPC service should not panic", func() {
+				So(func() { Start(m, c, "{}") }, ShouldNotPanic)
 			})
 
 		})

--- a/control/plugin/publisher_test.go
+++ b/control/plugin/publisher_test.go
@@ -40,8 +40,8 @@ func (f *MockPublisher) Publish(_ string, _ []byte, _ map[string]ctypes.ConfigVa
 	return nil
 }
 
-func (f *MockPublisher) GetConfigPolicy() cpolicy.ConfigPolicy {
-	return cpolicy.ConfigPolicy{}
+func (f *MockPublisher) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	return &cpolicy.ConfigPolicy{}, nil
 }
 
 type MockPublisherSessionState struct {
@@ -107,15 +107,14 @@ func (s *MockPublisherSessionState) heartbeatWatch(killChan chan int) {
 func TestStartPublisher(t *testing.T) {
 	Convey("Publisher", t, func() {
 		Convey("start with dynamic port", func() {
-			c := new(MockProcessor)
+			c := new(MockPublisher)
 			m := &PluginMeta{
-				RPCType: JSONRPC,
+				RPCType: NativeRPC,
 				Type:    PublisherPluginType,
 			}
-			// we will panic since rpc.HandleHttp has already
-			// been called during TestStartCollector
-			Convey("RPC service already registered", func() {
-				So(func() { Start(m, c, "{}") }, ShouldPanic)
+
+			Convey("RPC service should not panic", func() {
+				So(func() { Start(m, c, "{}") }, ShouldNotPanic)
 			})
 
 		})


### PR DESCRIPTION
Summary of changes:
- changed tests cases which utilize JSON RPC, converted to use NativeRPC (default)
- fixed test for publisher: 
   - changed MockProcessor to MockPublisher which should be used in this test
   - updated declaration of `GetConfigPolicy()` 

Testing done:
- run legacy tests

@intelsdi-x/snap-maintainers

