### PR TITLE
apply plugins defaults after config

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -127,6 +127,7 @@ type managesPlugins interface {
 	SetMetricCatalog(catalogsMetrics)
 	GenerateArgs(logLevel int) plugin.Arg
 	SetPluginConfig(*pluginConfig)
+	GetPluginConfig() *pluginConfig
 	SetPluginTags(map[string]map[string]string)
 	AddStandardAndWorkflowTags(core.Metric, map[string]map[string]string) core.Metric
 	SetPluginLoadTimeout(int)
@@ -757,6 +758,10 @@ func (p *pluginControl) getMetricsAndCollectors(requested []core.RequestedMetric
 			}
 			// set config to metric
 			mt.config = cfg
+
+			// apply the defaults from the global (plugin) config
+			cfgNode := p.pluginManager.GetPluginConfig().getPluginConfigDataNode(core.CollectorPluginType, mt.Plugin.Name(), mt.Plugin.Version())
+			cfg.ApplyDefaults(cfgNode.Table())
 
 			// apply defaults to the metric that may be present in the plugins
 			// configpolicy

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -73,6 +73,7 @@ func (m *MockPluginManagerBadSwap) UnloadPlugin(c core.Plugin) (*loadedPlugin, s
 }
 func (m *MockPluginManagerBadSwap) get(string) (*loadedPlugin, error)          { return nil, nil }
 func (m *MockPluginManagerBadSwap) teardown()                                  {}
+func (m *MockPluginManagerBadSwap) GetPluginConfig() *pluginConfig             { return nil }
 func (m *MockPluginManagerBadSwap) SetPluginConfig(*pluginConfig)              {}
 func (m *MockPluginManagerBadSwap) SetPluginTags(map[string]map[string]string) {}
 func (m *MockPluginManagerBadSwap) AddStandardAndWorkflowTags(met core.Metric, allTags map[string]map[string]string) core.Metric {

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -293,6 +293,11 @@ func (p *pluginManager) SetPluginConfig(cf *pluginConfig) {
 	p.pluginConfig = cf
 }
 
+// GetPluginConfig gets the plugin config
+func (p *pluginManager) GetPluginConfig() *pluginConfig {
+	return p.pluginConfig
+}
+
 // SetPluginTags sets plugin tags
 func (p *pluginManager) SetPluginTags(tags map[string]map[string]string) {
 	p.pluginTags = tags


### PR DESCRIPTION
Fixes #1495

Summary of changes:
- Applies plugin defaults after values from the plugin config 

Testing done:
- manual
- unit test 
  -`TestSubscriptionGroups_Process_GlobalPluginConfig` added to cover

@intelsdi-x/snap-maintainers