### PR TITLE
Fixes #1550, checking number of namespace elements in requested metric

### DIFF
--- a/control/metrics.go
+++ b/control/metrics.go
@@ -117,6 +117,10 @@ func errorMetricElementHasTuple(value, ns string) error {
 	return fmt.Errorf("A element %s should not define tuple for namespace %s.", value, ns)
 }
 
+func errorEmptyNamespace() error {
+	return fmt.Errorf("Incorrect format of requested metric, empty list of namespace elements")
+}
+
 type metricCatalogItem struct {
 	namespace string
 	versions  map[int]core.Metric

--- a/control/mttrie.go
+++ b/control/mttrie.go
@@ -196,6 +196,9 @@ func (mtt *mttNode) GetMetrics(ns []string, ver int) ([]*metricType, error) {
 	nodes := []*mttNode{}
 	mts := []*metricType{}
 
+	if len(ns) == 0 {
+		return nil, errorEmptyNamespace()
+	}
 	// search returns all of the nodes fulfilling the 'ns'
 	// even for some of them there is no metric (empty node.mts)
 	nodes = mtt.search(nodes, ns)
@@ -219,6 +222,10 @@ func (mtt *mttNode) GetMetrics(ns []string, ver int) ([]*metricType, error) {
 func (mtt *mttNode) GetVersions(ns []string) ([]*metricType, error) {
 	var nodes []*mttNode
 	var mts []*metricType
+
+	if len(ns) == 0 {
+		return nil, errorEmptyNamespace()
+	}
 
 	nodes = mtt.search(nodes, ns)
 

--- a/control/mttrie_medium_test.go
+++ b/control/mttrie_medium_test.go
@@ -431,6 +431,15 @@ func TestTrie_GetMetric(t *testing.T) {
 					So(err.Error(), ShouldContainSubstring, "Metric not found: /intel/mock/*/invalid (version: -1)")
 				})
 			})
+
+			Convey("for incorrect format of namespace", func() {
+				Convey("error: incorrect format of requested metric", func() {
+					mt, err := trie.GetMetric([]string{}, 6)
+					So(err, ShouldNotBeNil)
+					So(mt, ShouldBeNil)
+					So(err.Error(), ShouldContainSubstring, "Incorrect format of requested metric, empty list of namespace elements")
+				})
+			})
 		})
 	})
 	Convey("improper usage of GetMetric - requested namespace fulfills more than one metric's namespace", t, func() {
@@ -524,6 +533,15 @@ func TestTrie_GetVersions(t *testing.T) {
 				So(err, ShouldNotBeNil)
 				So(mts, ShouldBeNil)
 				So(err.Error(), ShouldContainSubstring, "Metric not found: /invalid/*")
+			})
+		})
+
+		Convey("for incorrect format of namespace", func() {
+			Convey("error: incorrect format of requested metric", func() {
+				mts, err := trie.GetVersions([]string{})
+				So(err, ShouldNotBeNil)
+				So(mts, ShouldBeNil)
+				So(err.Error(), ShouldContainSubstring, "Incorrect format of requested metric, empty list of namespace elements")
 			})
 		})
 	})


### PR DESCRIPTION
Fixes #1550

Summary of changes:
- Added checking of number of namespace elements in requested metric

`$` in task manifest indicates env variable. If variables are not set then namespace is empty.
Currently for empty namespace user will see following message:
```
Using task manifest to create task
Error creating task:Incorrect format of requested metric, empty list of namespace elements
```
Testing done:
- small, medium tests

@intelsdi-x/snap-maintainers
