### PR TITLE
Fixes #1324: Properly closes connections in tribe

### DIFF
--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -172,6 +172,7 @@ func (c *Client) do(method, path string, ct contentType, body ...[]byte) (*rbody
 			}
 			return nil, fmt.Errorf("URL target is not available. %v", err)
 		}
+		defer rsp.Body.Close()
 	case "PUT":
 		var b *bytes.Reader
 		if len(body) == 0 {
@@ -193,6 +194,7 @@ func (c *Client) do(method, path string, ct contentType, body ...[]byte) (*rbody
 			}
 			return nil, fmt.Errorf("URL target is not available. %v", err)
 		}
+		defer rsp.Body.Close()
 	case "DELETE":
 		var b *bytes.Reader
 		if len(body) == 0 {
@@ -214,6 +216,7 @@ func (c *Client) do(method, path string, ct contentType, body ...[]byte) (*rbody
 			}
 			return nil, fmt.Errorf("URL target is not available. %v", err)
 		}
+		defer rsp.Body.Close()
 	case "POST":
 		var b *bytes.Reader
 		if len(body) == 0 {
@@ -234,6 +237,7 @@ func (c *Client) do(method, path string, ct contentType, body ...[]byte) (*rbody
 			}
 			return nil, fmt.Errorf("URL target is not available. %v", err)
 		}
+		defer rsp.Body.Close()
 	}
 
 	return httpRespToAPIResp(rsp)


### PR DESCRIPTION
Fixes #1324

Summary of changes:
- adds proper http.Response.Close() calls. Primarily in worker.go (which causes this issue) but also around some of the client calls that I think could cause similar issues.

Testing done:
- Reproduced the bug in #1324 reliably, implemented the fix, and tested via same method and verified that the number of open connections isn't constantly growing. 

@intelsdi-x/snap-maintainers