### PR TITLE
update downloads, plugin tar.gz bundle no longer produced

### DIFF
--- a/download.html
+++ b/download.html
@@ -74,7 +74,7 @@
         <h2 class="text-center"> Download </h2><br>
     
     <p>
-    Here you’ll find the latest versioned binaries of Snap and a package of starter plugins. To view a comprehensive list of plugins please see our <a href="http://intelsdi-x.github.io/snap/plugins">Plugin Catalog</a>. You can also find previous releases on Snap's <a href="https://github.com/intelsdi-x/snap/releases">GitHub Releases</a> page.  More information on <a href="https://github.com/intelsdi-x/snap#getting-started">getting started and running Snap</a> can be found on the Snap Github page. 
+    Here you’ll find the latest versioned binaries of Snap. To view a comprehensive list of plugins please see our <a href="http://intelsdi-x.github.io/snap/plugins">Plugin Catalog</a>. You can also find previous releases on Snap's <a href="https://github.com/intelsdi-x/snap/releases">GitHub Releases</a> page.  More information on <a href="https://github.com/intelsdi-x/snap#getting-started">getting started and running Snap</a> can be found on the Snap Github page. 
     </p><br>
     <p>
     Right now, Snap only supports Linux* and OS X* (Darwin). 
@@ -136,18 +136,7 @@
     
     
             <br>
-            <h4>Snap Plugins</h4>
-            <div class="row collapse">
-            <div class="large-8 columns">
-              <p>Snap Plugins Binary TAR Latest Version</p>
-            </div>
-            <div class="large-4 columns">
     
-              <div class ="">
-              <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-              </div><br>
-            </div>
-            </div>
     
     
             <h4>Install</h4>
@@ -190,20 +179,6 @@
             <br>
     
     
-            <h4>Snap Plugins</h4>
-            <div class="row collapse">
-            <div class="large-8 columns">
-              <p>Snap Plugins Binary TAR Latest Version</p>
-            </div>
-            <div class="large-4 columns">          
-    
-              <div class ="">
-              <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-              </div><br>
-            </div>
-            </div>
-    
-    
             <h4>Install</h4>
             <p>full install details available <a href="https://packagecloud.io/intelsdi-x/snap/install">here</a> </p>
             
@@ -227,21 +202,6 @@
             </div>
             </div>
     
-    
-            <br>
-            <h4>Snap Plugins</h4>
-            <div class="row collapse">
-            <div class="large-8 columns">
-              <p>Snap Plugins Binary TAR Latest Version</p>
-            </div>
-            <div class="large-4 columns">  
-    
-              <div class ="">
-              <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-              </div><br>
-            </div>
-            </div>
-            <br>
     
           </div>
     
@@ -279,19 +239,7 @@
     
     
             <br>
-            <h4>Snap Plugins</h4>
-            <div class="row collapse">
-            <div class="large-8 columns">
-              <p>Snap Plugins Binary TAR Latest Version</p>
-            </div>
-            <div class="large-4 columns">  
-              <div class ="">
-              <a class="button_dwnld" href="http://mac.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-              </div><br>
-            </div>
-            </div>
-            <br>
-    
+           
           </div>
     
     

--- a/zurb-template/src/pages/download.html
+++ b/zurb-template/src/pages/download.html
@@ -5,7 +5,7 @@
     <h2 class="text-center"> Download </h2><br>
 
 <p>
-Here you’ll find the latest versioned binaries of Snap and a package of starter plugins. To view a comprehensive list of plugins please see our <a href="http://intelsdi-x.github.io/snap/plugins">Plugin Catalog</a>. You can also find previous releases on Snap's <a href="https://github.com/intelsdi-x/snap/releases">GitHub Releases</a> page.  More information on <a href="https://github.com/intelsdi-x/snap#getting-started">getting started and running Snap</a> can be found on the Snap Github page. 
+Here you’ll find the latest versioned binaries of Snap. To view a comprehensive list of plugins please see our <a href="http://intelsdi-x.github.io/snap/plugins">Plugin Catalog</a>. You can also find previous releases on Snap's <a href="https://github.com/intelsdi-x/snap/releases">GitHub Releases</a> page.  More information on <a href="https://github.com/intelsdi-x/snap#getting-started">getting started and running Snap</a> can be found on the Snap Github page. 
 </p><br>
 <p>
 Right now, Snap only supports Linux* and OS X* (Darwin). 
@@ -67,18 +67,7 @@ If you come across any issues, or have any recommendations or comments, please s
 
 
         <br>
-        <h4>Snap Plugins</h4>
-        <div class="row collapse">
-        <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR Latest Version</p>
-        </div>
-        <div class="large-4 columns">
 
-          <div class ="">
-          <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-          </div><br>
-        </div>
-        </div>
 
 
         <h4>Install</h4>
@@ -121,20 +110,6 @@ If you come across any issues, or have any recommendations or comments, please s
         <br>
 
 
-        <h4>Snap Plugins</h4>
-        <div class="row collapse">
-        <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR Latest Version</p>
-        </div>
-        <div class="large-4 columns">          
-
-          <div class ="">
-          <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-          </div><br>
-        </div>
-        </div>
-
-
         <h4>Install</h4>
         <p>full install details available <a href="https://packagecloud.io/intelsdi-x/snap/install">here</a> </p>
         
@@ -158,21 +133,6 @@ If you come across any issues, or have any recommendations or comments, please s
         </div>
         </div>
 
-
-        <br>
-        <h4>Snap Plugins</h4>
-        <div class="row collapse">
-        <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR Latest Version</p>
-        </div>
-        <div class="large-4 columns">  
-
-          <div class ="">
-          <a class="button_dwnld" href="http://linux.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-          </div><br>
-        </div>
-        </div>
-        <br>
 
       </div>
 
@@ -210,19 +170,7 @@ If you come across any issues, or have any recommendations or comments, please s
 
 
         <br>
-        <h4>Snap Plugins</h4>
-        <div class="row collapse">
-        <div class="large-8 columns">
-          <p>Snap Plugins Binary TAR Latest Version</p>
-        </div>
-        <div class="large-4 columns">  
-          <div class ="">
-          <a class="button_dwnld" href="http://mac.plugin.dl.snap-telemetry.io"><i class="fa fa-download" aria-hidden="true" style="color:white"></i> Snap Plugins</a>
-          </div><br>
-        </div>
-        </div>
-        <br>
-
+       
       </div>
 
 


### PR DESCRIPTION
update downloads page, remove plugin tar.gz links 

