### PR TITLE
adding collector plugin sessioninfo

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -39,6 +39,8 @@
 - intelsdi-x/snap-plugin-collector-facter
 - intelsdi-x/snap-plugin-collector-glance
 - intelsdi-x/snap-plugin-collector-haproxy
+- IrekRomaniuk/snap-plugin-collector-sessioninfo
+
 - intelsdi-x/snap-plugin-collector-influxdb
 - intelsdi-x/snap-plugin-collector-interface
 - intelsdi-x/snap-plugin-collector-iostat

--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -40,7 +40,6 @@
 - intelsdi-x/snap-plugin-collector-glance
 - intelsdi-x/snap-plugin-collector-haproxy
 - IrekRomaniuk/snap-plugin-collector-sessioninfo
-
 - intelsdi-x/snap-plugin-collector-influxdb
 - intelsdi-x/snap-plugin-collector-interface
 - intelsdi-x/snap-plugin-collector-iostat


### PR DESCRIPTION
Fixes #

Summary of changes:
- 
- 
- 

Testing done:
- 

@intelsdi-x/snap-maintainers

I created plugin sessioninfo to collect session information (so far only session count) from Paloalto firewalls.