### PR TITLE
Makes plugin healthchecks less aggressive

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -46,7 +46,7 @@ const (
 	// DefaultClientTimeout - default timeout for a client connection attempt
 	DefaultClientTimeout = time.Second * 10
 	// DefaultHealthCheckTimeout - default timeout for a health check
-	DefaultHealthCheckTimeout = time.Second * 1
+	DefaultHealthCheckTimeout = time.Second * 10
 	// DefaultHealthCheckFailureLimit - how any consecutive health check timeouts must occur to trigger a failure
 	DefaultHealthCheckFailureLimit = 3
 )

--- a/control/monitor.go
+++ b/control/monitor.go
@@ -28,7 +28,7 @@ const (
 	MonitorStarted
 
 	// DefaultMonitorDuration - the default monitor duration.
-	DefaultMonitorDuration = time.Second * 1
+	DefaultMonitorDuration = time.Second * 5
 )
 
 type monitorState int

--- a/control/monitor_test.go
+++ b/control/monitor_test.go
@@ -98,7 +98,7 @@ func TestMonitor(t *testing.T) {
 			oldOpt := m.Option(MonitorDurationOption(time.Millisecond * 200))
 			So(m.duration, ShouldResemble, time.Millisecond*200)
 			m.Option(oldOpt)
-			So(m.duration, ShouldResemble, time.Second*1)
+			So(m.duration, ShouldResemble, time.Second*5)
 		})
 	})
 }

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -80,7 +80,7 @@ const (
 var (
 	// Timeout settings
 	// How much time must elapse before a lack of Ping results in a timeout
-	PingTimeoutDurationDefault = time.Millisecond * 1500
+	PingTimeoutDurationDefault = time.Second * 10
 
 	// Array matching plugin type enum to a string
 	// note: in string representation we use lower case

--- a/control/plugin/session_deprecated.go
+++ b/control/plugin/session_deprecated.go
@@ -203,6 +203,7 @@ func (s *SessionState) generateResponse(r *Response) []byte {
 func (s *SessionState) heartbeatWatch(killChan chan int) {
 	s.logger.Debug("Heartbeat started")
 	count := 0
+	s.ResetHeartbeat()
 	for {
 		if time.Since(s.LastPing) >= s.PingTimeoutDuration {
 			count++


### PR DESCRIPTION


Summary of changes:

-Lengthens the timeout for plugin health checks in order to be less
aggressive about killing plugins.

@intelsdi-x/snap-maintainers