### PR TITLE
Add snap-plugin-collector-kubestate to plugin list

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -24,6 +24,7 @@
 - raintank/snap-plugin-collector-memcache
 - raintank/snap-plugin-collector-snapstats
 - raintank/snap-plugin-collector-tcpconns
+- raintank/snap-plugin-collector-kubestate
 - Staples-Inc/snap-plugin-collector-couchbase
 - Staples-Inc/snap-plugin-collector-netstat
 - Staples-Inc/snap-plugin-collector-nginx


### PR DESCRIPTION
#### Summary of changes:

- I'd like to add the [snap-plugin-collector-kubestate plugin](https://github.com/raintank/snap-plugin-collector-kubestate) to the plugin list. 

- This collector collects metrics from Kubernetes that are not available via Heapster or the docker collector. It is based on the Prometheus collector https://github.com/kubernetes/kube-state-metrics

#### Testing done:
- We have been using it in production for a more than a month to monitor our Kubernetes clusters.
- Unit tests

@intelsdi-x/snap-maintainers
