### PR TITLE
Fix snaptel environment variable.

### DIFF
--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -28,8 +28,8 @@ import (
 	"strconv"
 	"text/tabwriter"
 
-	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/core/ctypes"
+	"github.com/urfave/cli"
 )
 
 type config struct {

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -19,7 +19,7 @@ limitations under the License.
 
 package main
 
-import "github.com/codegangsta/cli"
+import "github.com/urfave/cli"
 
 var (
 
@@ -49,7 +49,7 @@ var (
 	}
 	flConfig = cli.StringFlag{
 		Name:   "config, c",
-		EnvVar: "SNAPCTL_CONFIG_PATH",
+		EnvVar: "SNAPTEL_CONFIG_PATH,SNAPCTL_CONFIG_PATH",
 		Usage:  "Path to a config file",
 		Value:  "",
 	}

--- a/cmd/snaptel/main.go
+++ b/cmd/snaptel/main.go
@@ -28,8 +28,8 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/cmd/snaptel/metric.go
+++ b/cmd/snaptel/metric.go
@@ -28,9 +28,9 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
 	"github.com/intelsdi-x/snap/mgmt/rest/rbody"
+	"github.com/urfave/cli"
 
 	"github.com/intelsdi-x/snap/pkg/stringutils"
 )

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -28,7 +28,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func loadPlugin(ctx *cli.Context) error {

--- a/cmd/snaptel/task.go
+++ b/cmd/snaptel/task.go
@@ -33,10 +33,10 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/robfig/cron"
+	"github.com/urfave/cli"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/ghodss/yaml"

--- a/cmd/snaptel/tribe.go
+++ b/cmd/snaptel/tribe.go
@@ -27,8 +27,8 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/codegangsta/cli"
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
+	"github.com/urfave/cli"
 )
 
 func listMembers(ctx *cli.Context) error {

--- a/control/flags.go
+++ b/control/flags.go
@@ -22,7 +22,7 @@ package control
 import (
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8fe2627eadf03d4c3aa9f8fac38b26a29340921c25ccc5b62490f91824014ace
-updated: 2016-11-16T15:41:06.279309067-08:00
+hash: 55584a3098467b96c2800b810444ba49663ade021e4f2d0796233b277d712415
+updated: 2016-11-22T14:54:43.026574122-08:00
 imports:
 - name: github.com/appc/spec
   version: db96f94ae6b227fe4d8288527ead8927181620f6
@@ -14,10 +14,6 @@ imports:
   version: 3df31a1ada83e310c2e24b267c8e8b68836547b4
 - name: github.com/asaskevich/govalidator
   version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
-- name: github.com/codegangsta/cli
-  version: 01857ac33766ce0c93856370626f9799281c14f4
-- name: github.com/codegangsta/negroni
-  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
 - name: github.com/coreos/go-semver
   version: 6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa
   subpackages:
@@ -59,6 +55,10 @@ imports:
   version: be52937128b38f1d99787bb476c789e2af1147f1
 - name: github.com/spf13/pflag
   version: 94e98a55fb412fcbcfc302555cb990f5e1590627
+- name: github.com/urfave/cli
+  version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
+- name: github.com/urfave/negroni
+  version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
 - name: github.com/vrischmann/jsonutil
   version: 694784f9315ee9fc763c1d30f28753cba21307aa
 - name: github.com/xeipuuv/gojsonpointer

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,9 +9,9 @@ import:
   - schema
 - package: github.com/asaskevich/govalidator
   version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
-- package: github.com/codegangsta/cli
-  version: 01857ac33766ce0c93856370626f9799281c14f4
-- package: github.com/codegangsta/negroni
+- package: github.com/urfave/cli
+  version: ^1.19.0
+- package: github.com/urfave/negroni
   version: c7477ad8e330bef55bf1ebe300cf8aa67c492d1b
 - package: github.com/ghodss/yaml
   version: c3eb24aeea63668ebdac08d2e252f20df8b6b1ae

--- a/mgmt/rest/flags.go
+++ b/mgmt/rest/flags.go
@@ -22,7 +22,7 @@ package rest
 import (
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/mgmt/rest/log_handler.go
+++ b/mgmt/rest/log_handler.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/negroni"
+	"github.com/urfave/negroni"
 )
 
 // Logger is a snap middleware that logs to a logrus facility

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -33,8 +33,8 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/negroni"
 	"github.com/julienschmidt/httprouter"
+	"github.com/urfave/negroni"
 
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"

--- a/mgmt/tribe/flags.go
+++ b/mgmt/tribe/flags.go
@@ -22,7 +22,7 @@ package tribe
 import (
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/scheduler/flags.go
+++ b/scheduler/flags.go
@@ -22,7 +22,7 @@ package scheduler
 import (
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 var (

--- a/snapteld.go
+++ b/snapteld.go
@@ -37,7 +37,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/vrischmann/jsonutil"
 
 	"github.com/intelsdi-x/snap/control"


### PR DESCRIPTION
Fixes snaptel environment flag to match new cli name

Summary of changes:
- Add SNAPTEL_CONFIG_PATH and maintain old SNAPCTL_CONFIG_PATH for now
- Update urfave/cli library to 1.19.0 since earlier versions does not detect env var as enabling the flag.

Testing done:
- Verify cli flags work as expected.

@intelsdi-x/snap-maintainers

