### PR TITLE
Removes commented out code from scheduler.go

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -487,7 +487,6 @@ func (s *scheduler) startTask(id, source string) []serror.SnapError {
 	var subbedDeps []string
 	for k := range depGroups {
 		var errs []serror.SnapError
-		// cps := returnCorePlugin(depGroups[k].subscribedPlugins)
 		mgr, err := t.RemoteManagers.Get(k)
 		if err != nil {
 			errs = append(errs, serror.New(err))


### PR DESCRIPTION
Removes commented out code that doesn't have any relevance to the current code in this area as far as I can tell.

@intelsdi-x/snap-maintainers

