### PR TITLE
Adding timeout setting to snaptel

### DIFF
--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -19,7 +19,11 @@ limitations under the License.
 
 package main
 
-import "github.com/urfave/cli"
+import (
+	"time"
+
+	"github.com/urfave/cli"
+)
 
 var (
 
@@ -52,6 +56,11 @@ var (
 		EnvVar: "SNAPTEL_CONFIG_PATH,SNAPCTL_CONFIG_PATH",
 		Usage:  "Path to a config file",
 		Value:  "",
+	}
+	flTimeout = cli.DurationFlag{
+		Name:  "timeout, t",
+		Usage: "Timeout to be set on HTTP request to the server",
+		Value: 10 * time.Second,
 	}
 
 	// Plugin flags

--- a/cmd/snaptel/main.go
+++ b/cmd/snaptel/main.go
@@ -61,7 +61,7 @@ func main() {
 	app.Name = "snaptel"
 	app.Version = gitversion
 	app.Usage = "The open telemetry framework"
-	app.Flags = []cli.Flag{flURL, flSecure, flAPIVer, flPassword, flConfig}
+	app.Flags = []cli.Flag{flURL, flSecure, flAPIVer, flPassword, flConfig, flTimeout}
 	app.Commands = append(commands, tribeCommands...)
 	sort.Sort(ByCommand(app.Commands))
 	app.Before = beforeAction
@@ -79,7 +79,7 @@ func main() {
 // Run before every command
 func beforeAction(ctx *cli.Context) error {
 	username, password := checkForAuth(ctx)
-	pClient, err = client.New(ctx.String("url"), ctx.String("api-version"), ctx.Bool("insecure"))
+	pClient, err = client.New(ctx.String("url"), ctx.String("api-version"), ctx.Bool("insecure"), client.Timeout(ctx.Duration("timeout")))
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}


### PR DESCRIPTION
Fixes lack of support for #1487 in Snap CLI client.

Summary of changes:
- added timeout flag

Testing done:
- all existing tests should pass

@intelsdi-x/snap-maintainers
