### PR TITLE
Fixes #1408: fix plugin catalog link typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
         <br>
           <div class="large-7 large-offset-5 end columns text-right">
             <h3>Active Community</h3>
-              <h4 class = "subheader"> With over 1,000 stars on <a href="https://github.com/intelsdi-x/snap"> Github </a> and 67 <a href="https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)"> plugins</a> Snap has an active and growing community! There’s never been a better time to get involved with Snap. </h4>
+              <h4 class = "subheader"> With over 1,000 stars on <a href="https://github.com/intelsdi-x/snap"> Github </a> and 67 <a href="https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md"> plugins</a> Snap has an active and growing community! There’s never been a better time to get involved with Snap. </h4>
           </div>
     
       </div>

--- a/zurb-template/src/pages/index.html
+++ b/zurb-template/src/pages/index.html
@@ -225,7 +225,7 @@ Dynamic updates ensure simple and secure bug fixes, security patching, and impro
     <br>
       <div class="large-7 large-offset-5 end columns text-right">
         <h3>Active Community</h3>
-          <h4 class = "subheader"> With over 1,000 stars on <a href="https://github.com/intelsdi-x/snap"> Github </a> and 67 <a href="https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md)"> plugins</a> Snap has an active and growing community! There’s never been a better time to get involved with Snap. </h4>
+          <h4 class = "subheader"> With over 1,000 stars on <a href="https://github.com/intelsdi-x/snap"> Github </a> and 67 <a href="https://github.com/intelsdi-x/snap/blob/master/docs/PLUGIN_CATALOG.md"> plugins</a> Snap has an active and growing community! There’s never been a better time to get involved with Snap. </h4>
       </div>
 
   </div>


### PR DESCRIPTION
Fixes #1408

Summary of changes:
- Fixes the typo reported in #1408 of an extra ')' in the plugin_catalog links

@intelsdi-x/snap-maintainers @mjbrender @sarahjhh 

