### PR TITLE
 Fix travis.ci glide path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   global:
   - SNAP_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap
   - GO15VENDOREXPERIMENT=1
+  - GLIDE_HOME="${HOME}/.glide"
   matrix:
   - SNAP_TEST_TYPE=legacy
   - SNAP_TEST_TYPE=small

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -31,5 +31,6 @@ _go_path
 
 _go_get github.com/Masterminds/glide
 
+_debug "$(glide --version)"
 _info "restoring dependency with glide"
 (cd "${__proj_dir}" && glide install)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,11 @@
 # Support travis.ci environment matrix:
 SNAP_TEST_TYPE="${SNAP_TEST_TYPE:-$1}"
 
-UNIT_TEST="${UNIT_TEST:-"gofmt goimports go_test go_cover"}"
+if [[ "${SNAP_TEST_TYPE}" == small ]]; then
+  UNIT_TEST="${UNIT_TEST:-"gofmt goimports go_test go_cover"}"
+else
+  UNIT_TEST="${UNIT_TEST:-"go_test go_cover"}"
+fi
 
 set -e
 set -u


### PR DESCRIPTION
* only run go_fmt, go_imports for small test to speed up ci.
* specify GLIDE_HOME, so .glide/cache does not pollute source code.
* add glide --version for debugging.