### PR TITLE
Added mkdir to Makefile to create sbin and bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ plugins:
 all:
 	bash -c "./scripts/build_all.sh"
 install:
+	mkdir -p /usr/local/sbin
+	mkdir -p /usr/local/bin
 	cp build/$(OS)/$(ARCH)/snapteld /usr/local/sbin/
 	cp build/$(OS)/$(ARCH)/snaptel /usr/local/bin/
 proto:


### PR DESCRIPTION
My workstation didn't have the directory /usr/local/sbin. I was receiving this error on running `make install`

![screen shot 2016-11-21 at 11 01 10 am](https://cloud.githubusercontent.com/assets/21182867/20496351/ac18c23e-afd9-11e6-893a-06a29fa1937b.png)

 Added code to create directories `sbin` and `bin` if they don't already exist. 

@intelsdi-x/snap-maintainers

