### PR TITLE
Improve Snappy image printing

### DIFF
--- a/snapteld.go
+++ b/snapteld.go
@@ -467,12 +467,12 @@ func action(ctx *cli.Context) error {
 			}
 		}
 	}
-
 	log.WithFields(
 		log.Fields{
 			"block":   "main",
 			"_module": logModule,
-		}).Info("snapteld started", `
+		}).Info("snapteld started")
+	fmt.Println(`
                                         ss                  ss
 	                             odyssyhhyo         oyhysshhoyo
                                  ddddyssyyysssssyyyyyyyssssyyysssyhy+-


### PR DESCRIPTION
Fixes #1419

Summary of changes:
- Changed the way of printing Snappy with snapteld logs - logrus function changed to fmt.Println()

Testing done:
-  small tests

@intelsdi-x/snap-maintainers
