### PR TITLE
Fixes #1246: Makes plugin restart limit configurable

### DIFF
--- a/control/config.go
+++ b/control/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	ListenAddr        string            `json:"listen_addr,omitempty"yaml:"listen_addr"`
 	ListenPort        int               `json:"listen_port,omitempty"yaml:"listen_port"`
 	Pprof             bool              `json:"pprof"yaml:"pprof"`
+	MaxPluginRestarts int               `json:"max_plugin_restarts"yaml:"max_plugin_restarts"`
 }
 
 const (
@@ -124,6 +125,9 @@ const (
 					},
 					"pprof": {
 						"type": "boolean"
+					},
+					"max_plugin_restarts": {
+						"type": "integer"
 					}
 				},
 				"additionalProperties": false
@@ -144,6 +148,7 @@ func GetDefaultConfig() *Config {
 		CacheExpiration:   jsonutil.Duration{defaultCacheExpiration},
 		Plugins:           newPluginConfig(),
 		Pprof:             defaultPprof,
+		MaxPluginRestarts: MaxPluginRestartCount,
 	}
 }
 
@@ -199,6 +204,10 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			}
 		case "pprof":
 			if err := json.Unmarshal(v, &(c.Pprof)); err != nil {
+				return err
+			}
+		case "max_plugin_restarts":
+			if err := json.Unmarshal(v, &(c.MaxPluginRestarts)); err != nil {
 				return err
 			}
 		default:

--- a/control/config_test.go
+++ b/control/config_test.go
@@ -162,6 +162,9 @@ func TestControlConfigJSON(t *testing.T) {
 		Convey("MaxRunningPlugins should be set to 1", func() {
 			So(cfg.MaxRunningPlugins, ShouldEqual, 1)
 		})
+		Convey("max_plugin_restarts should be set to 10", func() {
+			So(cfg.MaxPluginRestarts, ShouldEqual, 10)
+		})
 		Convey("ListenAddr should be set to 0.0.0.0", func() {
 			So(cfg.ListenAddr, ShouldEqual, "0.0.0.0")
 		})
@@ -230,6 +233,9 @@ func TestControlConfigYaml(t *testing.T) {
 		})
 		Convey("MaxRunningPlugins should be set to 1", func() {
 			So(cfg.MaxRunningPlugins, ShouldEqual, 1)
+		})
+		Convey("max_plugin_restarts should be set to 10", func() {
+			So(cfg.MaxPluginRestarts, ShouldEqual, 10)
 		})
 		Convey("ListenAddr should be set to 0.0.0.0", func() {
 			So(cfg.ListenAddr, ShouldEqual, "0.0.0.0")
@@ -300,6 +306,9 @@ func TestControlDefaultConfig(t *testing.T) {
 		})
 		Convey("PluginTrust should equal 1", func() {
 			So(cfg.PluginTrust, ShouldEqual, 1)
+		})
+		Convey("max_plugin_restarts should be set to 3", func() {
+			So(cfg.MaxPluginRestarts, ShouldEqual, 3)
 		})
 	})
 }

--- a/control/control.go
+++ b/control/control.go
@@ -174,6 +174,13 @@ func OptSetConfig(cfg *Config) PluginControlOpt {
 	}
 }
 
+// MaximumPluginRestarts
+func MaxPluginRestarts(cfg *Config) PluginControlOpt {
+	return func(*pluginControl) {
+		MaxPluginRestartCount = cfg.MaxPluginRestarts
+	}
+}
+
 // New returns a new pluginControl instance
 func New(cfg *Config) *pluginControl {
 	// construct a slice of options from the input configuration
@@ -181,6 +188,7 @@ func New(cfg *Config) *pluginControl {
 		MaxRunningPlugins(cfg.MaxRunningPlugins),
 		CacheExpiration(cfg.CacheExpiration.Duration),
 		OptSetConfig(cfg),
+		MaxPluginRestarts(cfg),
 	}
 	c := &pluginControl{}
 	c.Config = cfg

--- a/control/runner.go
+++ b/control/runner.go
@@ -51,7 +51,9 @@ const (
 	PluginStopped
 	// PluginDisabled is the disabled state of a plugin
 	PluginDisabled
+)
 
+var (
 	// MaximumRestartOnDeadPluginEvent is the maximum count of restarting a plugin
 	// after the event of control_event.DeadAvailablePluginEvent
 	MaxPluginRestartCount = 3

--- a/examples/configs/snap-config-sample.json
+++ b/examples/configs/snap-config-sample.json
@@ -6,6 +6,7 @@
     "gomaxprocs": 2,
     "control": {
         "auto_discover_path": "/some/directory/with/plugins",
+	"max_plugin_restarts": 10,
         "cache_expiration": "750ms",
         "listen_addr": "0.0.0.0",
 	"listen_port": 10082,

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -65,6 +65,10 @@ control:
   # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
   plugin_trust_level: 0
 
+  # max_plugin_restarts controls how many times a plugin is allowed to be restarted
+  # before failing.
+  max_plugin_restarts: 10
+
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
   plugins:


### PR DESCRIPTION
Fixes #1246.

Makes the MaxPluginRestartCount configurable from controls config
section in the globalconfig file. Updates the example configs to
include this field and adds tests for parsing of this option.

Testing done:
- make test-all
- manual testing

@intelsdi-x/snap-maintainers
