### PR TITLE
Fixes #1450 - check publish response for error

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -453,8 +453,8 @@ func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName str
 	pool.RLock()
 	defer pool.RUnlock()
 
-	p, err := pool.SelectAP(taskID, config)
-	if err != nil {
+	p, serr := pool.SelectAP(taskID, config)
+	if serr != nil {
 		return []error{serr}
 	}
 
@@ -463,9 +463,9 @@ func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName str
 		return []error{errors.New("unable to cast client to PluginPublisherClient")}
 	}
 
-	errp := cli.Publish(metrics, config)
-	if errp != nil {
-		return []error{errp}
+	err := cli.Publish(metrics, config)
+	if err != nil {
+		return []error{err}
 	}
 	p.(*availablePlugin).hitCount++
 	p.(*availablePlugin).lastHitTime = time.Now()

--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -441,12 +441,10 @@ func (ap *availablePlugins) collectMetrics(pluginKey string, metricTypes []core.
 }
 
 func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) []error {
-	var errs []error
 	key := strings.Join([]string{plugin.PublisherPluginType.String(), pluginName, strconv.Itoa(pluginVersion)}, core.Separator)
 	pool, serr := ap.getPool(key)
 	if serr != nil {
-		errs = append(errs, serr)
-		return errs
+		return []error{serr}
 	}
 	if pool == nil {
 		return []error{serror.New(ErrPoolNotFound, map[string]interface{}{"pool-key": key})}
@@ -457,8 +455,7 @@ func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName str
 
 	p, err := pool.SelectAP(taskID, config)
 	if err != nil {
-		errs = append(errs, err)
-		return errs
+		return []error{serr}
 	}
 
 	cli, ok := p.(*availablePlugin).client.(client.PluginPublisherClient)

--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -193,9 +193,12 @@ func (g *grpcClient) Publish(metrics []core.Metric, config map[string]ctypes.Con
 		Metrics: NewMetrics(metrics),
 		Config:  ToConfigMap(config),
 	}
-	_, err := g.publisher.Publish(getContext(g.timeout), arg)
+	reply, err := g.publisher.Publish(getContext(g.timeout), arg)
 	if err != nil {
 		return err
+	}
+	if reply.Error != "" {
+		return errors.New(reply.Error)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #1450

Summary of changes:
- [x] checks publish response (grpc client) for an error

![after](https://www.dropbox.com/s/q8fii983kvdfayl/after.gif?raw=1) 

related: https://github.com/intelsdi-x/snap-plugin-lib-go/pull/54
@intelsdi-x/snap-maintainers