### PR TITLE
Fixes #1438, set standard logger as logger for grpc

### DIFF
--- a/snapteld.go
+++ b/snapteld.go
@@ -47,6 +47,7 @@ import (
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 	"github.com/intelsdi-x/snap/pkg/cfgfile"
 	"github.com/intelsdi-x/snap/scheduler"
+	"google.golang.org/grpc/grpclog"
 )
 
 var (
@@ -287,6 +288,10 @@ func action(ctx *cli.Context) error {
 
 	// Switch log level to user defined
 	log.SetLevel(getLevel(cfg.LogLevel))
+
+	//Set standard logger as logger for grpc
+	grpclog.SetLogger(log.StandardLogger())
+
 	log.Info("setting log level to: ", l[cfg.LogLevel])
 
 	log.Info("Starting snapteld (version: ", gitversion, ")")


### PR DESCRIPTION
Fixes #1438

Summary of changes:
- Set standard logger as logger for grpc, logs from grpc depend on log level set for snapteld

Now user will see noisy logs from grpc only for log level set to DEBUG and INFO, logs will be visible in following form:
```
INFO[0015] transport: http2Client.notifyError got notified that the client transport was broken read tcp 127.0.0.1:57370->127.0.0.1:43376: read: connection reset by peer. 
INFO[0015] grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp 127.0.0.1:43376: operation was canceled"; Reconnecting to {"127.0.0.1:43376" <nil>} 
INFO[0015] grpc: addrConn.transportMonitor exits due to: grpc: the connection is closing 
```


Testing done:
- small, medium tests

@intelsdi-x/snap-maintainers
