### PR TITLE
Update dependency with plugin lib

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -49,7 +49,7 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: db68f6fda248706a71980abc58e969fcd63f5ea6
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: d54f454f345cd2f3579784ae8ffd07add438b402
+  version: 396b2b1222993fc310915fee81fa759c107a95bb
   subpackages:
   - v1/plugin
   - v1/plugin/rpc


### PR DESCRIPTION
So mock plugins are not using a deprecated library.