### PR TITLE
SDI-2267L update acbuild git

### DIFF
--- a/docs/PLUGIN_PACKAGING.md
+++ b/docs/PLUGIN_PACKAGING.md
@@ -43,5 +43,6 @@ loaded the binary version of the plugin.
     acbuild write snap-plugin-collector-mock1-linux-x86_64.aci
     acbuild end
     ```
+![example](https://media.giphy.com/media/l0HlxSTSUWVwriZfa/source.gif)
 
 That's it!

--- a/docs/PLUGIN_PACKAGING.md
+++ b/docs/PLUGIN_PACKAGING.md
@@ -43,6 +43,6 @@ loaded the binary version of the plugin.
     acbuild write snap-plugin-collector-mock1-linux-x86_64.aci
     acbuild end
     ```
-![example](https://media.giphy.com/media/l0HlxSTSUWVwriZfa/source.gif)
+![example](https://cloud.githubusercontent.com/assets/10092554/20983225/8355a382-bc70-11e6-82c6-6ac445e16513.gif)
 
 That's it!


### PR DESCRIPTION
Fixes #1383 

Summary of changes:
- updated the acbuild gif using snapteld and snaptel.

Testing done:
- manually view the gif

@intelsdi-x/snap-maintainers

