### PR TITLE
Fixes #1555, autodiscover loaded plugins use configured tmp dir

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -313,11 +313,7 @@ func (p *pluginControl) Start() error {
 		controlLogger.WithFields(log.Fields{
 			"_block": "start",
 		}).Info("auto discover path is enabled")
-		tempDirPath := p.GetTempDir()
-		controlLogger.WithFields(log.Fields{
-			"_block":      "start",
-			"tempdirpath": tempDirPath,
-		}).Info("temporary directory path set")
+
 		paths := filepath.SplitList(p.Config.AutoDiscoverPath)
 		p.SetAutodiscoverPaths(paths)
 		for _, pa := range paths {
@@ -396,7 +392,7 @@ func (p *pluginControl) Start() error {
 						}).Warn("Auto-loading of plugin '", fileName, "' skipped (plugin not executable)")
 						continue
 					}
-					rp, err := core.NewRequestedPlugin(path.Join(fullPath, fileName), tempDirPath, nil)
+					rp, err := core.NewRequestedPlugin(path.Join(fullPath, fileName), p.GetTempDir(), nil)
 					if err != nil {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",

--- a/control/control.go
+++ b/control/control.go
@@ -313,6 +313,11 @@ func (p *pluginControl) Start() error {
 		controlLogger.WithFields(log.Fields{
 			"_block": "start",
 		}).Info("auto discover path is enabled")
+		tempDirPath := p.GetTempDir()
+		controlLogger.WithFields(log.Fields{
+			"_block":      "start",
+			"tempdirpath": tempDirPath,
+		}).Info("temporary directory path set")
 		paths := filepath.SplitList(p.Config.AutoDiscoverPath)
 		p.SetAutodiscoverPaths(paths)
 		for _, pa := range paths {
@@ -391,7 +396,7 @@ func (p *pluginControl) Start() error {
 						}).Warn("Auto-loading of plugin '", fileName, "' skipped (plugin not executable)")
 						continue
 					}
-					rp, err := core.NewRequestedPlugin(path.Join(fullPath, fileName), GetDefaultConfig().TempDirPath, nil)
+					rp, err := core.NewRequestedPlugin(path.Join(fullPath, fileName), tempDirPath, nil)
 					if err != nil {
 						controlLogger.WithFields(log.Fields{
 							"_block":           "start",

--- a/snapteld.go
+++ b/snapteld.go
@@ -269,6 +269,17 @@ func action(ctx *cli.Context) error {
 		defer file.Close()
 		log.SetOutput(file)
 	}
+
+	// verify the temDirPath points to existing directory
+	tempDirPath := cfg.Control.TempDirPath
+	f, err := os.Stat(tempDirPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if !f.IsDir() {
+		log.Fatal("temp dir path provided must be a directory")
+	}
+
 	// Because even though github.com/Sirupsen/logrus states that
 	// 'Logs the event in colors if stdout is a tty, otherwise without colors'
 	// Seems like this does not work
@@ -293,6 +304,8 @@ func action(ctx *cli.Context) error {
 	grpclog.SetLogger(log.StandardLogger())
 
 	log.Info("setting log level to: ", l[cfg.LogLevel])
+
+	log.Info("setting temp dir path to: ", tempDirPath)
 
 	log.Info("Starting snapteld (version: ", gitversion, ")")
 


### PR DESCRIPTION
Fixes #1555

Summary of changes:
- Plugins loaded through the autodiscover path with utilize the configured temp directory
- Added INFO log to declare temp directory before the start of the autodiscover load loop

Testing done:
- Small Test on Mac OS X

@intelsdi-x/snap-maintainers
