### PR TITLE
Added snap-plugin-collector-schedstat to the plugin list

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -61,6 +61,7 @@
 - intelsdi-x/snap-plugin-collector-psutil
 - intelsdi-x/snap-plugin-collector-rabbitmq
 - intelsdi-x/snap-plugin-collector-scaleio
+- intelsdi-x/snap-plugin-collector-schedstat
 - intelsdi-x/snap-plugin-collector-snmp
 - intelsdi-x/snap-plugin-collector-smart
 - intelsdi-x/snap-plugin-collector-swap


### PR DESCRIPTION
Summary of changes:
- Added snap-plugin-collector-schedstat to the plugin list

@intelsdi-x/snap-maintainers

