### PR TITLE
Adds unit to metrics before calling CollectMetrics

### DIFF
--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -367,6 +367,7 @@ func ToMetric(co core.Metric) *rpc.Metric {
 			Sec:  co.LastAdvertisedTime().Unix(),
 			Nsec: int64(co.Timestamp().Nanosecond()),
 		},
+		Unit: co.Unit(),
 	}
 	if co.Config() != nil {
 		cm.Config = ConfigToConfigMap(co.Config())

--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -221,6 +221,7 @@ func (p *PluginNativeClient) CollectMetrics(mts []core.Metric) ([]core.Metric, e
 			Version_:            mt.Version(),
 			Tags_:               mt.Tags(),
 			Config_:             mt.Config(),
+			Unit_:               mt.Unit(),
 		}
 	}
 


### PR DESCRIPTION
- Adds 'unit' to metrics before calling collect

Fixes #1532

Summary of changes:
- Adds unit to metrics before calling CollectMetrics

Testing done:
- Manual
- Existing unit

----
Given plugins:
```
▶ snaptel plugin list
NAME 			 VERSION 	 TYPE 		 SIGNED 	 STATUS 	 LOADED TIME
mock-grpc 		 1 		 collector 	 false 		 loaded 	 Wed, 22 Feb 2017 16:30:21 PST
test-file-publisher 	 1 		 publisher 	 false 		 loaded 	 Wed, 22 Feb 2017 16:30:22 PST
```
Task:
```yaml
---
  version: 1
  schedule:
    type: "simple"
    interval: "1s"
  workflow:
    collect:
      metrics:
        ?intel?mock?/bar⽔: {}
      config:
        /random:
          return_error: false
      publish:
        -
          plugin_name: test-file-publisher
          config:
            file: /tmp/rand-file.out
```
## Before
![img](https://www.evernote.com/l/AA3Atu1SKZxAlJgyV-Lc6exg5V_BSN_CHkEB/image.png)

## After
![img](https://www.evernote.com/l/AA1-L-Dkg7NCwocBBnXe3gl07ps2tbljTH4B/image.png)

@intelsdi-x/snap-maintainers