### PR TITLE
Adds support for plugin pkgs w\ multiple commands

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -72,7 +71,6 @@ type availablePlugin struct {
 	failedHealthChecks int
 	healthChan         chan error
 	ePlugin            executablePlugin
-	exec               string
 	execPath           string
 	fromPackage        bool
 	pprofPort          string
@@ -240,8 +238,8 @@ func (a *availablePlugin) Kill(r string) error {
 			"_module":     "control-aplugin",
 			"block":       "kill",
 			"plugin_name": a,
-			"pluginPath":  path.Join(a.execPath, a.exec),
-		}).Debug("deleting available plugin path")
+			"pluginPath":  a.execPath,
+		}).Debug("deleting available plugin package")
 		os.RemoveAll(filepath.Dir(a.execPath))
 	}
 	return a.ePlugin.Kill()

--- a/control/control.go
+++ b/control/control.go
@@ -115,7 +115,7 @@ type runsPlugins interface {
 	SetMetricCatalog(catalogsMetrics)
 	SetPluginManager(managesPlugins)
 	Monitor() *monitor
-	runPlugin(*pluginDetails) error
+	runPlugin(string, *pluginDetails) error
 }
 
 type managesPlugins interface {
@@ -555,11 +555,11 @@ func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDe
 		if details.Manifest, err = aci.Manifest(f); err != nil {
 			return nil, serror.New(err)
 		}
-		details.Exec = details.Manifest.App.Exec[0]
+		details.Exec = details.Manifest.App.Exec
 		details.IsPackage = true
 	} else {
 		details.IsPackage = false
-		details.Exec = filepath.Base(rp.Path())
+		details.Exec = []string{filepath.Base(rp.Path())}
 		details.ExecPath = filepath.Dir(rp.Path())
 	}
 

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -960,7 +960,7 @@ func TestRoutingCachingStrategy(t *testing.T) {
 			}
 			for _, id := range tasks {
 				pool.Subscribe(id)
-				err = c.pluginRunner.runPlugin(lp.Details)
+				err = c.pluginRunner.runPlugin(lp.Name(), lp.Details)
 				So(err, ShouldBeNil)
 				serr := c.subscriptionGroups.Add(id, []core.RequestedMetric{metric}, cdt, []core.SubscribedPlugin{})
 				So(serr, ShouldBeNil)
@@ -1031,7 +1031,7 @@ func TestRoutingCachingStrategy(t *testing.T) {
 			}
 			for _, id := range tasks {
 				pool.Subscribe(id)
-				err = c.pluginRunner.runPlugin(lp.Details)
+				err = c.pluginRunner.runPlugin(lp.Name(), lp.Details)
 				So(err, ShouldBeNil)
 				serrs := c.subscriptionGroups.Add(id, []core.RequestedMetric{metric}, cdt, []core.SubscribedPlugin{})
 				So(serrs, ShouldBeNil)

--- a/control/plugin_manager_test.go
+++ b/control/plugin_manager_test.go
@@ -74,7 +74,7 @@ func loadPlugin(p *pluginManager, path string) (*loadedPlugin, serror.SnapError)
 	details := &pluginDetails{
 		Path:         path,
 		ExecPath:     filepath.Dir(path),
-		Exec:         filepath.Base(path),
+		Exec:         []string{filepath.Base(path)},
 		IsAutoLoaded: true,
 	}
 	for i := 0; i < 3; i++ {

--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -417,7 +417,7 @@ func (s *subscriptionGroup) subscribePlugins(id string,
 				serrs = append(serrs, serror.New(err))
 				return serrs
 			}
-			err = s.pluginRunner.runPlugin(plg.Details)
+			err = s.pluginRunner.runPlugin(plg.Name(), plg.Details)
 			if err != nil {
 				serrs = append(serrs, serror.New(err))
 				return serrs


### PR DESCRIPTION
Fixes #1346 

Summary of changes:
- Adds support for plugin packages with multiple commands
  -  Some plugins need to support declaring the interpreter and the entry point along with the command line args. 

Testing done:
- Unit
- Manual

The screen capture below demonstrates creating 3 python based plugin packages, loading and starting a task which uses them **using this branch**.  
![demo](https://www.dropbox.com/s/ier98lvwjm5rrle/packaging.gif?raw=1)

@intelsdi-x/snap-maintainers

- Plugin packages need to support declaring the interpreter and the entrypoint
  along with the command line args.