### PR TITLE
Adding default timeout to Snap REST client

### DIFF
--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -102,6 +102,13 @@ func Username(u string) metaOp {
 	}
 }
 
+//Timeout is an option that can be provided to the func client.New in order to set HTTP connection timeout.
+func Timeout(t time.Duration) metaOp {
+	return func(c *Client) {
+		c.http.Timeout = t
+	}
+}
+
 var (
 	secureTransport = &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: false},

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -26,6 +26,7 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -627,4 +628,20 @@ func TestSnapClient(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(c, ShouldBeNil)
 	})
+
+	go http.ListenAndServe("127.0.0.1:65000", timeoutHandler{})
+	c, err = New("http://127.0.0.1:65000", "", true, Timeout(time.Second))
+	Convey("Client should timeout", t, func() {
+		So(err, ShouldBeNil)
+		r := c.GetTasks()
+		So(r.Err, ShouldNotBeNil)
+	})
+}
+
+type timeoutHandler struct{}
+
+//ServeHTTP implements http.Handler interface
+func (th timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(3 * time.Second)
+	w.Write([]byte("Hello!"))
 }


### PR DESCRIPTION
Fixes issue of infinitely blocking HTTP connections (mitigates #1482 and similar issues).

Summary of changes:
- added default timeout of 10 seconds to secure and insecure transports

Testing done:
- added a functional test for the timeout feature

It does not seem to be possible to use `opts` parameter of `client.New() as client's `http` property is unexported and therefore unavailble from another packages.

@intelsdi-x/snap-maintainers
