### PR TITLE
Added 32-bit build

### DIFF
--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -24,5 +24,9 @@ export GOARCH=amd64
 "${__dir}/build_snap.sh" &
 "${__dir}/build_plugins.sh" &
 
+export GOOS=windows32
+export GOARCH=386
+"${__dir}/build_snap.sh" &
+"${__dir}/build_plugins.sh" &
 
 wait

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -24,7 +24,7 @@ export GOARCH=amd64
 "${__dir}/build_snap.sh" &
 "${__dir}/build_plugins.sh" &
 
-export GOOS=windows32
+export GOOS=windows
 export GOARCH=386
 "${__dir}/build_snap.sh" &
 "${__dir}/build_plugins.sh" &


### PR DESCRIPTION
Need a 32-bit build for customers running antiquated hardware.  I opened an issue to track this change here: https://github.com/intelsdi-x/snap/issues/1562

Fixes #

Summary of changes:
- 
- 
- 

Testing done:
- 

@intelsdi-x/snap-maintainers
