### PR TITLE
Deprecated JSON RPC - added deprecation warning

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -101,6 +101,11 @@ func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executab
 	case plugin.CollectorPluginType:
 		switch resp.Meta.RPCType {
 		case plugin.JSONRPC:
+			log.WithFields(log.Fields{
+				"_module":     "control-aplugin",
+				"_block":      "newAvailablePlugin",
+				"plugin_name": ap.name,
+			}).Warning("This plugin is using a deprecated JSON RPC protocol. Find more information here: https://github.com/intelsdi-x/snap/issues/1296 ")
 			c, e := client.NewCollectorHttpJSONRPCClient(listenURL, DefaultClientTimeout, resp.PublicKey, !resp.Meta.Unsecure)
 			if e != nil {
 				return nil, errors.New("error while creating client connection: " + e.Error())

--- a/control/plugin/client/httpjsonrpc_deprecated.go
+++ b/control/plugin/client/httpjsonrpc_deprecated.go
@@ -1,3 +1,8 @@
+/*          **  DEPRECATED  **
+For more information, see our deprecation notice
+on Github: https://github.com/intelsdi-x/snap/issues/1296
+*/
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 

--- a/control/plugin/client/httpjsonrpc_deprecated_test.go
+++ b/control/plugin/client/httpjsonrpc_deprecated_test.go
@@ -1,3 +1,8 @@
+/*          **  DEPRECATED  **
+For more information, see our deprecation notice
+on Github: https://github.com/intelsdi-x/snap/issues/1296
+*/
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 


### PR DESCRIPTION
Related with #1296 

Summary of changes:
- Added deprecation warning that will appear when loading legacy plugins
  - the same format of message as for [NativeRPC](https://github.com/intelsdi-x/snap/blob/master/control/available_plugin.go#L109)
- Renaming `httpjsonrpc.go` to `httpjsonrpc_deprecated.go`
- Renaming `httpjsonrpc_test.go` to `httpjsonrpc_deprecated_test.go`

Testing done:
- Unit tests, Running snap

@intelsdi-x/snap-maintainers

