### PR TITLE
Adds support for building Snap on Windows and FreeBSD

### DIFF
--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -324,7 +323,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 	// run from.
 	commands := make([]string, len(lPlugin.Details.Exec))
 	for i, e := range lPlugin.Details.Exec {
-		commands[i] = path.Join(lPlugin.Details.ExecPath, e)
+		commands[i] = filepath.Join(lPlugin.Details.ExecPath, e)
 	}
 	ePlugin, err := plugin.NewExecutablePlugin(
 		p.GenerateArgs(int(log.GetLevel())),

--- a/mgmt/rest/common/common.go
+++ b/mgmt/rest/common/common.go
@@ -3,7 +3,7 @@ package common
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 
 	log "github.com/Sirupsen/logrus"
@@ -17,7 +17,7 @@ func WriteFile(filename string, b []byte) (string, error) {
 		return "", err
 	}
 
-	f, err := os.Create(path.Join(dir, filename))
+	f, err := os.Create(filepath.Join(dir, filename))
 	if err != nil {
 		return "", err
 	}

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -19,4 +19,10 @@ export GOARCH=amd64
 "${__dir}/build_snap.sh" &
 "${__dir}/build_plugins.sh" &
 
+export GOOS=windows
+export GOARCH=amd64
+"${__dir}/build_snap.sh" &
+"${__dir}/build_plugins.sh" &
+
+
 wait

--- a/scripts/build_plugin.sh
+++ b/scripts/build_plugin.sh
@@ -35,6 +35,9 @@ fi
 
 plugin_src_path=$1
 plugin_name=$(basename "${plugin_src_path}")
+if [[ "${GOOS}" == "windows" ]]; then
+  plugin_name="${plugin_name}.exe"
+fi
 go_build=(go build -a -ldflags "-w")
 
 _debug "plugin source: ${plugin_src_path}"

--- a/scripts/build_plugin.sh
+++ b/scripts/build_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -38,8 +38,8 @@ _info "git commit: $(git log --pretty=format:"%H" -1)"
 export CGO_ENABLED=0
 
 # rebuild binaries:
-export GOOS=${GOOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}
-export GOARCH=${GOARCH:-"amd64"}
+export GOOS=${GOOS:-$(go env GOOS)}
+export GOARCH=${GOARCH:-$(go env GOARCH)}
 
 OS=$(uname -s)
 if [[ "${OS}" == "Darwin" ]]; then
@@ -58,5 +58,5 @@ else
 fi
 
 mkdir -p "${build_path}/plugins"
-_info "building plugins for ${GOOS}/${GOARCH} in ${p} parallels"
+_info "building plugins for ${GOOS}/${GOARCH} in ${p} parallel processes"
 find "${__proj_dir}/plugin/" -type d -iname "snap-*" -print0 | xargs -0 -n 1 -P $p -I{} "${__dir}/build_plugin.sh" {}

--- a/scripts/build_plugins.sh
+++ b/scripts/build_plugins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -48,7 +48,14 @@ else
   build_path="${__proj_dir}/build/${GOOS}/${GOARCH}"
 fi
 
+snaptel="snaptel"
+snapteld="snapteld"
+if [[ "${GOOS}" == "windows" ]]; then
+  snaptel="${snaptel}.exe"
+  snapteld="${snapteld}.exe"
+fi
+
 mkdir -p "${build_path}"
-_info "building snapteld/snaptel for ${GOOS}/${GOARCH}"
-"${go_build[@]}" -o "${build_path}/snapteld" . || exit 1
-(cd "${__proj_dir}/cmd/snaptel" && "${go_build[@]}" -o "${build_path}/snaptel" . || exit 1)
+_info "building snapteld/${snaptel} for ${GOOS}/${GOARCH}"
+"${go_build[@]}" -o "${build_path}/${snapteld}" . || exit 1
+(cd "${__proj_dir}/cmd/snaptel" && "${go_build[@]}" -o "${build_path}/${snaptel}" . || exit 1)

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -39,8 +39,8 @@ _info "git commit: $(git log --pretty=format:"%H" -1)"
 export CGO_ENABLED=0
 
 # rebuild binaries:
-export GOOS=${GOOS:-$(uname -s | tr '[:upper:]' '[:lower:]')}
-export GOARCH=${GOARCH:-"amd64"}
+export GOOS=${GOOS:-$(go env GOOS)}
+export GOARCH=${GOARCH:-$(go env GOARCH)}
 
 if [[ "${GOARCH}" == "amd64" ]]; then
   build_path="${__proj_dir}/build/${GOOS}/x86_64"

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -35,12 +35,17 @@ go_build=(go build -ldflags "-w -X main.gitversion=${git_version}")
 _info "snap build version: ${git_version}"
 _info "git commit: $(git log --pretty=format:"%H" -1)"
 
-# Disable CGO for builds.
-export CGO_ENABLED=0
-
 # rebuild binaries:
 export GOOS=${GOOS:-$(go env GOOS)}
 export GOARCH=${GOARCH:-$(go env GOARCH)}
+
+# Disable CGO for builds (except freebsd)
+if [[ "${GOOS}" == "freebsd" ]]; then
+  _info "CGO enabled for freebsd"
+  export CGO_ENABLED=1
+else 
+  export CGO_ENABLED=0
+fi
 
 if [[ "${GOARCH}" == "amd64" ]]; then
   build_path="${__proj_dir}/build/${GOOS}/x86_64"

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #

--- a/scripts/gen-proto.sh
+++ b/scripts/gen-proto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #
@@ -16,6 +16,8 @@
 #WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #See the License for the specific language governing permissions and
 #limitations under the License.
+
+set -e
 
 echo "Checking for proto"
 if ! which protoc > /dev/null

--- a/scripts/pre_deploy.sh
+++ b/scripts/pre_deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # File managed by pluginsync
 
 # http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/scripts/run_tests_with_docker.sh
+++ b/scripts/run_tests_with_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #http://www.apache.org/licenses/LICENSE-2.0.txt
 #


### PR DESCRIPTION
Fixes: #1527
Related: #1506 #671

Summary of changes:
- Adds portability of build scripts so building works on 
  - FreeBSD
  - Windows

Testing done:
- Built snap on 
  - FreeBSD 
  - Windows
    - caveats
      - required: [MinGW](http://www.mingw.org) 
      - Makefile is not supported (use scripts directly)  
        - scripts/deps.sh
        - scripts/build_all.sh
        - ....
  - Darwin
  - Linux

Windows:
![img](https://www.evernote.com/l/AA1uuUMdT8hAKqqeiklLZaZXYr147lpjCwEB/image.png)

FreeBSD:
![img](https://www.dropbox.com/s/1w7h2sqskst42a5/freebsd.gif?raw=1)

cc:  @brd @swills @stdale @jessemillar

This PR incorporates work done by @brd @stdale @IRCody for making snap build on FreeBSD and @jessemillar for Windows.  Thanks for your contributions.

@intelsdi-x/snap-maintainers