### PR TITLE
Stopping a task with plugin initiated workflow should not panic

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -236,7 +236,7 @@ func (a *availablePlugin) Stop(r string) error {
 	return a.client.Kill(r)
 }
 
-// Kill assumes aplugin is not able to here a Kill RPC call
+// Kill assumes a plugin is not able to hear a Kill RPC call
 func (a *availablePlugin) Kill(r string) error {
 	log.WithFields(log.Fields{
 		"_module":     "control-aplugin",
@@ -252,6 +252,7 @@ func (a *availablePlugin) Kill(r string) error {
 		}).Debug("deleting available plugin package")
 		os.RemoveAll(filepath.Dir(a.execPath))
 	}
+
 	// If it's a streaming plugin, we need to signal the scheduler that
 	// this plugin is being killed.
 	if c, ok := a.client.(client.PluginStreamCollectorClient); ok {

--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -219,10 +219,8 @@ func (g *grpcClient) Killed() {
 }
 
 func (g *grpcClient) Kill(reason string) error {
-
 	_, err := g.plugin.Kill(getContext(g.timeout), &rpc.KillArg{Reason: reason})
 	g.conn.Close()
-	g.Killed()
 	if err != nil {
 		return err
 	}

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -295,8 +295,11 @@ func (t *task) stream() {
 			}
 			select {
 			case <-t.killChan:
+				t.Lock()
 				t.state = core.TaskStopped
-				break
+				t.Unlock()
+				done = true
+				return
 			case mts, ok := <-metricsChan:
 				if !ok {
 					metricsChan = nil


### PR DESCRIPTION
Fixes https://github.com/intelsdi-x/snap/issues/1589

#### Before:
Stopping a task  with streaming schedule caused a panic:
![image](https://cloud.githubusercontent.com/assets/11335874/24667568/34e28a8e-1964-11e7-819b-6feb9b401e50.png)

#### After
Stopping the task behaves as expected:
  - there is no panic, no errors in snapteld logs
  - the task is in state Stopped after that

#### Summary of changes:
- set `done` to true after receiving that killChan has been Closed
- removed `g.Killed()` from control/plugin/client/grpc.go because:
   -  it should be done only for a streaming plugin based on its documentation:
![image](https://cloud.githubusercontent.com/assets/11335874/24667946/674e8dd2-1965-11e7-8f3e-b95f28abb755.png)
  -  this staff here https://github.com/intelsdi-x/snap/blob/master/control/available_plugin.go#L255 seems to be enough


Testing done:
- manual tests

@intelsdi-x/snap-maintainers
