### PR TITLE
Fixed tests in distributed task

### DIFF
--- a/core/scheduler_event/scheduler_event.go
+++ b/core/scheduler_event/scheduler_event.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	PluginsUnsubscribed    = "Scheduler.PluginUnsubscribed"
 	TaskCreated            = "Scheduler.TaskCreated"
 	TaskDeleted            = "Scheduler.TaskDeleted"
 	TaskStarted            = "Scheduler.TaskStarted"
@@ -33,6 +34,15 @@ const (
 	MetricCollected        = "Scheduler.MetricsCollected"
 	MetricCollectionFailed = "Scheduler.MetricCollectionFailed"
 )
+
+type PluginsUnsubscribedEvent struct {
+	TaskID  string
+	Plugins []core.SubscribedPlugin
+}
+
+func (e PluginsUnsubscribedEvent) Namespace() string {
+	return PluginsUnsubscribed
+}
 
 type TaskStartedEvent struct {
 	TaskID string

--- a/pkg/schedule/windowed_schedule_medium_test.go
+++ b/pkg/schedule/windowed_schedule_medium_test.go
@@ -330,7 +330,7 @@ func TestWindowedSchedule(t *testing.T) {
 	}) // the end of `Nominal windowed Schedule`
 
 	Convey("Windowed Schedule with determined the count of runs", t, func() {
-		interval := time.Millisecond * 10
+		interval := time.Second
 
 		Convey("expected to start immediately", func() {
 			Convey("single run", func() {
@@ -523,8 +523,6 @@ func TestWindowedSchedule(t *testing.T) {
 		Convey("started in the past", func() {
 			startWait := time.Millisecond * -200
 			count := uint(1)
-			interval := time.Millisecond * 10
-
 			start := time.Now().Add(startWait)
 			w := NewWindowedSchedule(
 				interval,
@@ -564,7 +562,6 @@ func TestWindowedSchedule(t *testing.T) {
 		Convey("with determined stop", func() {
 			startWait := time.Millisecond * 50
 			windowSize := time.Millisecond * 200
-			interval := time.Millisecond * 10
 			count := uint(1)
 
 			start := time.Now().Add(startWait)

--- a/scheduler/fixtures/fixtures.go
+++ b/scheduler/fixtures/fixtures.go
@@ -25,19 +25,23 @@ import "github.com/intelsdi-x/gomit"
 import "github.com/intelsdi-x/snap/core/scheduler_event"
 
 type listenToSchedulerEvent struct {
-	Ended chan struct{}
+	Ended                    chan struct{}
+	UnsubscribedPluginEvents chan *scheduler_event.PluginsUnsubscribedEvent
 }
 
 // NewListenToSchedulerEvent
 func NewListenToSchedulerEvent() *listenToSchedulerEvent {
 	return &listenToSchedulerEvent{
 		Ended: make(chan struct{}),
+		UnsubscribedPluginEvents: make(chan *scheduler_event.PluginsUnsubscribedEvent),
 	}
 }
 
 func (l *listenToSchedulerEvent) HandleGomitEvent(e gomit.Event) {
-	switch e.Body.(type) {
+	switch msg := e.Body.(type) {
 	case *scheduler_event.TaskEndedEvent:
 		l.Ended <- struct{}{}
+	case *scheduler_event.PluginsUnsubscribedEvent:
+		l.UnsubscribedPluginEvents <- msg
 	}
 }

--- a/scheduler/managers.go
+++ b/scheduler/managers.go
@@ -53,7 +53,7 @@ func (m *managers) Add(key string, val managesMetrics) {
 
 // Returns the managesMetric instance that maps to given
 // string. If an empty string is given, will instead return
-// the local instance passed in on initializiation.
+// the local instance passed in on initialization.
 func (m *managers) Get(key string) (managesMetrics, error) {
 	if key == "" {
 		return m.local, nil

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -777,6 +777,13 @@ func (s *scheduler) HandleGomitEvent(e gomit.Event) {
 		task, _ := s.getTask(v.TaskID)
 		task.UnsubscribePlugins()
 		s.taskWatcherColl.handleTaskDisabled(v.TaskID, v.Why)
+	case *scheduler_event.PluginsUnsubscribedEvent:
+		log.WithFields(log.Fields{
+			"_module":         "scheduler-events",
+			"_block":          "handle-events",
+			"event-namespace": e.Namespace(),
+			"task-id":         v.TaskID,
+		}).Debug("event received")
 	default:
 		log.WithFields(log.Fields{
 			"_module":         "scheduler-events",

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -366,6 +366,11 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 	depGroups := getWorkflowPlugins(t.workflow.processNodes, t.workflow.publishNodes, t.workflow.metrics)
 	var errs []serror.SnapError
 	for k := range depGroups {
+		event := scheduler_event.PluginsUnsubscribedEvent{
+			TaskID:  t.ID(),
+			Plugins: depGroups[k].subscribedPlugins,
+		}
+		defer t.eventEmitter.Emit(event)
 		mgr, err := t.RemoteManagers.Get(k)
 		if err != nil {
 			errs = append(errs, serror.New(err))

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -275,8 +275,17 @@ func (t *task) stream() {
 			t.maxMetricsBuffer)
 		if err != nil {
 			consecutiveFailures++
-			e := checkTaskFailures(t, consecutiveFailures)
-			if e != nil {
+			// check task failures
+			if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
+				taskLogger.WithFields(log.Fields{
+					"_block":               "stream",
+					"task-id":              t.id,
+					"task-name":            t.name,
+					"consecutive failures": consecutiveFailures,
+					"error":                t.lastFailureMessage,
+				}).Error(ErrTaskDisabledOnFailures)
+				// disable the task
+				t.disable(t.lastFailureMessage)
 				return
 			}
 			// If we are unsuccessful at setting up the stream
@@ -321,8 +330,17 @@ func (t *task) stream() {
 					time.Sleep(resetTime)
 					done = true
 				}
-				e := checkTaskFailures(t, consecutiveFailures)
-				if e != nil {
+				// check task failures
+				if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
+					taskLogger.WithFields(log.Fields{
+						"_block":               "stream",
+						"task-id":              t.id,
+						"task-name":            t.name,
+						"consecutive failures": consecutiveFailures,
+						"error":                t.lastFailureMessage,
+					}).Error(ErrTaskDisabledOnFailures)
+					// disable the task
+					t.disable(t.lastFailureMessage)
 					return
 				}
 			}
@@ -330,28 +348,6 @@ func (t *task) stream() {
 	}
 }
 
-func checkTaskFailures(t *task, consecutiveFailures int) error {
-	if t.stopOnFailure >= 0 && consecutiveFailures >= t.stopOnFailure {
-		taskLogger.WithFields(log.Fields{
-			"_block":               "spin",
-			"task-id":              t.id,
-			"task-name":            t.name,
-			"consecutive failures": consecutiveFailures,
-			"error":                t.lastFailureMessage,
-		}).Error(ErrTaskDisabledOnFailures)
-		// You must lock on state change for tasks
-		t.Lock()
-		t.state = core.TaskDisabled
-		t.Unlock()
-		// Send task disabled event
-		event := new(scheduler_event.TaskDisabledEvent)
-		event.TaskID = t.id
-		event.Why = fmt.Sprintf("Task disabled with error: %s", t.lastFailureMessage)
-		defer t.eventEmitter.Emit(event)
-		return ErrTaskDisabledOnFailures
-	}
-	return nil
-}
 func (t *task) Stop() {
 	t.Lock()
 	defer t.Unlock()
@@ -366,7 +362,7 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 	depGroups := getWorkflowPlugins(t.workflow.processNodes, t.workflow.publishNodes, t.workflow.metrics)
 	var errs []serror.SnapError
 	for k := range depGroups {
-		event := scheduler_event.PluginsUnsubscribedEvent{
+		event := &scheduler_event.PluginsUnsubscribedEvent{
 			TaskID:  t.ID(),
 			Plugins: depGroups[k].subscribedPlugins,
 		}
@@ -380,6 +376,14 @@ func (t *task) UnsubscribePlugins() []serror.SnapError {
 				errs = append(errs, uerrs...)
 			}
 		}
+	}
+	for _, err := range errs {
+		taskLogger.WithFields(log.Fields{
+			"_block":     "UnsubscribePlugins",
+			"task-id":    t.id,
+			"task-name":  t.name,
+			"task-state": t.state,
+		}).Error(err)
 	}
 	return errs
 }
@@ -489,15 +493,9 @@ func (t *task) spin() {
 						"consecutive failures": consecutiveFailures,
 						"error":                t.lastFailureMessage,
 					}).Error(ErrTaskDisabledOnFailures)
-					// You must lock on state change for tasks
-					t.Lock()
-					t.state = core.TaskDisabled
-					t.Unlock()
-					// Send task disabled event
-					event := new(scheduler_event.TaskDisabledEvent)
-					event.TaskID = t.id
-					event.Why = fmt.Sprintf("Task disabled with error: %s", t.lastFailureMessage)
-					defer t.eventEmitter.Emit(event)
+
+					// disable the task
+					t.disable(t.lastFailureMessage)
 					return
 				}
 
@@ -515,10 +513,9 @@ func (t *task) spin() {
 
 			// Schedule has errored
 			case schedule.Error:
-				// You must lock task to change state
-				t.Lock()
-				t.state = core.TaskDisabled
-				t.Unlock()
+				// disable the task
+				failureMessage := sr.Error().Error()
+				t.disable(failureMessage)
 				return //spin
 
 			}
@@ -540,6 +537,19 @@ func (t *task) fire() {
 	t.state = core.TaskFiring
 	t.workflow.Start(t)
 	t.state = core.TaskSpinning
+}
+
+// disable proceeds disabling a task which consists of changing task state to disabled and emitting an appropriate event
+func (t *task) disable(failureMsg string) {
+	t.Lock()
+	t.state = core.TaskDisabled
+	t.Unlock()
+
+	// Send task disabled event
+	event := new(scheduler_event.TaskDisabledEvent)
+	event.TaskID = t.id
+	event.Why = fmt.Sprintf("Task disabled with error: %s", failureMsg)
+	defer t.eventEmitter.Emit(event)
 }
 
 func (t *task) waitForSchedule() {


### PR DESCRIPTION
Fixes #1576

The following failures are fixed in `scheduler/distributed_task_test.go`:

![image](https://cloud.githubusercontent.com/assets/11335874/24364177/3a60246a-1312-11e7-9613-dc1ac4aac9f9.png)

The following failures are fixed in `pkg/schedule/windowed_schedule_medium_test.go`:
```
* /Users/egu/.gvm/pkgsets/go1.7/snap-1.7/src/github.com/intelsdi-x/snap/pkg/schedule/windowed_schedule_medium_test.go
  Line 471:
  Expected: '1'
  Actual:   '0'
  (Should be equal)

  * /Users/egu/.gvm/pkgsets/go1.7/snap-1.7/src/github.com/intelsdi-x/snap/pkg/schedule/windowed_schedule_medium_test.go
  Line 507:
  Expected: '10'
  Actual:   '7'
  (Should be equal)

 * /home/travis/gopath/src/github.com/intelsdi-x/snap/pkg/schedule/windowed_schedule_medium_test.go 
  Line 553:
  Expected: '1'
  Actual:   '0'
  (Should be equal)
```

### Summary of changes:
- added PluginsUnsubscribed event and listener to this event in distributed_workflow_test.go -> react on incoming PluginsUnsubscribed event fixes the flaky tests in `distributed_workflow_tests.go`

- added methods to proceed task disabling -> it's done couple times in different places, it's rather improving code readability, do not impact on how it behaves

- increase an interval to be sure that calculated stop_timestamp (equals to interval multiplied by count) does not pass before test starts -> this fixes tests in windowed_schedule_medium_test.go


### Testing done:
- manual tests
- medium, legacy and small tests

@intelsdi-x/snap-maintainers
