### PR TITLE
(SDI-2393) Fix #1448 log and document maxpluginrestarts

### DIFF
--- a/docs/SNAPTELD_CONFIGURATION.md
+++ b/docs/SNAPTELD_CONFIGURATION.md
@@ -101,6 +101,10 @@ control:
   # not be loaded. Valid values are 0 - Off, 1 - Enabled, 2 - Warning
   plugin_trust_level: 1
 
+  # max_plugin_restarts controls how many times a plugin is allowed to be restarted
+  # before failing. Snap will not disable a plugin due to failures when this value is -1.
+  max_plugin_restarts: 10
+
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
   plugins:

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -85,10 +85,13 @@ or without time zone offset (in that cases uppercase'Z' must be present):
 More on cron expressions can be found here: https://godoc.org/github.com/robfig/cron
 
 #### Max-Failures
+
 By default, Snap will disable a task if there are 10 consecutive errors from any plugins within the workflow.  The configuration
-can be changed by specifying the number of failures value in the task header.  If the max-failures value is -1, Snap will
+can be changed by specifying the number of failures value in the task header.  If the `max-failures` value is -1, Snap will
 not disable a task with consecutive failure.  Instead, Snap will sleep for 1 second for every 10 consecutive failures
 and retry again.
+
+If you intend to run tasks with `max-failures: -1`, please also configure `max_plugin_restarts: -1` in [snap daemon control configuration section](SNAPTELD_CONFIGURATION.md).
 
 For more on tasks, visit [`SNAPTEL.md`](SNAPTEL.md).
 

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -66,7 +66,7 @@ control:
   plugin_trust_level: 0
 
   # max_plugin_restarts controls how many times a plugin is allowed to be restarted
-  # before failing.
+  # before failing. Snap will not disable a plugin due to failures when this value is -1.
   max_plugin_restarts: 10
 
   # plugins section contains plugin config settings that will be applied for


### PR DESCRIPTION
Fixes #1448

Summary of changes:
- support -1 for max_plugin_restarts, so it works better with max-failure: -1.
- improve logging of MaxPluginRestarts so users are aware why a plugin is disabled.
- document changes and relationship to max-failure settings.

Example of disabling plugin due to exceeding maxpluginrestartcount:
```
time="2017-01-04T17:31:25-08:00" level=warning msg="plugin disabled due to exceeding restart limit: 10" _block=handle-events _module=control-runner plugin-name=opentsdb plugin-version=9
```

Testing done:
- manual kill of publisher plugin

@intelsdi-x/snap-maintainers
