### PR TITLE
Add verb to error message

### DIFF
--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -90,7 +90,7 @@ func getConfig(ctx *cli.Context) error {
 	defer w.Flush()
 	r := pClient.GetPluginConfig(ptyp, pname, strconv.Itoa(pver))
 	if r.Err != nil {
-		return fmt.Errorf("Error requesting info: ", r.Err)
+		return fmt.Errorf("Error requesting info: %v", r.Err)
 	}
 	printFields(w, false, 0,
 		"NAME",


### PR DESCRIPTION
Summary of changes:

Before:

    $ snaptel plugin config get test:test:1
    Error requesting info: %!(EXTRA *rbody.Error=invalid plugin type name given test)

After:

    $ snaptel plugin config get test:test:1
    Error requesting info: invalid plugin type name given test
