### PR TITLE
Fix get config policy rules from plugin catalog

### DIFF
--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -345,7 +345,7 @@ func (s *subscriptionGroup) process(id string) (serrs []serror.SnapError) {
 			plugins = append(plugins, plugin)
 			// add defaults to plugins (exposed in a plugins ConfigPolicy)
 			if lp, err := s.pluginManager.get(
-				fmt.Sprintf("%s:%s:%d",
+				fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d",
 					plugin.TypeName(),
 					plugin.Name(),
 					plugin.Version())); err == nil && lp.ConfigPolicy != nil {


### PR DESCRIPTION
#1199 introduced a new key format for plugin catalog, that didn't got followed by #1225 .

Summary of changes:
- Now use the good format.

Testing done:
- Use default values in config policy rules.