### PR TITLE
Preliminary support for configuring TLS channel between framework and…

### DIFF
--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -104,6 +104,8 @@ var (
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
+						flPluginCert,
+						flPluginKey,
 					},
 				},
 				{

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -68,6 +68,14 @@ var (
 		Name:  "plugin-asc, a",
 		Usage: "The plugin asc",
 	}
+	flPluginCert = cli.StringFlag{
+		Name:  "plugin-cert, c",
+		Usage: "The plugin cert",
+	}
+	flPluginKey = cli.StringFlag{
+		Name:  "plugin-key, k",
+		Usage: "The plugin key",
+	}
 	flPluginType = cli.StringFlag{
 		Name:  "plugin-type, t",
 		Usage: "The plugin type",

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -33,8 +34,10 @@ import (
 
 func loadPlugin(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
+	pCert := ctx.String("plugin-cert")
+	pKey := ctx.String("plugin-key")
 	var paths []string
-	if len(ctx.Args()) != 1 {
+	if len(ctx.Args()) >3 {
 		return newUsageError("Incorrect usage:", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
@@ -43,6 +46,28 @@ func loadPlugin(ctx *cli.Context) error {
 			return newUsageError("Must be a .asc file for the -a flag", ctx)
 		}
 		paths = append(paths, pAsc)
+	}
+	if pCert != "" {
+		tmpFile, err := ioutil.TempFile("", "crt.")
+		if err != nil {
+			return fmt.Errorf("Error processing plugin certificate - unable to create link:\n%v", err.Error())
+		}
+		_, err = tmpFile.WriteString(pCert)
+		if err != nil {
+			return fmt.Errorf("Error processing plugin certificate - unable to write link:\n%v", err.Error())
+		}
+		paths = append(paths, tmpFile.Name())
+	}
+	if pKey != "" {
+		tmpFile, err := ioutil.TempFile("", "key.")
+		if err != nil {
+			return fmt.Errorf("Error processing plugin key - unable to create link:\n%v", err.Error())
+		}
+		_, err = tmpFile.WriteString(pKey)
+		if err != nil {
+			return fmt.Errorf("Error processing plugin key - unable to write link:\n%v", err.Error())
+		}
+		paths = append(paths, tmpFile.Name())
 	}
 	r := pClient.LoadPlugin(paths)
 	if r.Err != nil {

--- a/control/control.go
+++ b/control/control.go
@@ -583,6 +583,8 @@ func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDe
 	details.CheckSum = rp.CheckSum()
 	details.Signature = rp.Signature()
 	details.IsAutoLoaded = rp.AutoLoaded()
+	details.CertPath = rp.CertPath()
+	details.KeyPath = rp.KeyPath()
 
 	if filepath.Ext(rp.Path()) == ".aci" {
 		f, err := os.Open(rp.Path())

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -143,6 +143,19 @@ type Arg struct {
 
 	// enable pprof
 	Pprof bool
+
+	CertPath string
+	KeyPath string
+}
+
+func (a Arg) SetCertPath(certPath string) Arg {
+	a.CertPath = certPath
+	return a
+}
+
+func (a Arg) SetKeyPath(keyPath string) Arg {
+	a.KeyPath = keyPath
+	return a
 }
 
 func NewArg(logLevel int, pprof bool) Arg {

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -166,6 +166,8 @@ type pluginDetails struct {
 	Path         string
 	Signed       bool
 	Signature    []byte
+	CertPath     string
+	KeyPath      string
 }
 
 type loadedPlugin struct {
@@ -327,7 +329,9 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 		commands[i] = path.Join(lPlugin.Details.ExecPath, e)
 	}
 	ePlugin, err := plugin.NewExecutablePlugin(
-		p.GenerateArgs(int(log.GetLevel())),
+		p.GenerateArgs(int(log.GetLevel())).
+			SetCertPath(details.CertPath).
+			SetKeyPath(details.KeyPath),
 		commands...)
 	if err != nil {
 		pmLogger.WithFields(log.Fields{

--- a/control/runner.go
+++ b/control/runner.go
@@ -321,7 +321,9 @@ func (r *runner) runPlugin(name string, details *pluginDetails) error {
 	for i, e := range details.Exec {
 		commands[i] = path.Join(details.ExecPath, e)
 	}
-	ePlugin, err := plugin.NewExecutablePlugin(r.pluginManager.GenerateArgs(int(log.GetLevel())), commands...)
+	ePlugin, err := plugin.NewExecutablePlugin(r.pluginManager.GenerateArgs(int(log.GetLevel())).
+		SetCertPath(details.CertPath).
+		SetKeyPath(details.KeyPath), commands...)
 	if err != nil {
 		runnerLog.WithFields(log.Fields{
 			"_block": "run-plugin",

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -99,6 +99,8 @@ type RequestedPlugin struct {
 	checkSum   [sha256.Size]byte
 	signature  []byte
 	autoLoaded bool
+	certPath   string
+	keyPath    string
 }
 
 func NewRequestedPlugin(path string) (*RequestedPlugin, error) {
@@ -118,6 +120,14 @@ func (p *RequestedPlugin) Path() string {
 	return p.path
 }
 
+func (p *RequestedPlugin) CertPath() string {
+	return p.certPath
+}
+
+func (p *RequestedPlugin) KeyPath() string {
+	return p.keyPath
+}
+
 func (p *RequestedPlugin) CheckSum() [sha256.Size]byte {
 	return p.checkSum
 }
@@ -132,6 +142,14 @@ func (p *RequestedPlugin) AutoLoaded() bool {
 
 func (p *RequestedPlugin) SetPath(path string) {
 	p.path = path
+}
+
+func (p *RequestedPlugin) SetCertPath(certPath string) {
+	p.certPath = certPath
+}
+
+func (p *RequestedPlugin) SetKeyPath(keyPath string) {
+	p.keyPath = keyPath
 }
 
 func (p *RequestedPlugin) SetSignature(data []byte) {

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -312,13 +312,15 @@ func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, 
 			return nil, err
 		}
 		file, err := os.Open(pluginPaths[i])
+		defer file.Close()
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close()
 		bufin := bufio.NewReader(file)
 		bufins = append(bufins, bufin)
-
+		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, "crt.") || strings.HasPrefix(baseName, "key.") {
+			defer os.Remove(pluginPath)
+		}
 		paths = append(paths, filepath.Base(pluginPath))
 	}
 	// with io.Pipe the write needs to be async

--- a/pkg/rpcutil/rpc.go
+++ b/pkg/rpcutil/rpc.go
@@ -24,15 +24,24 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // GetClientConnection returns a grcp.ClientConn that is unsecured
 // TODO: Add TLS security to connection
 func GetClientConnection(addr string, port int) (*grpc.ClientConn, error) {
+	return GetClientConnectionWithCreds(addr, port, nil)
+}
+
+func GetClientConnectionWithCreds(addr string, port int, creds *credentials.TransportCredentials) (*grpc.ClientConn, error) {
 	grpcDialOpts := []grpc.DialOption{
 		grpc.WithTimeout(2 * time.Second),
 	}
-	grpcDialOpts = append(grpcDialOpts, grpc.WithInsecure())
+	if creds != nil {
+		grpcDialOpts = append(grpcDialOpts, grpc.WithTransportCredentials(*creds))
+	} else {
+		grpcDialOpts = append(grpcDialOpts, grpc.WithInsecure())
+	}
 	conn, err := grpc.Dial(fmt.Sprintf("%v:%v", addr, port), grpcDialOpts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
… plugin

- Snap REST API is accepting additional files upon PluginLoad request;
- Snap PluginLoad accepts paths to plugin certificate and key to be passed inline with request;
- Snap embeds the certificate paths into plugin runtime arguments, so that plugin
may make use of it (fields CertPath, KeyPath);
- Snaptel extended to accept additional options: --plugin-cert and --plugin-key; arguments to those
options are packed into a request for Snap REST API.
- Few more changes were necessary to snap-plugin-lib-go.
- Refer to sample certificates, keys and instruction in snap-plugin-lib-go to test this POC.

Fixes #

Summary of changes:
- 
- 
- 

Testing done:
- 

@intelsdi-x/snap-maintainers
