### PR TITLE
SDI-2274: GRPC based collectors **must** provide LastAdvertisedTime o…

### DIFF
--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -252,10 +252,6 @@ func (g *grpcClient) GetMetricTypes(config plugin.ConfigType) ([]core.Metric, er
 		return nil, errors.New(reply.Error)
 	}
 
-	for _, metric := range reply.Metrics {
-		metric.LastAdvertisedTime = ToTime(time.Now())
-	}
-
 	results := ToCoreMetrics(reply.Metrics)
 	return results, nil
 }
@@ -305,6 +301,14 @@ func ToCoreMetrics(mts []*rpc.Metric) []core.Metric {
 }
 
 func ToCoreMetric(mt *rpc.Metric) core.Metric {
+	if mt.Timestamp == nil {
+		mt.Timestamp = ToTime(time.Now())
+	}
+
+	if mt.LastAdvertisedTime == nil {
+		mt.LastAdvertisedTime = ToTime(time.Now())
+	}
+
 	ret := &metric{
 		namespace:          ToCoreNamespace(mt.Namespace),
 		version:            int(mt.Version),

--- a/control/plugin/client/grpc_test.go
+++ b/control/plugin/client/grpc_test.go
@@ -1,0 +1,79 @@
+// +build small
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/intelsdi-x/snap/core"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestToCoreMetric(t *testing.T) {
+	tc := testCases()
+	Convey("Test ToCoreMetric", t, func() {
+		for _, c := range tc {
+			Convey(c.description, func() {
+				mt := ToMetric(c)
+				cmt := ToCoreMetric(mt)
+				So(cmt.Timestamp(), ShouldNotBeNil)
+				So(cmt.LastAdvertisedTime(), ShouldNotBeNil)
+
+				if cmt.Version() == 2 {
+					So(cmt.Timestamp(), ShouldResemble, cmt.LastAdvertisedTime())
+				}
+			})
+		}
+	})
+}
+
+func testCases() []*metric {
+	now := time.Now()
+	tc := []*metric{
+		&metric{
+			namespace:   core.NewNamespace("a", "b", "c"),
+			version:     1,
+			description: "No timeStamp and lastAdvertisedTime defined",
+		},
+		&metric{
+			namespace:   core.NewNamespace("x", "y", "z"),
+			version:     1,
+			timeStamp:   time.Now(),
+			description: "Has timestamp but no lastAdvertisedTime defined",
+		},
+		&metric{
+			namespace:          core.NewNamespace("x", "y", "z"),
+			version:            1,
+			lastAdvertisedTime: time.Now(),
+			description:        "No timestamp but has lastAdvertisedTime defined",
+		},
+		&metric{
+			namespace:          core.NewNamespace("x", "y", "z"),
+			version:            2,
+			timeStamp:          now,
+			lastAdvertisedTime: now,
+			description:        "Has both timestamp and lastAdvertisedTime defined",
+		},
+	}
+	return tc
+}


### PR DESCRIPTION
Fixes #1394 

Summary of changes:
- added check for metric timeStamp and lastAdvertisedTime.
- set it to time.Now() if they are nil.


Testing done:
- small and medium

@intelsdi-x/snap-maintainers

