### PR TITLE
Added docs/MAINTAINERS.md

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,0 +1,38 @@
+snap-maintainers, plugin-maintainers:
+  Joel Cooklin (@jcooklin)
+  Cody Roseborough (@IRCody)
+  Emily Gu (@candysmurf)
+  Marcin Krolik (@marcin-krolik)
+  Izabella Raulin (@IzabellaRaulin)
+  Matt Brender (@mjbrender)
+  Andrzej Kuriata (@andrzej-k)
+  Connor Doyle (@ConnorDoyle)
+  Olivier Cano (@kindermoumoute)
+  Niklas Quarfot Nielsen (@nqn)
+
+snap-maintainers:
+  Nicholas Weaver (@lynxbat)
+  dan pittman (@danielscottt)
+  Kelly Lyon (@kjlyon)
+
+plugin-maintainers:
+  Pawel Palucki (@ppalucki)
+  Patryk Matyjasek (@PatrykMatyjasek)
+  Marcin Spoczynski (@sandlbn)
+  Szymon Konefal (@skonefal)
+  Mateusz Kleina (@mkleina)
+  Łukasz Mróz (@lmroz)
+  Maria Rolbiecka (@mkuculyma)
+  Katarzyna Kujawa (@katarzyna-z)
+  iwankgb (@iwankgb)
+  B.J. Ray (@bjray)
+  Maciej Cichocki (@kimbarbel)
+  Maciej Patelczyk (@mpatelcz)
+  Paweł Adamczyk (@ppadamcz)
+  Piotr (@padamowi)
+  akwasnie (@akwasnie)
+  maciej-wisniewski (@maciej-wisniewski)
+  marcintao (@marcintao)
+  ptbuilder (@ptbuilder)
+  rashmigottipati (@rashmigottipati)
+


### PR DESCRIPTION
Summary of changes:
- Added document listing snap maintainers and plugins maintaintainers

Because it's not possible to list team members from outside of our organization, this information has to be delivered another way. This list is automatically generated so it may require adjustments.

@intelsdi-x/snap-maintainers
