### PR TITLE
Interpolate environment variable

### DIFF
--- a/cmd/snaptel/task.go
+++ b/cmd/snaptel/task.go
@@ -322,7 +322,7 @@ func createTaskUsingTaskManifest(ctx *cli.Context) error {
 	if e != nil {
 		return fmt.Errorf("File error [%s] - %v\n", ext, e)
 	}
-
+	file = []byte(os.ExpandEnv(string(file)))
 	// create an empty task struct and unmarshal the contents of the file into that object
 	t := task{}
 	switch ext {

--- a/control/config_test.go
+++ b/control/config_test.go
@@ -22,6 +22,7 @@ limitations under the License.
 package control
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -215,6 +216,7 @@ func TestControlConfigYaml(t *testing.T) {
 	config := &mockConfig{
 		Control: GetDefaultConfig(),
 	}
+	os.Setenv("password", "$password")
 	path := "../examples/configs/snap-config-sample.yaml"
 	err := cfgfile.Read(path, &config, MOCK_CONSTRAINTS)
 	var cfg *Config

--- a/core/task.go
+++ b/core/task.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -283,7 +284,7 @@ func UnmarshalBody(in interface{}, body io.ReadCloser) (int, error) {
 	if err != nil {
 		return 500, err
 	}
-	err = json.Unmarshal(b, in)
+	err = json.Unmarshal([]byte(os.ExpandEnv(string(b))), in)
 	if err != nil {
 		return 400, err
 	}

--- a/pkg/cfgfile/cfgfile.go
+++ b/pkg/cfgfile/cfgfile.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -104,6 +105,7 @@ func Read(path string, v interface{}, schema string) []serror.SnapError {
 	if err != nil {
 		return []serror.SnapError{serror.New(err)}
 	}
+	b = []byte(os.ExpandEnv(string(b)))
 	// convert from YAML to JSON (remember, JSON is actually valid YAML)
 	jb, err := yaml.YAMLToJSON(b)
 	if err != nil {


### PR DESCRIPTION
Fixes #791 

Summary of changes:
- Interpolate environment variable (`$var` and `${var}`) in global config and task manifest.

Testing done:
- Build and run the daemon.
- Load global config and task manifest

Notes:

- Adding env variables in task manifest (or global config) make those files are note JSON/YAML until we interpolate variables. The question is now, where should we interpolate those variables?

### On `snapteld`
pros:
- easy to implement
cons:
- We should remove [JSON validation on `snaptel`](https://github.com/intelsdi-x/snap/blob/master/cmd/snaptel/task.go#L344). 

### On `snaptel`
pros:
- The API receive static JSON. 
cons:
- Still need to implement on `snapteld` side for global config and autodiscover path.

### On both
This PR changes both side, but we should definitely choose a side. 