### PR TITLE
Fixed 1520: Cannot remove an Ended Task

### DIFF
--- a/core/scheduler_event/scheduler_event.go
+++ b/core/scheduler_event/scheduler_event.go
@@ -28,6 +28,7 @@ const (
 	TaskDeleted            = "Scheduler.TaskDeleted"
 	TaskStarted            = "Scheduler.TaskStarted"
 	TaskStopped            = "Scheduler.TaskStopped"
+	TaskEnded              = "Scheduler.TaskEnded"
 	TaskDisabled           = "Scheduler.TaskDisabled"
 	MetricCollected        = "Scheduler.MetricsCollected"
 	MetricCollectionFailed = "Scheduler.MetricCollectionFailed"
@@ -68,6 +69,15 @@ type TaskStoppedEvent struct {
 
 func (e TaskStoppedEvent) Namespace() string {
 	return TaskStopped
+}
+
+type TaskEndedEvent struct {
+	TaskID string
+	Source string
+}
+
+func (e TaskEndedEvent) Namespace() string {
+	return TaskEnded
 }
 
 type TaskDisabledEvent struct {

--- a/core/task.go
+++ b/core/task.go
@@ -52,7 +52,7 @@ var (
 		TaskStopped:  "Stopped",  // stopped but resumable
 		TaskSpinning: "Running",  // running
 		TaskFiring:   "Running",  // running (firing can happen so briefly we don't want to try and render it as a string state)
-		TaskEnded:    "Ended",    // ended, not resumable because the schedule will not fire again
+		TaskEnded:    "Ended",    // ended, but resumable if the schedule is still valid and might fire again
 		TaskStopping: "Stopping", // channel has been closed, wait for TaskStopped state
 	}
 )
@@ -65,6 +65,7 @@ type TaskWatcherHandler interface {
 	CatchCollection([]Metric)
 	CatchTaskStarted()
 	CatchTaskStopped()
+	CatchTaskEnded()
 	CatchTaskDisabled(string)
 }
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -12,10 +12,9 @@ A task can be in the following states:
 - **running:** a running task
 - **stopped:** a task that is not running
 - **disabled:** a task in a state not allowed to start. This happens when the task produces consecutive errors. A disabled task must be re-enabled before it can be started again. 
+- **ended:** a task for which the schedule is ended. At present this happens only for windowed schedule with defined _stop_timestamp_. An ended task is resumable if the schedule is still valid.
 
-
-![newtaskstatediagram2](https://cloud.githubusercontent.com/assets/21182867/19282545/a4179520-8fa3-11e6-9056-4fc3aa610983.png)
-
+![statediagram](https://cloud.githubusercontent.com/assets/11335874/23362447/0f0b9f74-fcf6-11e6-93d7-889a7ccdc45f.png)
 
 	    How To				                        |  Command
     ----------------------------------------|------------------------

--- a/mgmt/rest/client/task.go
+++ b/mgmt/rest/client/task.go
@@ -157,7 +157,7 @@ func (c *Client) WatchTask(id string) *WatchTasksResult {
 				case rbody.TaskWatchTaskDisabled:
 					r.EventChan <- ste
 					r.Close()
-				case rbody.TaskWatchTaskStopped, rbody.TaskWatchTaskStarted, rbody.TaskWatchMetricEvent:
+				case rbody.TaskWatchTaskStopped, rbody.TaskWatchTaskEnded, rbody.TaskWatchTaskStarted, rbody.TaskWatchMetricEvent:
 					r.EventChan <- ste
 				}
 			}

--- a/mgmt/rest/rest_v1_test.go
+++ b/mgmt/rest/rest_v1_test.go
@@ -119,7 +119,7 @@ func watchTask(id string, port int) *watchTaskResult {
 					r.eventChan <- ste.EventType
 					r.close()
 					return
-				case rbody.TaskWatchTaskStopped, rbody.TaskWatchTaskStarted, rbody.TaskWatchMetricEvent:
+				case rbody.TaskWatchTaskStopped, rbody.TaskWatchTaskEnded, rbody.TaskWatchTaskStarted, rbody.TaskWatchMetricEvent:
 					log.Info(ste.EventType)
 					r.eventChan <- ste.EventType
 				}

--- a/mgmt/rest/v1/rbody/task.go
+++ b/mgmt/rest/v1/rbody/task.go
@@ -36,6 +36,7 @@ const (
 	ScheduledTaskType              = "scheduled_task"
 	ScheduledTaskStartedType       = "scheduled_task_started"
 	ScheduledTaskStoppedType       = "scheduled_task_stopped"
+	ScheduledTaskEndedType         = "scheduled_task_ended"
 	ScheduledTaskRemovedType       = "scheduled_task_removed"
 	ScheduledTaskWatchingEndedType = "schedule_task_watch_ended"
 	ScheduledTaskEnabledType       = "scheduled_task_enabled"
@@ -46,6 +47,7 @@ const (
 	TaskWatchTaskDisabled = "task-disabled"
 	TaskWatchTaskStarted  = "task-started"
 	TaskWatchTaskStopped  = "task-stopped"
+	TaskWatchTaskEnded    = "task-ended"
 )
 
 type ScheduledTaskListReturned struct {

--- a/mgmt/rest/v1/task.go
+++ b/mgmt/rest/v1/task.go
@@ -149,7 +149,7 @@ func (s *apiV1) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.P
 				// The client can decide to stop receiving on the stream on Task Stopped.
 				// We write the event to the buffer
 				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
-			case rbody.TaskWatchTaskDisabled, rbody.TaskWatchTaskStopped:
+			case rbody.TaskWatchTaskDisabled, rbody.TaskWatchTaskStopped, rbody.TaskWatchTaskEnded:
 				// A disabled task should end the streaming and close the connection
 				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
 				// Flush since we are sending nothing new
@@ -286,6 +286,12 @@ func (t *TaskWatchHandler) CatchTaskStarted() {
 func (t *TaskWatchHandler) CatchTaskStopped() {
 	t.mChan <- rbody.StreamedTaskEvent{
 		EventType: rbody.TaskWatchTaskStopped,
+	}
+}
+
+func (t *TaskWatchHandler) CatchTaskEnded() {
+	t.mChan <- rbody.StreamedTaskEvent{
+		EventType: rbody.TaskWatchTaskEnded,
 	}
 }
 

--- a/mgmt/rest/v2/watch.go
+++ b/mgmt/rest/v2/watch.go
@@ -37,6 +37,7 @@ const (
 	TaskWatchTaskDisabled = "task-disabled"
 	TaskWatchTaskStarted  = "task-started"
 	TaskWatchTaskStopped  = "task-stopped"
+	TaskWatchTaskEnded    = "task-ended"
 )
 
 // The amount of time to buffer streaming events before flushing in seconds
@@ -95,7 +96,7 @@ func (s *apiV2) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.P
 				// The client can decide to stop receiving on the stream on Task Stopped.
 				// We write the event to the buffer
 				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
-			case TaskWatchTaskDisabled, TaskWatchTaskStopped:
+			case TaskWatchTaskDisabled, TaskWatchTaskStopped, TaskWatchTaskEnded:
 				// A disabled task should end the streaming and close the connection
 				fmt.Fprintf(w, "data: %s\n\n", e.ToJSON())
 				// Flush since we are sending nothing new
@@ -162,6 +163,12 @@ func (t *TaskWatchHandler) CatchTaskStarted() {
 func (t *TaskWatchHandler) CatchTaskStopped() {
 	t.mChan <- StreamedTaskEvent{
 		EventType: TaskWatchTaskStopped,
+	}
+}
+
+func (t *TaskWatchHandler) CatchTaskEnded() {
+	t.mChan <- StreamedTaskEvent{
+		EventType: TaskWatchTaskEnded,
 	}
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -64,6 +64,8 @@ var (
 	ErrTaskDisabledNotRunnable = errors.New("Task is disabled. Cannot be started.")
 	// ErrTaskDisabledNotStoppable - The error message for when a task is disabled and cannot be stopped
 	ErrTaskDisabledNotStoppable = errors.New("Task is disabled. Only running tasks can be stopped.")
+	// ErrTaskEndedNotStoppable - The error message for when a task is ended and cannot be stopped
+	ErrTaskEndedNotStoppable = errors.New("Task is ended. Only running tasks can be stopped.")
 )
 
 type schedulerState int
@@ -471,6 +473,7 @@ func (s *scheduler) startTask(id, source string) []serror.SnapError {
 			serror.New(ErrTaskDisabledNotRunnable),
 		}
 	}
+
 	if t.state == core.TaskFiring || t.state == core.TaskSpinning {
 		logger.WithFields(log.Fields{
 			"task-id":    t.ID(),
@@ -479,6 +482,16 @@ func (s *scheduler) startTask(id, source string) []serror.SnapError {
 		return []serror.SnapError{
 			serror.New(ErrTaskAlreadyRunning),
 		}
+	}
+
+	// Ensure the schedule is valid at this point and time.
+	if err := t.schedule.Validate(); err != nil {
+		errs := []serror.SnapError{
+			serror.New(err),
+		}
+		f := buildErrorsLog(errs, logger)
+		f.Error("schedule passed not valid")
+		return errs
 	}
 
 	// Group dependencies by the node they live on
@@ -558,6 +571,14 @@ func (s *scheduler) stopTask(id, source string) []serror.SnapError {
 		}).Error("task is already stopped")
 		return []serror.SnapError{
 			serror.New(ErrTaskAlreadyStopped),
+		}
+	case core.TaskEnded:
+		logger.WithFields(log.Fields{
+			"task-id":    t.ID(),
+			"task-state": t.State(),
+		}).Error("task is already ended")
+		return []serror.SnapError{
+			serror.New(ErrTaskEndedNotStoppable),
 		}
 	case core.TaskDisabled:
 		logger.WithFields(log.Fields{
@@ -768,6 +789,14 @@ func (s *scheduler) HandleGomitEvent(e gomit.Event) {
 			"task-id":         v.TaskID,
 		}).Debug("event received")
 		s.taskWatcherColl.handleTaskStopped(v.TaskID)
+	case *scheduler_event.TaskEndedEvent:
+		log.WithFields(log.Fields{
+			"_module":         "scheduler-events",
+			"_block":          "handle-events",
+			"event-namespace": e.Namespace(),
+			"task-id":         v.TaskID,
+		}).Debug("event received")
+		s.taskWatcherColl.handleTaskEnded(v.TaskID)
 	case *scheduler_event.TaskDisabledEvent:
 		log.WithFields(log.Fields{
 			"_module":         "scheduler-events",

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -272,36 +272,6 @@ func TestScheduler(t *testing.T) {
 			So(tsk.(*task).deadlineDuration, ShouldResemble, time.Duration(6*time.Second))
 		})
 
-		Convey("Enable a stopped task", func() {
-			tsk, _ := s.CreateTask(schedule.NewSimpleSchedule(time.Millisecond*100), w, false)
-			So(tsk, ShouldNotBeNil)
-
-			_, err := s.EnableTask(tsk.ID())
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("Enable a disabled task", func() {
-			tsk, _ := s.CreateTask(schedule.NewSimpleSchedule(time.Millisecond*100), w, false)
-			So(tsk, ShouldNotBeNil)
-
-			t := s.tasks.Get(tsk.ID())
-			t.state = core.TaskDisabled
-
-			etsk, err1 := s.EnableTask(tsk.ID())
-			So(err1, ShouldBeNil)
-			So(etsk.State(), ShouldEqual, core.TaskStopped)
-		})
-		Convey("Start disabled task", func() {
-			tsk, _ := s.CreateTask(schedule.NewSimpleSchedule(time.Millisecond*100), w, false)
-			So(tsk, ShouldNotBeNil)
-
-			t := s.tasks.Get(tsk.ID())
-			t.state = core.TaskDisabled
-
-			err := s.StartTask(tsk.ID())
-			So(err[0].Error(), ShouldResemble, "Task is disabled. Cannot be started.")
-			So(t.state, ShouldEqual, core.TaskDisabled)
-		})
 	})
 	Convey("Stop()", t, func() {
 		Convey("Should set scheduler state to SchedulerStopped", func() {

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -428,7 +428,7 @@ func (t *taskCollection) remove(task *task) error {
 	t.Lock()
 	defer t.Unlock()
 	if _, ok := t.table[task.id]; ok {
-		if task.state != core.TaskStopped && task.state != core.TaskDisabled {
+		if task.state != core.TaskStopped && task.state != core.TaskDisabled && task.state != core.TaskEnded {
 			taskLogger.WithFields(log.Fields{
 				"_block":  "remove",
 				"task id": task.id,

--- a/scheduler/watcher.go
+++ b/scheduler/watcher.go
@@ -179,6 +179,29 @@ func (t *taskWatcherCollection) handleTaskStopped(taskID string) {
 	}
 }
 
+func (t *taskWatcherCollection) handleTaskEnded(taskID string) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	// no taskID means no watches, early exit
+	if t.coll[taskID] == nil || len(t.coll[taskID]) == 0 {
+		// Uncomment this debug line if needed. Otherwise this is too verbose for even debug level.
+		// watcherLog.WithFields(log.Fields{
+		// 	"task-id": taskID,
+		// }).Debug("no watchers")
+		return
+	}
+	// Walk all watchers for a task ID
+	for _, v := range t.coll[taskID] {
+		// Check if they have a catcher assigned
+		watcherLog.WithFields(log.Fields{
+			"task-id":         taskID,
+			"task-watcher-id": v.id,
+		}).Debug("calling taskwatcher task ended func")
+		// Call the catcher
+		v.handler.CatchTaskEnded()
+	}
+}
+
 func (t *taskWatcherCollection) handleTaskDisabled(taskID string, why string) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/scheduler/watcher_test.go
+++ b/scheduler/watcher_test.go
@@ -53,6 +53,11 @@ func (d *mockCatcher) CatchTaskStopped() {
 	sum++
 }
 
+func (d *mockCatcher) CatchTaskEnded() {
+	d.count++
+	sum++
+}
+
 func (d *mockCatcher) CatchTaskStarted() {
 	d.count++
 	sum++


### PR DESCRIPTION
Fixed #1520 

**It's READY to review :)**

### To do:
- [x] Adding medium tests
- [x] Making an Ended state resumable
  
### Summary of changes:
1) Added documentation about _Ended_ state in docs/TASKS.md
2) **_Ended_ tasks can be removed**
See [scheduler/task.go#L431](https://github.com/intelsdi-x/snap/compare/master...IzabellaRaulin:fixed_1520?expand=1#diff-77f163e381dd113e90ebd1bd76479b54R431))
 **Before** trying to remove _Ended_ task:
      ```
     $ snaptel task remove 5db259f7-3403-421d-896a-78aa15031c80
     Error stopping task:
     Task must be stopped
      ```
     Notice that stopping an _Ended_ task did not work either (the state still was _Ended_, so it was a standpoint).

      **After**  removing _Ended_ task directly works fine :
      ```
      $ snaptel task remove 71cf766a-7d95-48ed-ad74-f73853545476
     Task removed:
     ID: 71cf766a-7d95-48ed-ad74-f73853545476

     //verification (for this example, a task list should be empty now)
	$ snaptel task list
	No task found. Have you created a task?
      ```
  

3) **An _Ended_ state migh be resumed if the schedule is still valid**
    In `startTask()` there is a check if the schedule is still valid at this point of time, see ([scheduler/scheduler.go#L487](https://github.com/intelsdi-x/snap/compare/master...IzabellaRaulin:fixed_1520?expand=1#diff-9667cfa1ad6b8b445794f7c2469f069fR487)). 
      **Before** trying to restart _Ended_ task:
      ```
      $ snaptel task start       fc303c34-0484-4507-b0f8-7f7c526d3983
      Error starting task:
      error 0: Subscription already exists
      ```
      **After** trying to restart _Ended_ task:
      (an approriate message will be returned if the schedule is not valid, what happens for windowed schedule)
      ```
      $ snaptel task start 71cf766a-7d95-48ed-ad74-f73853545476
      Error starting task:
      error 0: Task is ended. Cannot be restarted.
      ```

    Notice: if another scheduler also puts a task into an ended state, which is being proposed in work related with a single run task, it may make sense for the ended task to be restartable.

4) **Added an appropriate message that tasks in _Ended_ state cannot be stopped**
      **Before:** trying to stop an _Ended_ task
      Stopping an _Ended_ task does not work - there was no message, however, state of task still was _Ended_

      **After:** trying to stop an _Ended_ task
      An appropriate message will be returned
      ```
     $ snaptel task stop 71cf766a-7d95-48ed-ad74-f73853545476
     Error stopping task:
     error 0: Task is ended. Only running tasks can be stopped.
      ```

### Diagram for _Ended_ task
This diagram presents flow for _Ended_ task (sum up all points above):

![taskendedstatediagram](https://cloud.githubusercontent.com/assets/11335874/23362447/0f0b9f74-fcf6-11e6-93d7-889a7ccdc45f.png)


## Testing done:
- manually tested
- medium tests

@intelsdi-x/snap-maintainers
