### PR TITLE
Improved error message for `plugin unload` cmd

### DIFF
--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -84,7 +84,7 @@ func getConfig(ctx *cli.Context) error {
 		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pver < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	defer w.Flush()

--- a/cmd/snaptel/main.go
+++ b/cmd/snaptel/main.go
@@ -45,7 +45,7 @@ type usageError struct {
 }
 
 func (ue usageError) Error() string {
-	return ue.s
+	return fmt.Sprintf("Error: %s \nUsage: %s", ue.s, ue.ctx.Command.Usage)
 }
 
 func (ue usageError) help() {

--- a/cmd/snaptel/metric.go
+++ b/cmd/snaptel/metric.go
@@ -158,7 +158,7 @@ func printMetric(metric *client.GetMetricResult, idx int) error {
 
 func getMetric(ctx *cli.Context) error {
 	if !ctx.IsSet("metric-namespace") {
-		return newUsageError("namespace is required\n\n", ctx)
+		return newUsageError("Must provide metric namespace", ctx)
 	}
 	ns := ctx.String("metric-namespace")
 	ver := ctx.Int("metric-version")

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -35,7 +35,7 @@ func loadPlugin(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {
@@ -104,7 +104,7 @@ func swapPlugins(ctx *cli.Context) error {
 	pAsc := ctx.String("plugin-asc")
 	var paths []string
 	if len(ctx.Args()) < 1 || len(ctx.Args()) > 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 	paths = append(paths, ctx.Args().First())
 	if pAsc != "" {

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -66,7 +66,7 @@ func loadPlugin(ctx *cli.Context) error {
 func unloadPlugin(ctx *cli.Context) error {
 	pType := ctx.Args().Get(0)
 	pName := ctx.Args().Get(1)
-	pVer, err := strconv.Atoi(ctx.Args().Get(2))
+	pVerStr := ctx.Args().Get(2)
 
 	if pType == "" {
 		return newUsageError("Must provide plugin type", ctx)
@@ -74,11 +74,16 @@ func unloadPlugin(ctx *cli.Context) error {
 	if pName == "" {
 		return newUsageError("Must provide plugin name", ctx)
 	}
+	if pVerStr == "" {
+		return newUsageError("Must provide plugin version", ctx)
+	}
+
+	pVer, err := strconv.Atoi(pVerStr)
 	if err != nil {
 		return newUsageError("Can't convert version string to integer", ctx)
 	}
 	if pVer < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 
 	r := pClient.UnloadPlugin(pType, pName, pVer)
@@ -139,7 +144,7 @@ func swapPlugins(ctx *cli.Context) error {
 		return newUsageError("Must provide plugin name", ctx)
 	}
 	if pVer < 1 {
-		return newUsageError("Must provide plugin version", ctx)
+		return newUsageError("Plugin version must be greater than zero", ctx)
 	}
 
 	r := pClient.SwapPlugin(paths, pType, pName, pVer)

--- a/cmd/snaptel/tribe.go
+++ b/cmd/snaptel/tribe.go
@@ -55,7 +55,7 @@ func listMembers(ctx *cli.Context) error {
 
 func showMember(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.GetMember(ctx.Args().First())
@@ -105,7 +105,7 @@ func listAgreements(ctx *cli.Context) error {
 
 func createAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.AddAgreement(ctx.Args().First())
@@ -118,7 +118,7 @@ func createAgreement(ctx *cli.Context) error {
 
 func deleteAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.DeleteAgreement(ctx.Args().First())
@@ -131,7 +131,7 @@ func deleteAgreement(ctx *cli.Context) error {
 
 func joinAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.JoinAgreement(ctx.Args().First(), ctx.Args().Get(1))
@@ -144,7 +144,7 @@ func joinAgreement(ctx *cli.Context) error {
 
 func leaveAgreement(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.LeaveAgreement(ctx.Args().First(), ctx.Args().Get(1))
@@ -157,7 +157,7 @@ func leaveAgreement(ctx *cli.Context) error {
 
 func agreementMembers(ctx *cli.Context) error {
 	if len(ctx.Args()) != 1 {
-		return newUsageError("Incorrect usage:", ctx)
+		return newUsageError("Incorrect usage", ctx)
 	}
 
 	resp := pClient.GetAgreement(ctx.Args().First())


### PR DESCRIPTION
Fixes #1465

### Summary of changes:
- improved the last error message "Must provide plugin version" to help to forge proper plugin unload command

The table has been updated after including the `usage` into error message

Command | Before | After
----| ------- | ------------
`$ snaptel plugin unload collector perfevents` | Can't convert version string to integer | Error: Must provide plugin version </br>Usage: unload <plugin_type> <plugin_name> <plugin_version>
`$ snaptel plugin unload collector perfevents 0` | Must provide plugin version | Error: Plugin version must be greater than zero </br>Usage: unload <plugin_type> <plugin_name> <plugin_version>
 | |
 | |
<sup>(*)</sup> `$ snaptel plugin swap plugins/snap-plugin-collector-mock1 collector:mock:0` | Must provide plugin version |  Error: Plugin version must be greater than zero </br>Usage: swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version>




<sup>(*)</sup> Plus changed the error message for swapPlugins to be more appropriate

### Testing done:
- manual tests

@intelsdi-x/snap-maintainers
