### PR TITLE
Fix: #1578 Fix typo in snapteld configuration file

### DIFF
--- a/docs/SNAPTELD_CONFIGURATION.md
+++ b/docs/SNAPTELD_CONFIGURATION.md
@@ -72,7 +72,7 @@ The control section contains settings for configuring the Control module within 
 ```yaml
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
-  # the start of the snap daemon. This can be a comma separated list of directories.
+  # the start of the snap daemon. This can be a colon separated list of directories.
   auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -28,7 +28,7 @@ gomaxprocs: 2
 # control module of snapteld.
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
-  # the start of the snap daemon. This can be a comma separated list of directories.
+  # the start of the snap daemon. This can be a colon separated list of directories.
   auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before


### PR DESCRIPTION
To auto-load plugins and tasks, a colon separated list of directories
must be provided. This fixes the typo that states it should be a comma
separated list of directories.

Fixes #1578 

Summary of changes:
- Changed comma to colon in docs/SNAPTELD_CONFIGURATION.md
- Changed comma to colon in examples/configs/snap-config-sample.yaml

@intelsdi-x/snap-maintainers
