### PR TITLE
symlinks handling during plugins autodiscovery

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -315,52 +315,79 @@ func (p *pluginControl) Start() error {
 				}).Fatal(err)
 			}
 			for _, file := range files {
-				if file.IsDir() {
+				fileName := file.Name()
+
+				statCheck := file
+				if file.Mode()&os.ModeSymlink != 0 {
+					realPath, err := filepath.EvalSymlinks(filepath.Join(fullPath, fileName))
+					if err != nil {
+						controlLogger.WithFields(log.Fields{
+							"_block":           "start",
+							"autodiscoverpath": pa,
+							"error":            err,
+							"plugin":           fileName,
+						}).Error("Cannot follow symlink")
+						continue
+					}
+					statCheck, err = os.Stat(realPath)
+					if err != nil {
+						controlLogger.WithFields(log.Fields{
+							"_block":           "start",
+							"autodiscoverpath": pa,
+							"error":            err,
+							"plugin":           fileName,
+							"target-path":      realPath,
+						}).Error("Target of symlink inacessible")
+						continue
+					}
+				}
+
+				if statCheck.IsDir() {
 					controlLogger.WithFields(log.Fields{
 						"_block":           "start",
 						"autodiscoverpath": pa,
-					}).Warning("Ignoring subdirectory: ", file.Name())
+					}).Warning("Ignoring subdirectory: ", fileName)
 					continue
 				}
 				// Ignore tasks files (JSON and YAML)
-				fname := strings.ToLower(file.Name())
+				fname := strings.ToLower(fileName)
 				if strings.HasSuffix(fname, ".json") || strings.HasSuffix(fname, ".yaml") || strings.HasSuffix(fname, ".yml") {
 					controlLogger.WithFields(log.Fields{
 						"_block":           "start",
 						"autodiscoverpath": pa,
-					}).Warning("Ignoring JSON/Yaml file: ", file.Name())
+					}).Warning("Ignoring JSON/Yaml file: ", fileName)
 					continue
 				}
 				// if the file is a plugin package (which would have a suffix of '.aci') or if the file
 				// is not a plugin signing file (which would have a suffix of '.asc'), then attempt to
 				// automatically load the file as a plugin
-				if strings.HasSuffix(file.Name(), ".aci") || !(strings.HasSuffix(file.Name(), ".asc")) {
+				if strings.HasSuffix(fileName, ".aci") || !(strings.HasSuffix(fileName, ".asc")) {
 					// check to makd sure the file is executable by someone (even if it isn't you); if no one
 					// can execute this file then skip it (and include a warning in the log output)
-					if (file.Mode() & 0111) == 0 {
+					if (statCheck.Mode() & 0111) == 0 {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",
 							"autodiscoverpath": pa,
-							"plugin":           file,
-						}).Warn("Auto-loading of plugin '", file.Name(), "' skipped (plugin not executable)")
+							"plugin":           fileName,
+						}).Warn("Auto-loading of plugin '", fileName, "' skipped (plugin not executable)")
 						continue
 					}
-					rp, err := core.NewRequestedPlugin(path.Join(fullPath, file.Name()))
+					rp, err := core.NewRequestedPlugin(path.Join(fullPath, fileName))
 					if err != nil {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",
 							"autodiscoverpath": pa,
-							"plugin":           file,
+							"plugin":           fileName,
 						}).Error(err)
 					}
-					signatureFile := file.Name() + ".asc"
+					signatureFile := fileName + ".asc"
 					if _, err := os.Stat(path.Join(fullPath, signatureFile)); err == nil {
 						err = rp.ReadSignatureFile(path.Join(fullPath, signatureFile))
 						if err != nil {
 							controlLogger.WithFields(log.Fields{
 								"_block":           "start",
 								"autodiscoverpath": pa,
-								"plugin":           file.Name() + ".asc",
+								"plugin":           fileName + ".asc",
 							}).Error(err)
 						}
 					}
@@ -369,13 +396,13 @@ func (p *pluginControl) Start() error {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",
 							"autodiscoverpath": fullPath,
-							"plugin":           file,
+							"plugin":           fileName,
 						}).Error(err)
 					} else {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",
 							"autodiscoverpath": fullPath,
-							"plugin-file-name": file.Name(),
+							"plugin-file-name": fileName,
 							"plugin-name":      pl.Name(),
 							"plugin-version":   pl.Version(),
 							"plugin-type":      pl.TypeName(),


### PR DESCRIPTION
Fixes #1332

Summary of changes:
- Check if file in autodiscovery path is symlink
- Symlink evaluation to get target's FileInfo

Testing done:
- Manual testing

@intelsdi-x/snap-maintainers