### PR TITLE
Securing Snap plugin communication with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Documentation for Snap will be kept in this repository for now with an emphasis 
 * [plugin life cycle](docs/PLUGIN_LIFECYCLE.md)
 * [plugin signing](docs/PLUGIN_SIGNING.md)
 * [tribe](docs/TRIBE.md)
+* [secure plugin communication](docs/SECURE_PLUGIN_COMMUNICATION.md)
 
 To learn more about Snap and how others are using it, check out our [blog](https://medium.com/intel-sdi). A good first post to read is [My How-to for the Snap Telemetry Framework](https://medium.com/intel-sdi/my-how-to-for-the-snap-telemetry-framework-e3bb641bc740#.6f5nk543t) by @mjbrender.
 

--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -101,7 +101,7 @@ var (
 			Subcommands: []cli.Command{
 				{
 					Name:   "load",
-					Usage:  "load <plugin_path>",
+					Usage:  "load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]",
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
@@ -116,7 +116,7 @@ var (
 				},
 				{
 					Name:   "swap",
-					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version>",
+					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]",
 					Action: swapPlugins,
 					Flags: []cli.Flag{
 						flPluginAsc,

--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -101,13 +101,13 @@ var (
 			Subcommands: []cli.Command{
 				{
 					Name:   "load",
-					Usage:  "load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-root-certs=<root_cert_paths>]",
+					Usage:  "load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-ca-certs=<ca_cert_paths>]",
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
 						flPluginCert,
 						flPluginKey,
-						flPluginRootCerts,
+						flPluginCACerts,
 					},
 				},
 				{
@@ -117,7 +117,7 @@ var (
 				},
 				{
 					Name:   "swap",
-					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-root-certs=<root_cert_paths>]",
+					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-ca-certs=<ca_cert_paths>]",
 					Action: swapPlugins,
 					Flags: []cli.Flag{
 						flPluginAsc,
@@ -126,7 +126,7 @@ var (
 						flPluginVersion,
 						flPluginCert,
 						flPluginKey,
-						flPluginRootCerts,
+						flPluginCACerts,
 					},
 				},
 				{

--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -101,12 +101,13 @@ var (
 			Subcommands: []cli.Command{
 				{
 					Name:   "load",
-					Usage:  "load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]",
+					Usage:  "load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-root-certs=<root_cert_paths>]",
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
 						flPluginCert,
 						flPluginKey,
+						flPluginRootCerts,
 					},
 				},
 				{
@@ -116,7 +117,7 @@ var (
 				},
 				{
 					Name:   "swap",
-					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]",
+					Usage:  "swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-root-certs=<root_cert_paths>]",
 					Action: swapPlugins,
 					Flags: []cli.Flag{
 						flPluginAsc,
@@ -125,6 +126,7 @@ var (
 						flPluginVersion,
 						flPluginCert,
 						flPluginKey,
+						flPluginRootCerts,
 					},
 				},
 				{

--- a/cmd/snaptel/commands.go
+++ b/cmd/snaptel/commands.go
@@ -105,6 +105,8 @@ var (
 					Action: loadPlugin,
 					Flags: []cli.Flag{
 						flPluginAsc,
+						flPluginCert,
+						flPluginKey,
 					},
 				},
 				{
@@ -121,6 +123,8 @@ var (
 						flPluginType,
 						flPluginName,
 						flPluginVersion,
+						flPluginCert,
+						flPluginKey,
 					},
 				},
 				{

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -81,7 +81,7 @@ var (
 	}
 	flPluginCACerts = cli.StringFlag{
 		Name:  "plugin-ca-certs, r",
-		Usage: "List of CA cert paths for plugin (directory/file) to verify TLS clients",
+		Usage: "List of CA cert paths (directory/file) for plugin to verify TLS clients",
 	}
 	flPluginType = cli.StringFlag{
 		Name:  "plugin-type, t",

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -73,15 +73,15 @@ var (
 	}
 	flPluginCert = cli.StringFlag{
 		Name:  "plugin-cert, c",
-		Usage: "The plugin cert",
+		Usage: "The path to plugin certificate file",
 	}
 	flPluginKey = cli.StringFlag{
 		Name:  "plugin-key, k",
-		Usage: "The plugin key",
+		Usage: "The path to plugin private key file",
 	}
-	flPluginRootCerts = cli.StringFlag{
-		Name:  "plugin-root-certs, r",
-		Usage: "List of root cert paths for TLS to use (folder/file)",
+	flPluginCACerts = cli.StringFlag{
+		Name:  "plugin-ca-certs, r",
+		Usage: "List of CA cert paths for plugin (directory/file) to verify TLS clients",
 	}
 	flPluginType = cli.StringFlag{
 		Name:  "plugin-type, t",

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -79,6 +79,10 @@ var (
 		Name:  "plugin-key, k",
 		Usage: "The plugin key",
 	}
+	flPluginRootCerts = cli.StringFlag{
+		Name:  "plugin-root-certs, r",
+		Usage: "List of root cert paths for TLS to use (folder/file)",
+	}
 	flPluginType = cli.StringFlag{
 		Name:  "plugin-type, t",
 		Usage: "The plugin type",

--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -71,6 +71,14 @@ var (
 		Name:  "plugin-asc, a",
 		Usage: "The plugin asc",
 	}
+	flPluginCert = cli.StringFlag{
+		Name:  "plugin-cert, c",
+		Usage: "The plugin cert",
+	}
+	flPluginKey = cli.StringFlag{
+		Name:  "plugin-key, k",
+		Usage: "The plugin key",
+	}
 	flPluginType = cli.StringFlag{
 		Name:  "plugin-type, t",
 		Usage: "The plugin type",

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -205,12 +205,13 @@ func listPlugins(ctx *cli.Context) error {
 	return nil
 }
 
-// storeTLSPaths extracts paths related to TLS (certificate, key) from command
-// line context into temporary files. Those files are appended to list of paths
-// returned from this function.
+// storeTLSPaths extracts paths related to TLS (certificate, key, root certs)
+// from command line context into temporary files. Those files are appended to
+// list of paths returned from this function.
 func storeTLSPaths(ctx *cli.Context, paths []string) ([]string, error) {
 	pCert := ctx.String("plugin-cert")
 	pKey := ctx.String("plugin-key")
+	pRootCertPaths := ctx.String("plugin-root-certs")
 	if pCert != pKey && (pCert == "" || pKey == "") {
 		return paths, fmt.Errorf("Error processing plugin TLS arguments - one of (certificate, key) arguments is missing")
 	}
@@ -233,6 +234,17 @@ func storeTLSPaths(ctx *cli.Context, paths []string) ([]string, error) {
 		_, err = tmpFile.WriteString(pKey)
 		if err != nil {
 			return paths, fmt.Errorf("Error processing plugin TLS key - unable to write link:\n%v", err.Error())
+		}
+		paths = append(paths, tmpFile.Name())
+	}
+	if pRootCertPaths != "" {
+		tmpFile, err := ioutil.TempFile("", v1.TLSRootCertsPrefix)
+		if err != nil {
+			return paths, fmt.Errorf("Error processing plugin TLS root certificates - unable to create link:\n%v", err.Error())
+		}
+		_, err = tmpFile.WriteString(pRootCertPaths)
+		if err != nil {
+			return paths, fmt.Errorf("Error processing plugin TLS root certificates - unable to write link:\n%v", err.Error())
 		}
 		paths = append(paths, tmpFile.Name())
 	}

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -29,6 +29,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/intelsdi-x/snap/mgmt/rest/v1"
 	"github.com/urfave/cli"
 )
 
@@ -210,25 +211,28 @@ func listPlugins(ctx *cli.Context) error {
 func storeTLSPaths(ctx *cli.Context, paths []string) ([]string, error) {
 	pCert := ctx.String("plugin-cert")
 	pKey := ctx.String("plugin-key")
+	if pCert != pKey && (pCert == "" || pKey == "") {
+		return paths, fmt.Errorf("Error processing plugin TLS arguments - one of (certificate, key) arguments is missing")
+	}
 	if pCert != "" {
-		tmpFile, err := ioutil.TempFile("", "crt.")
+		tmpFile, err := ioutil.TempFile("", v1.TLSCertPrefix)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin certificate - unable to create link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS certificate - unable to create link:\n%v", err.Error())
 		}
 		_, err = tmpFile.WriteString(pCert)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin certificate - unable to write link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS certificate - unable to write link:\n%v", err.Error())
 		}
 		paths = append(paths, tmpFile.Name())
 	}
 	if pKey != "" {
-		tmpFile, err := ioutil.TempFile("", "key.")
+		tmpFile, err := ioutil.TempFile("", v1.TLSKeyPrefix)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin key - unable to create link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS key - unable to create link:\n%v", err.Error())
 		}
 		_, err = tmpFile.WriteString(pKey)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin key - unable to write link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS key - unable to write link:\n%v", err.Error())
 		}
 		paths = append(paths, tmpFile.Name())
 	}

--- a/cmd/snaptel/plugin.go
+++ b/cmd/snaptel/plugin.go
@@ -205,13 +205,13 @@ func listPlugins(ctx *cli.Context) error {
 	return nil
 }
 
-// storeTLSPaths extracts paths related to TLS (certificate, key, root certs)
+// storeTLSPaths extracts paths related to TLS (certificate, key, plugin CA certs)
 // from command line context into temporary files. Those files are appended to
 // list of paths returned from this function.
 func storeTLSPaths(ctx *cli.Context, paths []string) ([]string, error) {
 	pCert := ctx.String("plugin-cert")
 	pKey := ctx.String("plugin-key")
-	pRootCertPaths := ctx.String("plugin-root-certs")
+	pCACertPaths := ctx.String("plugin-ca-certs")
 	if pCert != pKey && (pCert == "" || pKey == "") {
 		return paths, fmt.Errorf("Error processing plugin TLS arguments - one of (certificate, key) arguments is missing")
 	}
@@ -237,14 +237,14 @@ func storeTLSPaths(ctx *cli.Context, paths []string) ([]string, error) {
 		}
 		paths = append(paths, tmpFile.Name())
 	}
-	if pRootCertPaths != "" {
-		tmpFile, err := ioutil.TempFile("", v1.TLSRootCertsPrefix)
+	if pCACertPaths != "" {
+		tmpFile, err := ioutil.TempFile("", v1.TLSCACertsPrefix)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin TLS root certificates - unable to create link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS CA certificates - unable to create link:\n%v", err.Error())
 		}
-		_, err = tmpFile.WriteString(pRootCertPaths)
+		_, err = tmpFile.WriteString(pCACertPaths)
 		if err != nil {
-			return paths, fmt.Errorf("Error processing plugin TLS root certificates - unable to write link:\n%v", err.Error())
+			return paths, fmt.Errorf("Error processing plugin TLS CA certificates - unable to write link:\n%v", err.Error())
 		}
 		paths = append(paths, tmpFile.Name())
 	}

--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -51,8 +51,10 @@ const (
 )
 
 var (
-	ErrPoolNotFound = errors.New("plugin pool not found")
-	ErrBadKey       = errors.New("bad key")
+	ErrPoolNotFound      = errors.New("plugin pool not found")
+	ErrBadKey            = errors.New("bad key")
+	ErrMsgInsecurePlugin = "secure framework can't connect to insecure plugin"
+	ErrMsgInsecureClient = "insecure framework can't connect to secure plugin"
 )
 
 // availablePlugin represents a plugin which is
@@ -78,7 +80,13 @@ type availablePlugin struct {
 
 // newAvailablePlugin returns an availablePlugin with information from a
 // plugin.Response
-func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executablePlugin) (*availablePlugin, error) {
+func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executablePlugin, security client.GRPCSecurity) (*availablePlugin, error) {
+	if security.TLSEnabled && !resp.Meta.TLSEnabled {
+		return nil, errors.New(ErrMsgInsecurePlugin + "; plugin_name: " + resp.Meta.Name)
+	}
+	if !security.TLSEnabled && resp.Meta.TLSEnabled {
+		return nil, errors.New(ErrMsgInsecureClient + "; plugin_name: " + resp.Meta.Name)
+	}
 	if resp.Type != plugin.CollectorPluginType && resp.Type != plugin.ProcessorPluginType && resp.Type != plugin.PublisherPluginType {
 		return nil, strategy.ErrBadType
 	}
@@ -111,7 +119,7 @@ func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executab
 			}
 			ap.client = c
 		case plugin.GRPC:
-			c, e := client.NewCollectorGrpcClient(resp.ListenAddress, DefaultClientTimeout, resp.PublicKey, !resp.Meta.Unsecure)
+			c, e := client.NewCollectorGrpcClient(resp.ListenAddress, DefaultClientTimeout, security)
 			if e != nil {
 				return nil, errors.New("error while creating client connection: " + e.Error())
 			}
@@ -120,8 +128,7 @@ func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executab
 			c, e := client.NewStreamCollectorGrpcClient(
 				resp.ListenAddress,
 				DefaultClientTimeout,
-				resp.PublicKey,
-				!resp.Meta.Unsecure)
+				security)
 			if e != nil {
 				return nil, errors.New("error while creating client connection: " + e.Error())
 			}
@@ -138,7 +145,7 @@ func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executab
 			}
 			ap.client = c
 		case plugin.GRPC:
-			c, e := client.NewPublisherGrpcClient(resp.ListenAddress, DefaultClientTimeout, resp.PublicKey, !resp.Meta.Unsecure)
+			c, e := client.NewPublisherGrpcClient(resp.ListenAddress, DefaultClientTimeout, security)
 			if e != nil {
 				return nil, errors.New("error while creating client connection: " + e.Error())
 			}
@@ -155,7 +162,7 @@ func newAvailablePlugin(resp plugin.Response, emitter gomit.Emitter, ep executab
 			}
 			ap.client = c
 		case plugin.GRPC:
-			c, e := client.NewProcessorGrpcClient(resp.ListenAddress, DefaultClientTimeout, resp.PublicKey, !resp.Meta.Unsecure)
+			c, e := client.NewProcessorGrpcClient(resp.ListenAddress, DefaultClientTimeout, security)
 			if e != nil {
 				return nil, errors.New("error while creating client connection: " + e.Error())
 			}

--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	// DefaultClientTimeout - default timeout for a client connection attempt
+	// DefaultClientTimeout - default timeout for RPC method completion
 	DefaultClientTimeout = time.Second * 10
 	// DefaultHealthCheckTimeout - default timeout for a health check
 	DefaultHealthCheckTimeout = time.Second * 10

--- a/control/available_plugin_test.go
+++ b/control/available_plugin_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/intelsdi-x/snap/control/fixtures"
 	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/client"
 	"github.com/intelsdi-x/snap/core"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -45,7 +46,7 @@ func TestAvailablePlugin(t *testing.T) {
 				Type:          plugin.CollectorPluginType,
 				ListenAddress: "127.0.0.1:4000",
 			}
-			ap, err := newAvailablePlugin(resp, nil, nil)
+			ap, err := newAvailablePlugin(resp, nil, nil, client.SecurityTLSOff())
 			So(ap, ShouldHaveSameTypeAs, new(availablePlugin))
 			So(err, ShouldBeNil)
 		})
@@ -112,7 +113,7 @@ func TestAvailablePlugins(t *testing.T) {
 			Type:          plugin.CollectorPluginType,
 			ListenAddress: "localhost:asdf",
 		}
-		ap, err := newAvailablePlugin(resp, nil, nil)
+		ap, err := newAvailablePlugin(resp, nil, nil, client.SecurityTLSOff())
 		So(ap, ShouldBeNil)
 		So(err, ShouldNotBeNil)
 	})

--- a/control/config.go
+++ b/control/config.go
@@ -48,6 +48,9 @@ var (
 	defaultCacheExpiration   = 500 * time.Millisecond
 	defaultPprof             = false
 	defaultTempDirPath       = os.TempDir()
+	defaultTLSCertPath       = ""
+	defaultTLSKeyPath        = ""
+	defaultRootCertPaths     = ""
 )
 
 type pluginConfig struct {
@@ -88,6 +91,7 @@ type Config struct {
 	TempDirPath       string                       `json:"temp_dir_path"yaml:"temp_dir_path"`
 	TLSCertPath       string                       `json:"tls_cert_path"yaml:"tls_cert_path"`
 	TLSKeyPath        string                       `json:"tls_key_path"yaml:"tls_key_path"`
+	RootCertPaths     string                       `json:"root_cert_paths"yaml:"root_cert_paths"`
 }
 
 const (
@@ -148,6 +152,9 @@ const (
 					},
 					"tls_key_path": {
 						"type": "string"
+					},
+					"root_cert_paths": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false
@@ -171,6 +178,9 @@ func GetDefaultConfig() *Config {
 		Pprof:             defaultPprof,
 		MaxPluginRestarts: MaxPluginRestartCount,
 		TempDirPath:       defaultTempDirPath,
+		TLSCertPath:       defaultTLSCertPath,
+		TLSKeyPath:        defaultTLSKeyPath,
+		RootCertPaths:     defaultRootCertPaths,
 	}
 }
 

--- a/control/config.go
+++ b/control/config.go
@@ -50,7 +50,7 @@ var (
 	defaultTempDirPath       = os.TempDir()
 	defaultTLSCertPath       = ""
 	defaultTLSKeyPath        = ""
-	defaultRootCertPaths     = ""
+	defaultCACertPaths       = ""
 )
 
 type pluginConfig struct {
@@ -91,7 +91,7 @@ type Config struct {
 	TempDirPath       string                       `json:"temp_dir_path"yaml:"temp_dir_path"`
 	TLSCertPath       string                       `json:"tls_cert_path"yaml:"tls_cert_path"`
 	TLSKeyPath        string                       `json:"tls_key_path"yaml:"tls_key_path"`
-	RootCertPaths     string                       `json:"root_cert_paths"yaml:"root_cert_paths"`
+	CACertPaths       string                       `json:"ca_cert_paths"yaml:"ca_cert_paths"`
 }
 
 const (
@@ -153,7 +153,7 @@ const (
 					"tls_key_path": {
 						"type": "string"
 					},
-					"root_cert_paths": {
+					"ca_cert_paths": {
 						"type": "string"
 					}
 				},
@@ -180,7 +180,7 @@ func GetDefaultConfig() *Config {
 		TempDirPath:       defaultTempDirPath,
 		TLSCertPath:       defaultTLSCertPath,
 		TLSKeyPath:        defaultTLSKeyPath,
-		RootCertPaths:     defaultRootCertPaths,
+		CACertPaths:       defaultCACertPaths,
 	}
 }
 
@@ -250,7 +250,7 @@ func (p *Config) GetPluginConfigDataNodeAll() cdata.ConfigDataNode {
 	return *p.Plugins.All
 }
 
-// IsTLSEnabled returns true if config values enable TLS security
+// IsTLSEnabled returns true if config values enable TLS in plugin communication
 func (p *Config) IsTLSEnabled() bool {
 	if p.TLSCertPath != "" && p.TLSKeyPath != "" {
 		return true

--- a/control/config.go
+++ b/control/config.go
@@ -86,6 +86,8 @@ type Config struct {
 	Pprof             bool                         `json:"pprof"yaml:"pprof"`
 	MaxPluginRestarts int                          `json:"max_plugin_restarts"yaml:"max_plugin_restarts"`
 	TempDirPath       string                       `json:"temp_dir_path"yaml:"temp_dir_path"`
+	TLSCertPath       string                       `json:"tls_cert_path"yaml:"tls_cert_path"`
+	TLSKeyPath        string                       `json:"tls_key_path"yaml:"tls_key_path"`
 }
 
 const (
@@ -140,6 +142,12 @@ const (
 					},
 					"max_plugin_restarts": {
 						"type": "integer"
+					},
+					"tls_cert_path": {
+						"type": "string"
+					},
+					"tls_key_path": {
+						"type": "string"
 					}
 				},
 				"additionalProperties": false
@@ -230,6 +238,14 @@ func (p *Config) DeletePluginConfigDataNodeFieldAll(fields ...string) cdata.Conf
 
 func (p *Config) GetPluginConfigDataNodeAll() cdata.ConfigDataNode {
 	return *p.Plugins.All
+}
+
+// IsTLSEnabled returns true if config values enable TLS security
+func (p *Config) IsTLSEnabled() bool {
+	if p.TLSCertPath != "" && p.TLSKeyPath != "" {
+		return true
+	}
+	return false
 }
 
 // UnmarshalJSON unmarshals valid json into pluginConfig.  An example Config

--- a/control/control.go
+++ b/control/control.go
@@ -222,7 +222,6 @@ func New(cfg *Config) *pluginControl {
 		OptSetTempDirPath(cfg.TempDirPath),
 	}
 	runnerOpts := []pluginRunnerOpt{}
-	// Plugin Manager
 	if cfg.IsTLSEnabled() {
 		if cfg.CACertPaths != "" {
 			certPaths := filepath.SplitList(cfg.CACertPaths)
@@ -233,6 +232,7 @@ func New(cfg *Config) *pluginControl {
 		managerOpts = append(managerOpts, OptEnableManagerTLS(c.grpcSecurity))
 		runnerOpts = append(runnerOpts, OptEnableRunnerTLS(c.grpcSecurity))
 	}
+	// Plugin Manager
 	c.pluginManager = newPluginManager(managerOpts...)
 	controlLogger.WithFields(log.Fields{
 		"_block": "new",

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -1,0 +1,526 @@
+// +build medium
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package control
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/gomit"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/snap/control/fixtures"
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/client"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/core/ctypes"
+	"github.com/intelsdi-x/snap/plugin/helper"
+)
+
+type MockEmitter struct{}
+
+const (
+	tlsTestCAFn  = "snaptest-CA"
+	tlsTestSrvFn = "snaptest-srv"
+	tlsTestCliFn = "snaptest-cli"
+)
+
+var tlsTestCA, tlsTestSrv, tlsTestCli string
+
+var testFilesToRemove []string
+
+func (memitter *MockEmitter) Emit(gomit.EventBody) (int, error) { return 0, nil }
+
+type configTLSMock Config
+
+func (m *configTLSMock) export() *Config {
+	return (*Config)(m)
+}
+
+func (m *configTLSMock) setTLSCertPath(certPath string) *configTLSMock {
+	m.TLSCertPath = certPath
+	return m
+}
+
+func (m *configTLSMock) setTLSKeyPath(keyPath string) *configTLSMock {
+	m.TLSKeyPath = keyPath
+	return m
+}
+
+func TestMain(m *testing.M) {
+	setUpTestMain()
+	retCode := m.Run()
+	tearDownTestMain()
+	os.Exit(retCode)
+}
+
+func TestSecureCollector(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	Convey("Having a secure collector", t, func() {
+		var ap *availablePlugin
+		Convey("framework should establish secure connection", func() {
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			var err error
+			ap, err = runPlugin(plugin.Arg{}.
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-collector-mock2-grpc"),
+				security)
+			So(err, ShouldBeNil)
+			Convey("and valid plugin client should be obtained", func() {
+				cli, isCollector := ap.client.(client.PluginCollectorClient)
+				So(isCollector, ShouldBeTrue)
+				Convey("Ping should not fail", func() {
+					err := cli.Ping()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetConfigPolicy should not fail", func() {
+					_, err := cli.GetConfigPolicy()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetMetricTypes should not fail", func() {
+					cfg := plugin.ConfigType{ConfigDataNode: cdata.NewNode()}
+					_, err := cli.GetMetricTypes(cfg)
+					So(err, ShouldBeNil)
+				})
+				Convey("CollectMetrics should not fail", func() {
+					_, err := cli.CollectMetrics([]core.Metric{})
+					So(err, ShouldBeNil)
+				})
+			})
+			Reset(func() {
+				ap.Kill("end-of-test")
+			})
+		})
+	})
+}
+
+func TestSecureProcessor(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	Convey("Having a secure processor", t, func() {
+		var ap *availablePlugin
+		Convey("framework should establish secure connection", func() {
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			var err error
+			ap, err = runPlugin(plugin.Arg{}.
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-processor-passthru-grpc"),
+				security)
+			So(err, ShouldBeNil)
+			Convey("and valid plugin client should be obtained", func() {
+				cli, isProcessor := ap.client.(client.PluginProcessorClient)
+				So(isProcessor, ShouldBeTrue)
+				Convey("Ping should not fail", func() {
+					err := cli.Ping()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetConfigPolicy should not fail", func() {
+					_, err := cli.GetConfigPolicy()
+					So(err, ShouldBeNil)
+				})
+				Convey("Process should not fail", func() {
+					cfg := map[string]ctypes.ConfigValue{}
+					_, err := cli.Process([]core.Metric{}, cfg)
+					So(err, ShouldBeNil)
+				})
+			})
+			Reset(func() {
+				ap.Kill("end-of-test")
+			})
+		})
+	})
+}
+
+func TestSecurePublisher(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	Convey("Having a secure publisher", t, func() {
+		var ap *availablePlugin
+		Convey("framework should establish secure connection", func() {
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			var err error
+			ap, err = runPlugin(plugin.NewArg(int(log.DebugLevel), false).
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-publisher-mock-file-grpc"),
+				security)
+			So(err, ShouldBeNil)
+			Convey("and valid plugin client should be obtained", func() {
+				cli, isPublisher := ap.client.(client.PluginPublisherClient)
+				So(isPublisher, ShouldBeTrue)
+				Convey("Ping should not fail", func() {
+					err := cli.Ping()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetConfigPolicy should not fail", func() {
+					_, err := cli.GetConfigPolicy()
+					So(err, ShouldBeNil)
+				})
+				Convey("Publish should not fail", func() {
+					cfg := map[string]ctypes.ConfigValue{}
+					tf, err := ioutil.TempFile("", "mock-file-publisher-output")
+					if err != nil {
+						panic(err)
+					}
+					testFilesToRemove = append(testFilesToRemove, tf.Name())
+					tf.Close()
+					cfg["file"] = ctypes.ConfigValueStr{Value: tf.Name()}
+					err = cli.Publish([]core.Metric{}, cfg)
+					So(err, ShouldBeNil)
+				})
+			})
+			Reset(func() {
+				ap.Kill("end-of-test")
+			})
+		})
+	})
+}
+
+func TestSecureStreamingCollector(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	Convey("Having a secure streaming collector", t, func() {
+		var ap *availablePlugin
+		Convey("framework should establish secure connection", func() {
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			var err error
+			ap, err = runPlugin(plugin.Arg{}.
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-stream-collector-rand1"),
+				security)
+			So(err, ShouldBeNil)
+			Convey("and valid plugin client should be obtained", func() {
+				cli, isStreamer := ap.client.(client.PluginStreamCollectorClient)
+				So(isStreamer, ShouldBeTrue)
+				Convey("Ping should not fail", func() {
+					err := cli.Ping()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetConfigPolicy should not fail", func() {
+					_, err := cli.GetConfigPolicy()
+					So(err, ShouldBeNil)
+				})
+				Convey("GetMetricTypes should not fail", func() {
+					cfg := plugin.ConfigType{ConfigDataNode: cdata.NewNode()}
+					_, err := cli.GetMetricTypes(cfg)
+					So(err, ShouldBeNil)
+				})
+				Convey("StreamMetrics should not fail", func() {
+					cli.UpdateCollectDuration(time.Second)
+					cli.UpdateMetricsBuffer(1)
+					mtsin := []core.Metric{}
+					m := plugin.MetricType{Namespace_: core.NewNamespace(strings.Fields("a b integer")...)}
+					mtsin = append(mtsin, m)
+					mch, errch, err := cli.StreamMetrics(mtsin)
+					So(err, ShouldBeNil)
+					Convey("streaming should deliver metrics rather than error", func() {
+						select {
+						case mtsout := <-mch:
+							So(mtsout, ShouldNotBeNil)
+							break
+						case err := <-errch:
+							t.Fatal(err)
+						case <-time.After(5 * time.Second):
+							t.Fatal("failed to receive response from stream collector")
+						}
+					})
+				})
+				Convey("UpdateCollectedMetrics should not fail", func() {
+					err := cli.UpdateCollectedMetrics([]core.Metric{})
+					So(err, ShouldBeNil)
+				})
+				Convey("UpdateCollectDuration should not fail", func() {
+					err := cli.UpdateCollectDuration(5 * time.Second)
+					So(err, ShouldBeNil)
+					err = cli.UpdateCollectDuration(1 * time.Second)
+					So(err, ShouldBeNil)
+				})
+				Convey("UpdateMetricsBuffer should not fail", func() {
+					err := cli.UpdateMetricsBuffer(100)
+					So(err, ShouldBeNil)
+					err = cli.UpdateMetricsBuffer(10)
+					So(err, ShouldBeNil)
+				})
+			})
+			Reset(func() {
+				ap.Kill("end-of-test")
+			})
+		})
+	})
+}
+
+func TestInsecureConfigurationFails(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	tcs := []struct {
+		name string
+		msg  func(*plugin.Arg, *client.GRPCSecurity, func(string))
+	}{
+		{
+			name: "SecureFrameworkInsecurePlugin_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				// note: server root certs are used to validate client certs (and vice versa)
+				*srv = srv.SetTLSEnabled(false)
+				f("Attempting TLS connection between secure framework and insecure plugin")
+			},
+		},
+		{
+			name: "InvalidPluginCertKeyPair_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				*srv = srv.SetCertPath(tlsTestCA + fixtures.TestCrtFileExt)
+				f("Attempting TLS connection between secure framework and plugin with invalid cert-key pair")
+			},
+		},
+		{
+			name: "BadRootCertInFramework_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				cli.RootCertPaths = []string{tlsTestCA + fixtures.TestBadCrtFileExt}
+				f("Attempting TLS connection between framework and plugin using incompatible root certs, bad cert in framework")
+			},
+		},
+		{
+			name: "PluginRootCertsUnknownToFramework_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				cli.RootCertPaths = []string{}
+				f("Attempting TLS connection between secure framework and plugin with certificate without root certs known to framework")
+			},
+		},
+		{
+			name: "InsecureFrameworkSecurePlugin_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				cli.TLSEnabled = false
+				f("Attempting TLS connection between insecure framework and secure plugin")
+			},
+		},
+		{
+			name: "InvalidFrameworkCertKeyPair_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				cli.TLSCertPath = tlsTestCA + fixtures.TestCrtFileExt
+				f("Attempting TLS connection between invalid framework with invalid cert-key pair and secure plugin")
+			},
+		},
+		{
+			name: "FrameworkRootCertsUnknownToPlugin_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				srv.RootCertPaths = ""
+				f("Attempting TLS connection between invalid framework with no root certs known to plugin and secure plugin")
+			},
+		},
+		{
+			name: "BadRootCertInPlugin_Fail",
+			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
+				srv.RootCertPaths = tlsTestCA + fixtures.TestBadCrtFileExt
+				f("Attempting TLS connection between framework and plugin using incompatible root certs, bad cert in plugin")
+			},
+		},
+	}
+	for _, tc := range tcs {
+		security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+		pluginArgs := plugin.Arg{}.
+			SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
+			SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
+			SetRootCertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+			SetTLSEnabled(true)
+		runThisCase := func(f func(msg string)) {
+			t.Run(tc.name, func(_ *testing.T) {
+				tc.msg(&pluginArgs, &security, f)
+			})
+		}
+		runThisCase(func(msg string) {
+			Convey(msg, t, func() {
+				var ap *availablePlugin
+				Convey("should fail", func() {
+					So(func() {
+						var err error
+						ap, err = runPlugin(pluginArgs, helper.PluginFilePath("snap-plugin-collector-mock2-grpc"),
+							security)
+						// currently grpc may not return error immediately; attempt to ping
+						if err != nil {
+							panic(err)
+						}
+						cli, isCollector := ap.client.(client.PluginCollectorClient)
+						So(isCollector, ShouldBeTrue)
+						err = cli.Ping()
+						if err != nil {
+							panic(err)
+						}
+					}, ShouldPanic)
+				})
+				Reset(func() {
+					if ap != nil {
+						ap.Kill("end-of-test")
+					}
+				})
+			})
+		})
+	}
+}
+
+func (m *configTLSMock) setRootCertPaths(rootCertPaths string) *configTLSMock {
+	m.RootCertPaths = rootCertPaths
+	return m
+}
+
+func TestSecuritySetupFromConfig(t *testing.T) {
+	var (
+		fakeSampleCert           = "/fake-samples/certs/server-cert"
+		fakeSampleKey            = "/fake-samples/keys/server-key"
+		fakeSampleRootCertsSplit = []string{"/fake-samples/root-ca/ca-one", "/fake-samples/root-ca/ca-two"}
+		fakeSampleRootCerts      = strings.Join(fakeSampleRootCertsSplit, string(filepath.ListSeparator))
+	)
+	tcs := []struct {
+		name           string
+		msg            func(func(string))
+		cfg            *Config
+		wantError      bool
+		wantRunnersec  client.GRPCSecurity
+		wantManagersec client.GRPCSecurity
+	}{
+		{
+			name: "DefaultEmptyConfig",
+			msg: func(f func(string)) {
+				f("passing default (empty) config values, initialization should succeed and result in security disabled")
+			},
+			cfg:            GetDefaultConfig(),
+			wantError:      false,
+			wantRunnersec:  client.SecurityTLSOff(),
+			wantManagersec: client.SecurityTLSOff(),
+		},
+		{
+			name: "TLSEnabledForwardedToSubmodules",
+			msg: func(f func(string)) {
+				f("having TLS enabled in config, plugin runner and manager receive same security values")
+			},
+			cfg: (*configTLSMock)(GetDefaultConfig()).
+				setTLSCertPath(fakeSampleCert).
+				setTLSKeyPath(fakeSampleKey).
+				export(),
+			wantError:      false,
+			wantRunnersec:  client.SecurityTLSEnabled(fakeSampleCert, fakeSampleKey, client.SecureClient),
+			wantManagersec: client.SecurityTLSEnabled(fakeSampleCert, fakeSampleKey, client.SecureClient),
+		},
+		{
+			name: "TLSEnabledRootCertsForwardedToSubmodules",
+			msg: func(f func(string)) {
+				f("having TLS enabled with root cert paths in config, plugin runner and manager receive same security values")
+			},
+			cfg: (*configTLSMock)(GetDefaultConfig()).
+				setTLSCertPath(fakeSampleCert).
+				setTLSKeyPath(fakeSampleKey).
+				setRootCertPaths(fakeSampleRootCerts).
+				export(),
+			wantError:      false,
+			wantRunnersec:  client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleRootCertsSplit),
+			wantManagersec: client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleRootCertsSplit),
+		},
+	}
+	var gotRunner *runner
+	var gotManager *pluginManager
+
+	for _, tc := range tcs {
+		oldRunnerOpts, oldManagerOpts := append([]pluginRunnerOpt{}, defaultRunnerOpts...), append([]pluginManagerOpt{}, defaultManagerOpts...)
+		defaultRunnerOpts = append(defaultRunnerOpts, func(r *runner) {
+			gotRunner = r
+		})
+		defaultManagerOpts = append(defaultManagerOpts, func(m *pluginManager) {
+			gotManager = m
+		})
+		runThisCase := func(f func(msg string)) {
+			t.Run(tc.name, func(_ *testing.T) {
+				Convey("Initializing plugin control module", t, func() {
+					tc.msg(f)
+				})
+			})
+		}
+		runThisCase(func(msg string) {
+			Convey(msg, func() {
+				if tc.wantError {
+					So(func() {
+						New(tc.cfg)
+					}, ShouldPanic)
+					return
+				}
+				So(func() {
+					New(tc.cfg)
+				}, ShouldNotPanic)
+				So(gotRunner.grpcSecurity, ShouldResemble, tc.wantRunnersec)
+				So(gotManager.grpcSecurity, ShouldResemble, tc.wantManagersec)
+			})
+			Reset(func() {
+				defaultRunnerOpts, defaultManagerOpts = oldRunnerOpts, oldManagerOpts
+			})
+		})
+	}
+}
+
+func runPlugin(args plugin.Arg, pluginPath string, security client.GRPCSecurity) (*availablePlugin, error) {
+	ep, err := fixtures.NewExecutablePlugin(args, pluginPath)
+	if err != nil {
+		panic(err)
+	}
+	var r *runner
+	if security.TLSEnabled {
+		r = newRunner(OptEnableRunnerTLS(security))
+	} else {
+		r = newRunner()
+	}
+	r.SetEmitter(new(MockEmitter))
+	ap, err := r.startPlugin(ep)
+	if err != nil {
+		return nil, err
+	}
+	return ap, nil
+}
+
+func setUpTestMain() {
+	rand.Seed(time.Now().Unix())
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Errorf("unable to reach current dir for generating TLS certificates: %v", err))
+	}
+	u := fixtures.CertTestUtil{Prefix: cwd}
+	if tlsTestFiles, err := u.StoreTLSCerts(tlsTestCAFn, tlsTestSrvFn, tlsTestCliFn); err != nil {
+		panic(err)
+	} else {
+		testFilesToRemove = append(testFilesToRemove, tlsTestFiles...)
+	}
+	tlsTestCA = filepath.Join(cwd, tlsTestCAFn)
+	tlsTestSrv = filepath.Join(cwd, tlsTestSrvFn)
+	tlsTestCli = filepath.Join(cwd, tlsTestCliFn)
+}
+
+func tearDownTestMain() {
+	for _, fn := range testFilesToRemove {
+		os.Remove(fn)
+	}
+}

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -1,4 +1,4 @@
-// + build medium
+// +build medium
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -86,12 +86,12 @@ func TestSecureCollector(t *testing.T) {
 	Convey("Having a secure collector", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-collector-mock2-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -128,12 +128,12 @@ func TestSecureProcessor(t *testing.T) {
 	Convey("Having a secure processor", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-processor-passthru-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -166,12 +166,12 @@ func TestSecurePublisher(t *testing.T) {
 	Convey("Having a secure publisher", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.NewArg(int(log.DebugLevel), false).
-				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-publisher-mock-file-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -211,12 +211,12 @@ func TestSecureStreamingCollector(t *testing.T) {
 	Convey("Having a secure streaming collector", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-stream-collector-rand1"),
 				security)
 			So(err, ShouldBeNil)
@@ -345,7 +345,7 @@ func TestInsecureConfigurationFails(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+		security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 		pluginArgs := plugin.Arg{}.
 			SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
 			SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -1,4 +1,4 @@
-// +build medium
+// + build medium
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -91,7 +91,7 @@ func TestSecureCollector(t *testing.T) {
 			ap, err = runPlugin(plugin.Arg{}.
 				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
 				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-collector-mock2-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -133,7 +133,7 @@ func TestSecureProcessor(t *testing.T) {
 			ap, err = runPlugin(plugin.Arg{}.
 				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
 				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-processor-passthru-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -171,7 +171,7 @@ func TestSecurePublisher(t *testing.T) {
 			ap, err = runPlugin(plugin.NewArg(int(log.DebugLevel), false).
 				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
 				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-publisher-mock-file-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -216,7 +216,7 @@ func TestSecureStreamingCollector(t *testing.T) {
 			ap, err = runPlugin(plugin.Arg{}.
 				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
 				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetRootCertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-stream-collector-rand1"),
 				security)
 			So(err, ShouldBeNil)
@@ -289,7 +289,7 @@ func TestInsecureConfigurationFails(t *testing.T) {
 		{
 			name: "SecureFrameworkInsecurePlugin_Fail",
 			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
-				// note: server root certs are used to validate client certs (and vice versa)
+				// note: server CA certs are used to validate client certs (and vice versa)
 				*srv = srv.SetTLSEnabled(false)
 				f("Attempting TLS connection between secure framework and insecure plugin")
 			},
@@ -302,17 +302,17 @@ func TestInsecureConfigurationFails(t *testing.T) {
 			},
 		},
 		{
-			name: "BadRootCertInFramework_Fail",
+			name: "BadCACertInFramework_Fail",
 			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
-				cli.RootCertPaths = []string{tlsTestCA + fixtures.TestBadCrtFileExt}
-				f("Attempting TLS connection between framework and plugin using incompatible root certs, bad cert in framework")
+				cli.CACertPaths = []string{tlsTestCA + fixtures.TestBadCrtFileExt}
+				f("Attempting TLS connection between framework and plugin using incompatible CA certs, bad cert in framework")
 			},
 		},
 		{
-			name: "PluginRootCertsUnknownToFramework_Fail",
+			name: "PluginCACertsUnknownToFramework_Fail",
 			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
-				cli.RootCertPaths = []string{}
-				f("Attempting TLS connection between secure framework and plugin with certificate without root certs known to framework")
+				cli.CACertPaths = []string{}
+				f("Attempting TLS connection between secure framework and plugin with certificate without CA certs known to framework")
 			},
 		},
 		{
@@ -330,17 +330,17 @@ func TestInsecureConfigurationFails(t *testing.T) {
 			},
 		},
 		{
-			name: "FrameworkRootCertsUnknownToPlugin_Fail",
+			name: "FrameworkCACertsUnknownToPlugin_Fail",
 			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
-				srv.RootCertPaths = ""
-				f("Attempting TLS connection between invalid framework with no root certs known to plugin and secure plugin")
+				srv.CACertPaths = ""
+				f("Attempting TLS connection between invalid framework with no CA certs known to plugin and secure plugin")
 			},
 		},
 		{
-			name: "BadRootCertInPlugin_Fail",
+			name: "BadCACertInPlugin_Fail",
 			msg: func(srv *plugin.Arg, cli *client.GRPCSecurity, f func(string)) {
-				srv.RootCertPaths = tlsTestCA + fixtures.TestBadCrtFileExt
-				f("Attempting TLS connection between framework and plugin using incompatible root certs, bad cert in plugin")
+				srv.CACertPaths = tlsTestCA + fixtures.TestBadCrtFileExt
+				f("Attempting TLS connection between framework and plugin using incompatible CA certs, bad cert in plugin")
 			},
 		},
 	}
@@ -349,7 +349,7 @@ func TestInsecureConfigurationFails(t *testing.T) {
 		pluginArgs := plugin.Arg{}.
 			SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
 			SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
-			SetRootCertPaths(tlsTestCA + fixtures.TestCrtFileExt).
+			SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
 			SetTLSEnabled(true)
 		runThisCase := func(f func(msg string)) {
 			t.Run(tc.name, func(_ *testing.T) {
@@ -386,17 +386,17 @@ func TestInsecureConfigurationFails(t *testing.T) {
 	}
 }
 
-func (m *configTLSMock) setRootCertPaths(rootCertPaths string) *configTLSMock {
-	m.RootCertPaths = rootCertPaths
+func (m *configTLSMock) setCACertPaths(caCertPaths string) *configTLSMock {
+	m.CACertPaths = caCertPaths
 	return m
 }
 
 func TestSecuritySetupFromConfig(t *testing.T) {
 	var (
-		fakeSampleCert           = "/fake-samples/certs/server-cert"
-		fakeSampleKey            = "/fake-samples/keys/server-key"
-		fakeSampleRootCertsSplit = []string{"/fake-samples/root-ca/ca-one", "/fake-samples/root-ca/ca-two"}
-		fakeSampleRootCerts      = strings.Join(fakeSampleRootCertsSplit, string(filepath.ListSeparator))
+		fakeSampleCert         = "/fake-samples/certs/server-cert"
+		fakeSampleKey          = "/fake-samples/keys/server-key"
+		fakeSampleCACertsSplit = []string{"/fake-samples/root-ca/ca-one", "/fake-samples/root-ca/ca-two"}
+		fakeSampleCACerts      = strings.Join(fakeSampleCACertsSplit, string(filepath.ListSeparator))
 	)
 	tcs := []struct {
 		name           string
@@ -430,18 +430,18 @@ func TestSecuritySetupFromConfig(t *testing.T) {
 			wantManagersec: client.SecurityTLSEnabled(fakeSampleCert, fakeSampleKey, client.SecureClient),
 		},
 		{
-			name: "TLSEnabledRootCertsForwardedToSubmodules",
+			name: "TLSEnabledCACertsForwardedToSubmodules",
 			msg: func(f func(string)) {
-				f("having TLS enabled with root cert paths in config, plugin runner and manager receive same security values")
+				f("having TLS enabled with CA cert paths in config, plugin runner and manager receive same security values")
 			},
 			cfg: (*configTLSMock)(GetDefaultConfig()).
 				setTLSCertPath(fakeSampleCert).
 				setTLSKeyPath(fakeSampleKey).
-				setRootCertPaths(fakeSampleRootCerts).
+				setCACertPaths(fakeSampleCACerts).
 				export(),
 			wantError:      false,
-			wantRunnersec:  client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleRootCertsSplit),
-			wantManagersec: client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleRootCertsSplit),
+			wantRunnersec:  client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleCACertsSplit),
+			wantManagersec: client.SecurityTLSExtended(fakeSampleCert, fakeSampleKey, client.SecureClient, fakeSampleCACertsSplit),
 		},
 	}
 	var gotRunner *runner
@@ -484,7 +484,7 @@ func TestSecuritySetupFromConfig(t *testing.T) {
 }
 
 func runPlugin(args plugin.Arg, pluginPath string, security client.GRPCSecurity) (*availablePlugin, error) {
-	ep, err := fixtures.NewExecutablePlugin(args, pluginPath)
+	ep, err := plugin.NewExecutablePlugin(args, pluginPath)
 	if err != nil {
 		panic(err)
 	}

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -86,12 +86,12 @@ func TestSecureCollector(t *testing.T) {
 	Convey("Having a secure collector", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-collector-mock2-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -128,12 +128,12 @@ func TestSecureProcessor(t *testing.T) {
 	Convey("Having a secure processor", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-processor-passthru-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -166,12 +166,12 @@ func TestSecurePublisher(t *testing.T) {
 	Convey("Having a secure publisher", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.NewArg(int(log.DebugLevel), false).
-				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-publisher-mock-file-grpc"),
 				security)
 			So(err, ShouldBeNil)
@@ -211,12 +211,12 @@ func TestSecureStreamingCollector(t *testing.T) {
 	Convey("Having a secure streaming collector", t, func() {
 		var ap *availablePlugin
 		Convey("framework should establish secure connection", func() {
-			security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+			security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 			var err error
 			ap, err = runPlugin(plugin.Arg{}.
-				SetCertPath(tlsTestSrv+fixtures.TestCrtFileExt).
-				SetKeyPath(tlsTestSrv+fixtures.TestKeyFileExt).
-				SetCACertPaths(tlsTestCA+fixtures.TestCrtFileExt).
+				SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
+				SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).
+				SetCACertPaths(tlsTestCA + fixtures.TestCrtFileExt).
 				SetTLSEnabled(true), helper.PluginFilePath("snap-plugin-stream-collector-rand1"),
 				security)
 			So(err, ShouldBeNil)
@@ -345,7 +345,7 @@ func TestInsecureConfigurationFails(t *testing.T) {
 		},
 	}
 	for _, tc := range tcs {
-		security := client.SecurityTLSExtended(tlsTestCli+fixtures.TestCrtFileExt, tlsTestCli+fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
+		security := client.SecurityTLSExtended(tlsTestCli + fixtures.TestCrtFileExt, tlsTestCli + fixtures.TestKeyFileExt, client.SecureClient, []string{tlsTestCA + fixtures.TestCrtFileExt})
 		pluginArgs := plugin.Arg{}.
 			SetCertPath(tlsTestSrv + fixtures.TestCrtFileExt).
 			SetKeyPath(tlsTestSrv + fixtures.TestKeyFileExt).

--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/plugin/helper"
@@ -154,4 +155,21 @@ func (m MockRequestedMetric) Version() int {
 
 func (m MockRequestedMetric) Namespace() core.Namespace {
 	return m.namespace
+}
+
+func NewExecutablePlugin(a plugin.Arg, path string) (*plugin.ExecutablePlugin, error) {
+	// Travis optimization: Try starting the plugin three times before finally
+	// returning an error
+	var e error
+	var ep *plugin.ExecutablePlugin
+	for i := 0; i < 3; i++ {
+		ep, e = plugin.NewExecutablePlugin(a, path)
+		if e == nil {
+			break
+		}
+		if e != nil && i == 2 {
+			return nil, e
+		}
+	}
+	return ep, nil
 }

--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -155,20 +155,3 @@ func (m MockRequestedMetric) Version() int {
 func (m MockRequestedMetric) Namespace() core.Namespace {
 	return m.namespace
 }
-
-// func NewExecutablePlugin(a plugin.Arg, path string) (*plugin.ExecutablePlugin, error) {
-// 	// Travis optimization: Try starting the plugin three times before finally
-// 	// returning an error
-// 	var e error
-// 	var ep *plugin.ExecutablePlugin
-// 	for i := 0; i < 3; i++ {
-// 		ep, e = plugin.NewExecutablePlugin(a, path)
-// 		if e == nil {
-// 			break
-// 		}
-// 		if e != nil && i == 2 {
-// 			return nil, e
-// 		}
-// 	}
-// 	return ep, nil
-// }

--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/plugin/helper"
@@ -157,19 +156,19 @@ func (m MockRequestedMetric) Namespace() core.Namespace {
 	return m.namespace
 }
 
-func NewExecutablePlugin(a plugin.Arg, path string) (*plugin.ExecutablePlugin, error) {
-	// Travis optimization: Try starting the plugin three times before finally
-	// returning an error
-	var e error
-	var ep *plugin.ExecutablePlugin
-	for i := 0; i < 3; i++ {
-		ep, e = plugin.NewExecutablePlugin(a, path)
-		if e == nil {
-			break
-		}
-		if e != nil && i == 2 {
-			return nil, e
-		}
-	}
-	return ep, nil
-}
+// func NewExecutablePlugin(a plugin.Arg, path string) (*plugin.ExecutablePlugin, error) {
+// 	// Travis optimization: Try starting the plugin three times before finally
+// 	// returning an error
+// 	var e error
+// 	var ep *plugin.ExecutablePlugin
+// 	for i := 0; i < 3; i++ {
+// 		ep, e = plugin.NewExecutablePlugin(a, path)
+// 		if e == nil {
+// 			break
+// 		}
+// 		if e != nil && i == 2 {
+// 			return nil, e
+// 		}
+// 	}
+// 	return ep, nil
+// }

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -60,6 +60,7 @@ type CertTestUtil struct {
 	Prefix string
 }
 
+// WritePEMFile writes block of bytes into a PEM formatted file with given header.
 func (u CertTestUtil) WritePEMFile(fn string, pemHeader string, b []byte) error {
 	f, err := os.Create(fn)
 	if err != nil {
@@ -75,6 +76,8 @@ func (u CertTestUtil) WritePEMFile(fn string, pemHeader string, b []byte) error 
 	return nil
 }
 
+// MakeCACertKeyPair generates asymmetric private key and certificate
+// for CA, suitable for signing certificates
 func (u CertTestUtil) MakeCACertKeyPair(caName, ouName string, keyValidPeriod time.Duration) (caCertTpl *x509.Certificate, caCertBytes []byte, caPrivKey *rsa.PrivateKey, err error) {
 	caPrivKey, err = rsa.GenerateKey(rand.Reader, keyBitsDefault)
 	if err != nil {
@@ -109,6 +112,8 @@ func (u CertTestUtil) MakeCACertKeyPair(caName, ouName string, keyValidPeriod ti
 	return caCertTpl, caCertBytes, caPrivKey, nil
 }
 
+// MakeSubjCertKeyPair generates a private key and a certificate for subject
+// suitable for securing TLS communication
 func (u CertTestUtil) MakeSubjCertKeyPair(cn, ou string, keyValidPeriod time.Duration, caCertTpl *x509.Certificate, caPrivKey *rsa.PrivateKey) (subjCertBytes []byte, subjPrivKey *rsa.PrivateKey, err error) {
 	subjPrivKey, err = rsa.GenerateKey(rand.Reader, keyBitsDefault)
 	if err != nil {

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -1,4 +1,4 @@
-// + build legacy small medium large
+// +build legacy small medium large
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -154,7 +154,7 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return nil, err
 	}
-	caCertFn := filepath.Join(u.Prefix, caCN+TestCrtFileExt)
+	caCertFn := filepath.Join(u.Prefix, caCN + TestCrtFileExt)
 	if err := u.WritePEMFile(caCertFn, certificatePEMHeader, caCert); err != nil {
 		return nil, err
 	}
@@ -172,8 +172,8 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return resFiles, err
 	}
-	srvCertFn := filepath.Join(u.Prefix, srvCN+TestCrtFileExt)
-	srvKeyFn := filepath.Join(u.Prefix, srvCN+TestKeyFileExt)
+	srvCertFn := filepath.Join(u.Prefix, srvCN + TestCrtFileExt)
+	srvKeyFn := filepath.Join(u.Prefix, srvCN + TestKeyFileExt)
 	if err := u.WritePEMFile(srvCertFn, certificatePEMHeader, srvCert); err != nil {
 		return resFiles, err
 	}
@@ -186,8 +186,8 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return resFiles, err
 	}
-	cliCertFn := filepath.Join(u.Prefix, cliCN+TestCrtFileExt)
-	cliKeyFn := filepath.Join(u.Prefix, cliCN+TestKeyFileExt)
+	cliCertFn := filepath.Join(u.Prefix, cliCN + TestCrtFileExt)
+	cliKeyFn := filepath.Join(u.Prefix, cliCN + TestKeyFileExt)
 	if err := u.WritePEMFile(cliCertFn, certificatePEMHeader, cliCert); err != nil {
 		return resFiles, err
 	}

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -1,4 +1,4 @@
-// +build legacy small medium large
+// + build legacy small medium large
 
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -35,7 +35,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -139,7 +138,7 @@ func (u CertTestUtil) MakeSubjCertKeyPair(cn, ou string, keyValidPeriod time.Dur
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		SubjectKeyId: subjPubSha256[:],
 	}
-	subjCertTpl.DNSNames = strings.Fields("localhost")
+	subjCertTpl.DNSNames = []string{"localhost"}
 	subjCertTpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
 	subjCertBytes, err = x509.CreateCertificate(rand.Reader, &subjCertTpl, caCertTpl, subjPrivKey.Public(), caPrivKey)
 	return subjCertBytes, subjPrivKey, err

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -154,7 +154,7 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return nil, err
 	}
-	caCertFn := filepath.Join(u.Prefix, caCN + TestCrtFileExt)
+	caCertFn := filepath.Join(u.Prefix, caCN+TestCrtFileExt)
 	if err := u.WritePEMFile(caCertFn, certificatePEMHeader, caCert); err != nil {
 		return nil, err
 	}
@@ -172,8 +172,8 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return resFiles, err
 	}
-	srvCertFn := filepath.Join(u.Prefix, srvCN + TestCrtFileExt)
-	srvKeyFn := filepath.Join(u.Prefix, srvCN + TestKeyFileExt)
+	srvCertFn := filepath.Join(u.Prefix, srvCN+TestCrtFileExt)
+	srvKeyFn := filepath.Join(u.Prefix, srvCN+TestKeyFileExt)
 	if err := u.WritePEMFile(srvCertFn, certificatePEMHeader, srvCert); err != nil {
 		return resFiles, err
 	}
@@ -186,8 +186,8 @@ func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []strin
 	if err != nil {
 		return resFiles, err
 	}
-	cliCertFn := filepath.Join(u.Prefix, cliCN + TestCrtFileExt)
-	cliKeyFn := filepath.Join(u.Prefix, cliCN + TestKeyFileExt)
+	cliCertFn := filepath.Join(u.Prefix, cliCN+TestCrtFileExt)
+	cliKeyFn := filepath.Join(u.Prefix, cliCN+TestKeyFileExt)
 	if err := u.WritePEMFile(cliCertFn, certificatePEMHeader, cliCert); err != nil {
 		return resFiles, err
 	}

--- a/control/fixtures/tls_cert_util.go
+++ b/control/fixtures/tls_cert_util.go
@@ -1,0 +1,196 @@
+// +build legacy small medium large
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixtures
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	TestCrtFileExt    = ".crt"
+	TestBadCrtFileExt = "-BAD.crt"
+	TestKeyFileExt    = ".key"
+)
+
+const (
+	keyBitsDefault            = 2048
+	defaultKeyValidPeriod     = 6 * time.Hour
+	rsaKeyPEMHeader           = "RSA PRIVATE KEY"
+	certificatePEMHeader      = "CERTIFICATE"
+	defaultSignatureAlgorithm = x509.SHA256WithRSA
+	defaultPublicKeyAlgorithm = x509.RSA
+)
+
+// CertTestUtil offers a few methods to generate a few self-signed certificates
+// suitable only for test.
+type CertTestUtil struct {
+	Prefix string
+}
+
+func (u CertTestUtil) WritePEMFile(fn string, pemHeader string, b []byte) error {
+	f, err := os.Create(fn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	pem.Encode(w, &pem.Block{
+		Type:  pemHeader,
+		Bytes: b,
+	})
+	w.Flush()
+	return nil
+}
+
+func (u CertTestUtil) MakeCACertKeyPair(caName, ouName string, keyValidPeriod time.Duration) (caCertTpl *x509.Certificate, caCertBytes []byte, caPrivKey *rsa.PrivateKey, err error) {
+	caPrivKey, err = rsa.GenerateKey(rand.Reader, keyBitsDefault)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPubKey := caPrivKey.Public()
+	caPubBytes, err := x509.MarshalPKIXPublicKey(caPubKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPubSha256 := sha256.Sum256(caPubBytes)
+	caCertTpl = &x509.Certificate{
+		SignatureAlgorithm: defaultSignatureAlgorithm,
+		PublicKeyAlgorithm: defaultPublicKeyAlgorithm,
+		Version:            3,
+		SerialNumber:       big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: caName,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(keyValidPeriod),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		MaxPathLenZero:        true,
+		IsCA:                  true,
+		SubjectKeyId:          caPubSha256[:],
+	}
+	caCertBytes, err = x509.CreateCertificate(rand.Reader, caCertTpl, caCertTpl, caPubKey, caPrivKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return caCertTpl, caCertBytes, caPrivKey, nil
+}
+
+func (u CertTestUtil) MakeSubjCertKeyPair(cn, ou string, keyValidPeriod time.Duration, caCertTpl *x509.Certificate, caPrivKey *rsa.PrivateKey) (subjCertBytes []byte, subjPrivKey *rsa.PrivateKey, err error) {
+	subjPrivKey, err = rsa.GenerateKey(rand.Reader, keyBitsDefault)
+	if err != nil {
+		return nil, nil, err
+	}
+	subjPubBytes, err := x509.MarshalPKIXPublicKey(subjPrivKey.Public())
+	if err != nil {
+		return nil, nil, err
+	}
+	subjPubSha256 := sha256.Sum256(subjPubBytes)
+	subjCertTpl := x509.Certificate{
+		SignatureAlgorithm: defaultSignatureAlgorithm,
+		PublicKeyAlgorithm: defaultPublicKeyAlgorithm,
+		Version:            3,
+		SerialNumber:       big.NewInt(1),
+		Subject: pkix.Name{
+			OrganizationalUnit: []string{ou},
+			CommonName:         cn,
+		},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(keyValidPeriod),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageDataEncipherment | x509.KeyUsageKeyAgreement,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		SubjectKeyId: subjPubSha256[:],
+	}
+	subjCertTpl.DNSNames = strings.Fields("localhost")
+	subjCertTpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	subjCertBytes, err = x509.CreateCertificate(rand.Reader, &subjCertTpl, caCertTpl, subjPrivKey.Public(), caPrivKey)
+	return subjCertBytes, subjPrivKey, err
+}
+
+// StoreTLSCerts builds a set of certificates and private keys for testing TLS.
+// Generated files include: CA certificate, server certificate and private key,
+// client certificate and private key, and alternate (BAD) CA certificate.
+// Certificate and key files are named after given common names (e.g.: srvCN).
+func (u CertTestUtil) StoreTLSCerts(caCN, srvCN, cliCN string) (resFiles []string, err error) {
+	ou := fmt.Sprintf("%06x", mrand.Intn(1<<24))
+	caCertTpl, caCert, caPrivKey, err := u.MakeCACertKeyPair(caCN, ou, defaultKeyValidPeriod)
+	if err != nil {
+		return nil, err
+	}
+	caCertFn := filepath.Join(u.Prefix, caCN+TestCrtFileExt)
+	if err := u.WritePEMFile(caCertFn, certificatePEMHeader, caCert); err != nil {
+		return nil, err
+	}
+	resFiles = append(resFiles, caCertFn)
+	_, caBadCert, _, err := u.MakeCACertKeyPair(caCN, ou, defaultKeyValidPeriod)
+	if err != nil {
+		return resFiles, err
+	}
+	badCaCertFn := caCN + TestBadCrtFileExt
+	if err := u.WritePEMFile(badCaCertFn, certificatePEMHeader, caBadCert); err != nil {
+		return resFiles, err
+	}
+	resFiles = append(resFiles, badCaCertFn)
+	srvCert, srvPrivKey, err := u.MakeSubjCertKeyPair(srvCN, ou, defaultKeyValidPeriod, caCertTpl, caPrivKey)
+	if err != nil {
+		return resFiles, err
+	}
+	srvCertFn := filepath.Join(u.Prefix, srvCN+TestCrtFileExt)
+	srvKeyFn := filepath.Join(u.Prefix, srvCN+TestKeyFileExt)
+	if err := u.WritePEMFile(srvCertFn, certificatePEMHeader, srvCert); err != nil {
+		return resFiles, err
+	}
+	resFiles = append(resFiles, srvCertFn)
+	if err := u.WritePEMFile(srvKeyFn, rsaKeyPEMHeader, x509.MarshalPKCS1PrivateKey(srvPrivKey)); err != nil {
+		return resFiles, err
+	}
+	resFiles = append(resFiles, srvKeyFn)
+	cliCert, cliPrivKey, err := u.MakeSubjCertKeyPair(cliCN, ou, defaultKeyValidPeriod, caCertTpl, caPrivKey)
+	if err != nil {
+		return resFiles, err
+	}
+	cliCertFn := filepath.Join(u.Prefix, cliCN+TestCrtFileExt)
+	cliKeyFn := filepath.Join(u.Prefix, cliCN+TestKeyFileExt)
+	if err := u.WritePEMFile(cliCertFn, certificatePEMHeader, cliCert); err != nil {
+		return resFiles, err
+	}
+	resFiles = append(resFiles, cliCertFn)
+	if err := u.WritePEMFile(cliKeyFn, rsaKeyPEMHeader, x509.MarshalPKCS1PrivateKey(cliPrivKey)); err != nil {
+		return resFiles, err
+	}
+	resFiles = append(resFiles, cliKeyFn)
+	return resFiles, nil
+}

--- a/control/flags.go
+++ b/control/flags.go
@@ -58,6 +58,15 @@ var (
 		EnvVar: "SNAP_CACHE_EXPIRATION",
 	}
 
+	flTLSCert = cli.StringFlag{
+		Name:  "tls-cert",
+		Usage: "A path to PEM-encoded certificate to use for TLS channels",
+	}
+	flTLSKey = cli.StringFlag{
+		Name:  "tls-key",
+		Usage: "A path to PEM-encoded private key file to use for TLS channels",
+	}
+
 	flControlRpcPort = cli.StringFlag{
 		Name:   "control-listen-port",
 		Usage:  fmt.Sprintf("Listen port for control RPC server (default: %v)", defaultListenPort),
@@ -76,5 +85,5 @@ var (
 		EnvVar: "SNAP_TEMP_DIR_PATH",
 	}
 
-	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath}
+	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath, flTLSCert, flTLSKey}
 )

--- a/control/flags.go
+++ b/control/flags.go
@@ -60,15 +60,15 @@ var (
 
 	flTLSCert = cli.StringFlag{
 		Name:  "tls-cert",
-		Usage: "A path to PEM-encoded certificate to use for TLS channels",
+		Usage: "A path to PEM-encoded certificate to use for GRPC TLS channels",
 	}
 	flTLSKey = cli.StringFlag{
 		Name:  "tls-key",
-		Usage: "A path to PEM-encoded private key file to use for TLS channels",
+		Usage: "A path to PEM-encoded private key file to use for GRPC TLS channels",
 	}
-	flRootCertPaths = cli.StringFlag{
-		Name:  "root-cert-paths",
-		Usage: "A list of paths to root certificates or their parent directories, separated with OS path separator",
+	flCACertPaths = cli.StringFlag{
+		Name:  "ca-cert-paths",
+		Usage: "A list of paths to CA certificates or their parent directories, separated with OS path separator",
 	}
 
 	flControlRpcPort = cli.StringFlag{
@@ -89,5 +89,5 @@ var (
 		EnvVar: "SNAP_TEMP_DIR_PATH",
 	}
 
-	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath, flTLSCert, flTLSKey, flRootCertPaths}
+	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath, flTLSCert, flTLSKey, flCACertPaths}
 )

--- a/control/flags.go
+++ b/control/flags.go
@@ -66,6 +66,10 @@ var (
 		Name:  "tls-key",
 		Usage: "A path to PEM-encoded private key file to use for TLS channels",
 	}
+	flRootCertPaths = cli.StringFlag{
+		Name:  "root-cert-paths",
+		Usage: "A list of paths to root certificates or their parent directories, separated with OS path separator",
+	}
 
 	flControlRpcPort = cli.StringFlag{
 		Name:   "control-listen-port",
@@ -85,5 +89,5 @@ var (
 		EnvVar: "SNAP_TEMP_DIR_PATH",
 	}
 
-	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath, flTLSCert, flTLSKey}
+	Flags = []cli.Flag{flNumberOfPLs, flPluginLoadTimeout, flAutoDiscover, flPluginTrust, flKeyringPaths, flCache, flControlRpcPort, flControlRpcAddr, flTempDirPath, flTLSCert, flTLSKey, flRootCertPaths}
 )

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -150,10 +150,10 @@ type Arg struct {
 	// enable pprof
 	Pprof bool
 
-	CertPath      string `json:"CertPath"`
-	KeyPath       string `json:"KeyPath"`
-	RootCertPaths string `json:"RootCertPaths"`
-	TLSEnabled    bool   `json:"TLSEnabled"`
+	CertPath    string `json:"CertPath"`
+	KeyPath     string `json:"KeyPath"`
+	CACertPaths string `json:"RootCertPaths"`
+	TLSEnabled  bool   `json:"TLSEnabled"`
 }
 
 // SetCertPath sets path to TLS certificate in plugin arguments
@@ -174,9 +174,9 @@ func (a Arg) SetTLSEnabled(tlsEnabled bool) Arg {
 	return a
 }
 
-// SetRootCertPaths sets list of certificate paths for client verification
-func (a Arg) SetRootCertPaths(rootCertPaths string) Arg {
-	a.RootCertPaths = rootCertPaths
+// SetCACertPaths sets list of certificate paths for client verification
+func (a Arg) SetCACertPaths(caCertPaths string) Arg {
+	a.CACertPaths = caCertPaths
 	return a
 }
 

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -131,9 +131,11 @@ type PluginMeta struct {
 	// RoutingStrategy will override the routing strategy this plugin requires.
 	// The default routing strategy round-robin.
 	RoutingStrategy RoutingStrategyType
+	// TLSEnabled identifies status of plugin security
+	TLSEnabled bool
 }
 
-// Arguments passed to startup of Plugin
+// Arg contains arguments passed to startup of Plugin
 type Arg struct {
 	// Plugin log level
 	LogLevel log.Level
@@ -146,8 +148,31 @@ type Arg struct {
 
 	// enable pprof
 	Pprof bool
+
+	CertPath   string
+	KeyPath    string
+	TLSEnabled bool
 }
 
+// SetCertPath sets path to TLS certificate in plugin arguments
+func (a Arg) SetCertPath(certPath string) Arg {
+	a.CertPath = certPath
+	return a
+}
+
+// SetKeyPath sets path to TLS key in plugin arguments
+func (a Arg) SetKeyPath(keyPath string) Arg {
+	a.KeyPath = keyPath
+	return a
+}
+
+// SetTLSEnabled sets flag enabling TLS security in plugin arguments
+func (a Arg) SetTLSEnabled(tlsEnabled bool) Arg {
+	a.TLSEnabled = tlsEnabled
+	return a
+}
+
+//
 func NewArg(logLevel int, pprof bool) Arg {
 	return Arg{
 		LogLevel:            log.Level(logLevel),

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 )
 
@@ -149,9 +150,10 @@ type Arg struct {
 	// enable pprof
 	Pprof bool
 
-	CertPath   string
-	KeyPath    string
-	TLSEnabled bool
+	CertPath      string `json:"CertPath"`
+	KeyPath       string `json:"KeyPath"`
+	RootCertPaths string `json:"RootCertPaths"`
+	TLSEnabled    bool   `json:"TLSEnabled"`
 }
 
 // SetCertPath sets path to TLS certificate in plugin arguments
@@ -169,6 +171,12 @@ func (a Arg) SetKeyPath(keyPath string) Arg {
 // SetTLSEnabled sets flag enabling TLS security in plugin arguments
 func (a Arg) SetTLSEnabled(tlsEnabled bool) Arg {
 	a.TLSEnabled = tlsEnabled
+	return a
+}
+
+// SetRootCertPaths sets list of certificate paths for client verification
+func (a Arg) SetRootCertPaths(rootCertPaths string) Arg {
+	a.RootCertPaths = rootCertPaths
 	return a
 }
 

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -172,7 +172,7 @@ func (a Arg) SetTLSEnabled(tlsEnabled bool) Arg {
 	return a
 }
 
-//
+// NewArg returns new plugin arguments structure
 func NewArg(logLevel int, pprof bool) Arg {
 	return Arg{
 		LogLevel:            log.Level(logLevel),

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -158,18 +158,18 @@ func (l *loadedPlugins) findLatest(typeName, name string) (*loadedPlugin, error)
 
 // the struct representing a plugin that is loaded into snap
 type pluginDetails struct {
-	CheckSum      [sha256.Size]byte
-	Exec          []string
-	ExecPath      string
-	IsPackage     bool
-	Manifest      *schema.ImageManifest
-	Path          string
-	Signed        bool
-	Signature     []byte
-	CertPath      string
-	KeyPath       string
-	RootCertPaths string
-	TLSEnabled    bool
+	CheckSum    [sha256.Size]byte
+	Exec        []string
+	ExecPath    string
+	IsPackage   bool
+	Manifest    *schema.ImageManifest
+	Path        string
+	Signed      bool
+	Signature   []byte
+	CertPath    string
+	KeyPath     string
+	CACertPaths string
+	TLSEnabled  bool
 }
 
 type loadedPlugin struct {
@@ -359,7 +359,7 @@ func (p *pluginManager) LoadPlugin(details *pluginDetails, emitter gomit.Emitter
 		p.GenerateArgs(int(log.GetLevel())).
 			SetCertPath(details.CertPath).
 			SetKeyPath(details.KeyPath).
-			SetRootCertPaths(details.RootCertPaths).
+			SetCACertPaths(details.CACertPaths).
 			SetTLSEnabled(details.TLSEnabled),
 		commands...)
 	if err != nil {

--- a/control/runner.go
+++ b/control/runner.go
@@ -347,7 +347,7 @@ func (r *runner) runPlugin(name string, details *pluginDetails) error {
 	ePlugin, err := plugin.NewExecutablePlugin(r.pluginManager.GenerateArgs(int(log.GetLevel())).
 		SetCertPath(details.CertPath).
 		SetKeyPath(details.KeyPath).
-		SetRootCertPaths(details.RootCertPaths).
+		SetCACertPaths(details.CACertPaths).
 		SetTLSEnabled(details.TLSEnabled), commands...)
 	if err != nil {
 		runnerLog.WithFields(log.Fields{

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -336,7 +336,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -358,7 +358,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -376,7 +376,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -393,7 +393,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -410,7 +410,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -431,7 +431,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -464,7 +464,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					r := newRunner()
 					r.SetEmitter(new(MockEmitter))
 					a := plugin.Arg{}
-					exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
+					exPlugin, err := plugin.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 					if err != nil {
 						panic(err)
 					}

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -324,23 +324,6 @@ func TestRunnerState(t *testing.T) {
 	})
 }
 
-func newExecutablePlugin(a plugin.Arg, path string) (*plugin.ExecutablePlugin, error) {
-	// Travis optimization: Try starting the plugin three times before finally
-	// returning an error
-	var e error
-	var ep *plugin.ExecutablePlugin
-	for i := 0; i < 3; i++ {
-		ep, e = plugin.NewExecutablePlugin(a, path)
-		if e == nil {
-			break
-		}
-		if e != nil && i == 2 {
-			return nil, e
-		}
-	}
-	return ep, nil
-}
-
 func TestRunnerPluginRunning(t *testing.T) {
 	// log.SetLevel(log.DebugLevel)
 	Convey("snap/control", t, func() {
@@ -353,7 +336,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -375,7 +358,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -393,7 +376,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -410,7 +393,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -427,7 +410,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -448,7 +431,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 						r := newRunner()
 						r.SetEmitter(new(MockEmitter))
 						a := plugin.Arg{}
-						exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+						exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 						if err != nil {
 							panic(err)
 						}
@@ -481,7 +464,7 @@ func TestRunnerPluginRunning(t *testing.T) {
 					r := newRunner()
 					r.SetEmitter(new(MockEmitter))
 					a := plugin.Arg{}
-					exPlugin, err := newExecutablePlugin(a, fixtures.PluginPathMock2)
+					exPlugin, err := fixtures.NewExecutablePlugin(a, fixtures.PluginPathMock2)
 					if err != nil {
 						panic(err)
 					}

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -122,9 +122,12 @@ type SubscribedPlugin interface {
 }
 
 type RequestedPlugin struct {
-	path      string
-	checkSum  [sha256.Size]byte
-	signature []byte
+	path       string
+	checkSum   [sha256.Size]byte
+	signature  []byte
+	certPath   string
+	keyPath    string
+	tlsEnabled bool
 }
 
 // NewRequestedPlugin returns a Requested Plugin which represents the plugin path and signature
@@ -185,6 +188,21 @@ func (p *RequestedPlugin) Path() string {
 	return p.path
 }
 
+// CertPath returns the path to TLS certificate for requested plugin to use
+func (p *RequestedPlugin) CertPath() string {
+	return p.certPath
+}
+
+// KeyPath returns the path to TLS key for requested plugin to use
+func (p *RequestedPlugin) KeyPath() string {
+	return p.keyPath
+}
+
+// TLSEnabled returns the TLS enabled flag for requested plugin
+func (p *RequestedPlugin) TLSEnabled() bool {
+	return p.tlsEnabled
+}
+
 func (p *RequestedPlugin) CheckSum() [sha256.Size]byte {
 	return p.checkSum
 }
@@ -195,6 +213,21 @@ func (p *RequestedPlugin) Signature() []byte {
 
 func (p *RequestedPlugin) SetPath(path string) {
 	p.path = path
+}
+
+// SetCertPath sets the path to TLS certificate for requested plugin to use
+func (p *RequestedPlugin) SetCertPath(certPath string) {
+	p.certPath = certPath
+}
+
+// SetKeyPath sets the path to TLS key for requested plugin to use
+func (p *RequestedPlugin) SetKeyPath(keyPath string) {
+	p.keyPath = keyPath
+}
+
+// SetTLSEnabled sets the TLS flag on requested plugin
+func (p *RequestedPlugin) SetTLSEnabled(tlsEnabled bool) {
+	p.tlsEnabled = tlsEnabled
 }
 
 func (p *RequestedPlugin) SetSignature(data []byte) {

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -122,13 +122,13 @@ type SubscribedPlugin interface {
 }
 
 type RequestedPlugin struct {
-	path          string
-	checkSum      [sha256.Size]byte
-	signature     []byte
-	certPath      string
-	keyPath       string
-	rootCertPaths string
-	tlsEnabled    bool
+	path        string
+	checkSum    [sha256.Size]byte
+	signature   []byte
+	certPath    string
+	keyPath     string
+	caCertPaths string
+	tlsEnabled  bool
 }
 
 // NewRequestedPlugin returns a Requested Plugin which represents the plugin path and signature
@@ -199,9 +199,9 @@ func (p *RequestedPlugin) KeyPath() string {
 	return p.keyPath
 }
 
-// RootCertPaths returns the list of TLS root cert paths for plugin to use
-func (p *RequestedPlugin) RootCertPaths() string {
-	return p.rootCertPaths
+// CACertPaths returns the list of TLS CA cert paths for plugin to use
+func (p *RequestedPlugin) CACertPaths() string {
+	return p.caCertPaths
 }
 
 // TLSEnabled returns the TLS enabled flag for requested plugin
@@ -231,9 +231,9 @@ func (p *RequestedPlugin) SetKeyPath(keyPath string) {
 	p.keyPath = keyPath
 }
 
-// SetRootCertPaths sets the list of paths to TLS root certificate for plugin to use
-func (p *RequestedPlugin) SetRootCertPaths(rootCertPaths string) {
-	p.rootCertPaths = rootCertPaths
+// SetCACertPaths sets the list of paths to TLS CA certificate for plugin to use
+func (p *RequestedPlugin) SetCACertPaths(caCertPaths string) {
+	p.caCertPaths = caCertPaths
 }
 
 // SetTLSEnabled sets the TLS flag on requested plugin

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -122,12 +122,13 @@ type SubscribedPlugin interface {
 }
 
 type RequestedPlugin struct {
-	path       string
-	checkSum   [sha256.Size]byte
-	signature  []byte
-	certPath   string
-	keyPath    string
-	tlsEnabled bool
+	path          string
+	checkSum      [sha256.Size]byte
+	signature     []byte
+	certPath      string
+	keyPath       string
+	rootCertPaths string
+	tlsEnabled    bool
 }
 
 // NewRequestedPlugin returns a Requested Plugin which represents the plugin path and signature
@@ -198,6 +199,11 @@ func (p *RequestedPlugin) KeyPath() string {
 	return p.keyPath
 }
 
+// RootCertPaths returns the list of TLS root cert paths for plugin to use
+func (p *RequestedPlugin) RootCertPaths() string {
+	return p.rootCertPaths
+}
+
 // TLSEnabled returns the TLS enabled flag for requested plugin
 func (p *RequestedPlugin) TLSEnabled() bool {
 	return p.tlsEnabled
@@ -223,6 +229,11 @@ func (p *RequestedPlugin) SetCertPath(certPath string) {
 // SetKeyPath sets the path to TLS key for requested plugin to use
 func (p *RequestedPlugin) SetKeyPath(keyPath string) {
 	p.keyPath = keyPath
+}
+
+// SetRootCertPaths sets the list of paths to TLS root certificate for plugin to use
+func (p *RequestedPlugin) SetRootCertPaths(rootCertPaths string) {
+	p.rootCertPaths = rootCertPaths
 }
 
 // SetTLSEnabled sets the TLS flag on requested plugin

--- a/docs/SECURE_PLUGIN_COMMUNICATION.md
+++ b/docs/SECURE_PLUGIN_COMMUNICATION.md
@@ -1,0 +1,124 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Secure Plugin Communication
+
+Snap communicates with plugins over gRPC protocol, which in general transfers data in plaintext.
+Snap allows securing communication with plugins by opening TLS channels and using certificates to authenticate plugins and framework.
+
+## Usage 
+
+This walkthrough assumes you have downloaded a Snap release as described in [Getting Started](../README.md#getting-started).
+
+### Shortest guide
+
+Assuming all the test files are available, the following steps will result in secure plugin communication:
+
+```
+snapteld --log-level 1 --plugin-trust 0 --tls-cert /tmp/snaptest-cli.crt --tls-key /tmp/snaptest-cli.key --ca-cert-paths /tmp/snaptest-ca.crt
+## (in another terminal)
+## Load each plugin
+snaptel plugin load --plugin-cert /tmp/snaptest-srv.crt --plugin-key /tmp/snaptest-srv.key --plugin-ca-certs /tmp/snaptest-ca.crt plugins/snap-plugin-collector-rand
+## Start a sample task
+snaptel task create -t sample-task.json
+```
+
+### Detailed preparation
+
+Starting secure communication requires following steps:
+1. Obtain TLS certificate and private key for framework.
+    * Please note that this certificate should allow usage for TLS web client authentication (as specified in RFC 3280)
+1. Obtain TLS certificate and private key for each plugin or group of plugins.
+    * Please note that this certificate should allow usage for TLS web server authentication (as specified in RFC 3280)
+1. Obtain and locate the CA certificates that are necessary to authenticate framework and plugin certificates.
+
+Process of acquiring a TLS certificate is a complex one. Every organization has its specific rules on security, thus the details are not given here.
+
+We do provide a short guide on obtaining self-signed certificates that may be used for tests outside production environment; see [Obtaining self-signed TLS certificates for tests](#obtaining-self-signed-tls-certificates-for-tests).
+
+### Enabling secure communication
+
+Secure communication is enabled by passing the required paths to programs: `snapteld`, and plugin (via `snaptel`). The minimum paths necessary are:
+* for `snapteld`: `--tls-cert`, `--tls-key`,
+* for plugins (`snaptel`): `--plugin-cert`, `--plugin-key`.
+
+The required paths are sufficient and necessary to enable TLS. Daemon (`snapteld`) and plugins (via `snaptel`) will refuse to start if certificate or key file argument is missing.
+
+### Using system-installed CA certificates
+
+Framework and plugins need CA certificates to validate each other's certificate. The CA certificates may be obtained in two ways:
+* by passing a list of CA certificate paths directly as a parameter, e.g.: `--ca-cert-paths=/tmp/small-setup-ca.crt:/tmp/medium-setup-ca.crt:/tmp/ca-certs/`, `--plugin-ca-certs`
+    * plugin as well as framework will examine each path in the list and either load a file directly or list directory contents and load the enumerated files (e.g.: the files in `/tmp/ca-certs/` folder) 
+* by relying on default CA certificate discovery mechanism
+    * plugin and framework will by default load certificates from system (if no paths were given as parameter). Each OS has its own specific locations, e.g.: `/etc/ssl/certs` on Ubuntu. This mechanism is provided by Go language, and is only available on selected OSes.     
+    System CA certificates may also be loaded explicitly by listing system locations explicitly, e.g.: `--ca-cert-paths /etc/ssl/certs:/tmp/snaptest-ca.crt`
+
+## More information
+
+### Exclusive security
+
+It's important to note that once secure plugin communication is enabled in framework, only secure connections may be established. 
+
+In other words: attempting to load insecure plugin in framework will result in an error. 
+
+### Relation to other functionalities
+
+Several modes of operation do not fully support secure communication:
+* distributed workflow is not covered by secure communication,
+* tribe doesn't support secure communication; `snapteld` will refuse to start in tribe mode if configured with secure communication,
+* plugin and task autodiscovery doesn't support secure communication; `snapteld` will refuse to start with autodiscovery path and secure communication enabled.
+
+### Obtaining self-signed TLS certificates for tests
+
+The following intstructions will result in TLS certificate files. These files may be used for manual tests.
+1. Install tool [certstrap](https://github.com/square/certstrap) for generating test certificates. Further steps will assume that `certstrap` is available under `$PATH` location.
+1. Generate root CA certificate:
+    ```
+    certstrap init --cn "snaptest-ca" --o "snaptest" --ou "ca" --key-bits 2048 --years 1 --passphrase '
+    ```
+1. **optional** Install root CA certificate in the system:
+    ```
+    sudo cp out/snaptest-ca.crt /usr/local/share/ca-certificates/; sudo update-ca-certificates --verbose --fresh
+    ``` 
+1. Generate server certificate and key to use with plugins:
+    ```
+    certstrap request-cert --cn "snaptest-srv" --ip "127.0.0.1" --domain "localhost" --passphrase '' --key-bits 2048 --o "snaptest" --ou "server"
+    certstrap sign "snaptest-srv" --CA "snaptest-ca" --passphrase '' --years 1
+    ```
+1. Generate client certificate and key to use with `snapteld`:
+    ```
+    certstrap request-cert --cn "snaptest-cli" --ip "127.0.0.1" --domain "localhost" --passphrase '' --key-bits 2048 --o "snaptest" --ou "client"
+    certstrap sign "snaptest-cli" --CA "snaptest-ca" --passphrase '' --years 1
+    ```
+1. Copy server and client certificates into common location, e.g.: `/tmp`:
+    ```
+    for unit in srv cli; do for fname in crt key; do cp out/snaptest-$unit.$fname /tmp; done; done
+    ```
+The following files are relevant for running the tests:
+* `/tmp/snaptest-cli.crt`, `/tmp/snaptest-cli.key` - these are the certificate and private key files for `snapteld`,
+* `/tmp/snaptest-srv.crt`, `/tmp/snaptest-srv.key` - these are the certificate and private key files for plugin,
+* `/tmp/snaptest-ca.crt` - this is the CA certificate that should be used to authenticate framework and plugins.
+
+## More information
+
+* [SNAPTELD_CONFIGURATION.md](SNAPTELD_CONFIGURATION.md)
+* [SNAPTELD](SNAPTELD.md)
+* [SNAPTELD](SNAPTELD.md)
+* [TRIBE.md](TRIBE.md)
+* [DISTRIBUTED_WORKFLOW_ARCHITECTURE](DISTRIBUTED_WORKFLOW_ARCHITECTURE.md)

--- a/docs/SECURE_PLUGIN_COMMUNICATION.md
+++ b/docs/SECURE_PLUGIN_COMMUNICATION.md
@@ -19,7 +19,27 @@ limitations under the License.
 
 # Secure Plugin Communication
 
-Snap communicates with plugins over gRPC protocol, which in general transfers data in plaintext.
+<!-- TOC -->
+
+- [Secure Plugin Communication](#secure-plugin-communication)
+    - [Overview](#overview)
+    - [Usage](#usage)
+        - [Shortest guide](#shortest-guide)
+        - [Detailed preparation](#detailed-preparation)
+        - [Enabling secure communication](#enabling-secure-communication)
+        - [Using system-installed CA certificates](#using-system-installed-ca-certificates)
+    - [More information](#more-information)
+        - [Exclusive security](#exclusive-security)
+        - [Relation to other functionalities](#relation-to-other-functionalities)
+        - [TLS setup requirements](#tls-setup-requirements)
+        - [Obtaining self-signed TLS certificates for tests](#obtaining-self-signed-tls-certificates-for-tests)
+    - [More information](#more-information-1)
+
+<!-- /TOC -->
+
+## Overview
+
+Snap framework communicates with plugins over gRPC protocol, which in general transfers data in plaintext.
 Snap allows securing communication with plugins by opening TLS channels and using certificates to authenticate plugins and framework.
 
 ## Usage 
@@ -28,23 +48,20 @@ This walkthrough assumes you have downloaded a Snap release as described in [Get
 
 ### Shortest guide
 
-Assuming all the test files are available, the following steps will result in secure plugin communication:
+Assuming all the test files are available (basing on [test instructions](#obtaining-self-signed-tls-certificates-for-tests)) , the following steps will result in secure plugin communication:
 
 ```
 snapteld --log-level 1 --plugin-trust 0 --tls-cert /tmp/snaptest-cli.crt --tls-key /tmp/snaptest-cli.key --ca-cert-paths /tmp/snaptest-ca.crt
-## (in another terminal)
-## Load each plugin
 snaptel plugin load --plugin-cert /tmp/snaptest-srv.crt --plugin-key /tmp/snaptest-srv.key --plugin-ca-certs /tmp/snaptest-ca.crt plugins/snap-plugin-collector-rand
-## Start a sample task
 snaptel task create -t sample-task.json
 ```
 
 ### Detailed preparation
 
 Starting secure communication requires following steps:
-1. Obtain TLS certificate and private key for framework.
+1. Obtain X.509 certificate and private key for framework.
     * Please note that this certificate should allow usage for TLS web client authentication (as specified in RFC 3280)
-1. Obtain TLS certificate and private key for each plugin or group of plugins.
+1. Obtain X.509 certificate and private key for each plugin or group of plugins.
     * Please note that this certificate should allow usage for TLS web server authentication (as specified in RFC 3280)
 1. Obtain and locate the CA certificates that are necessary to authenticate framework and plugin certificates.
 
@@ -83,6 +100,14 @@ Several modes of operation do not fully support secure communication:
 * distributed workflow is not covered by secure communication,
 * tribe doesn't support secure communication; `snapteld` will refuse to start in tribe mode if configured with secure communication,
 * plugin and task autodiscovery doesn't support secure communication; `snapteld` will refuse to start with autodiscovery path and secure communication enabled.
+
+### TLS setup requirements
+
+Snap plugin security is subject to following constraints:
+* certificates must be valid for use with following cipher suites:
+    * TLS_RSA_WITH_AES_128_GCM_SHA256,
+    * TLS_RSA_WITH_AES_256_GCM_SHA384.
+* certificates should allow usage for TLS web client or server authentication, as specified in RFC 3280 (server usage is for plugins).
 
 ### Obtaining self-signed TLS certificates for tests
 

--- a/docs/SNAPTEL.md
+++ b/docs/SNAPTEL.md
@@ -87,9 +87,9 @@ help, h     Shows a list of commands or help for one command
 $ snaptel plugin command [command options] [arguments...]
 ```
 ```
-load        load <plugin_path>
+load        load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]
 unload      unload <plugin_type> <plugin_name> <plugin_version>
-swap        swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version>
+swap        swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>
 list        list
 help, h     Shows a list of commands or help for one command
 ```

--- a/docs/SNAPTEL.md
+++ b/docs/SNAPTEL.md
@@ -87,9 +87,9 @@ help, h     Shows a list of commands or help for one command
 $ snaptel plugin command [command options] [arguments...]
 ```
 ```
-load        load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>]
+load        load <plugin_path> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> --plugin-ca-certs=<ca_cert_paths>]
 unload      unload <plugin_type> <plugin_name> <plugin_version>
-swap        swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path>
+swap        swap <load_plugin_path> <unload_plugin_type>:<unload_plugin_name>:<unload_plugin_version> or swap <load_plugin_path> -t <unload_plugin_type> -n <unload_plugin_name> -v <unload_plugin_version> [--plugin-cert=<plugin_cert_path> --plugin-key=<plugin_key_path> [--plugin-ca-certs=<ca_cert_paths>] ]
 list        list
 help, h     Shows a list of commands or help for one command
 ```
@@ -205,3 +205,6 @@ $ snaptel plugin unload collector mock <version>
 $ snaptel plugin unload processor passthru <version>
 $ snaptel plugin unload publisher publisher <version>
 ```
+
+## More information
+* [SECURE_PLUGIN_COMMUNICATION](SECURE_PLUGIN_COMMUNICATION.md)

--- a/docs/SNAPTELD.md
+++ b/docs/SNAPTELD.md
@@ -44,8 +44,9 @@ $ snapteld [global options] command [command options] [arguments...]
 --control-listen-port value                  Listen port for control RPC server (default: 8082) [$SNAP_CONTROL_LISTEN_PORT]
 --control-listen-addr value                  Listen address for control RPC server [$SNAP_CONTROL_LISTEN_ADDR]
 --temp_dir_path value                        Temporary path for loading plugins [$SNAP_TEMP_DIR_PATH]
---tls-cert value                             A path to PEM-encoded certificate to use for TLS channels
---tls-key value                              A path to PEM-encoded private key file to use for TLS channels
+--tls-cert value                             A path to PEM-encoded certificate for framework to use for securing communication channels to plugins over TLS
+--tls-key value                              A path to PEM-encoded private key file for framework to use for securing communication channels to plugins over TLS
+--ca-cert-paths                              List of paths (directories/files) to CA certificates for validating plugin certificates in secure TLS communication
 --work-manager-queue-size value              Size of the work manager queue (default: 25) [$WORK_MANAGER_QUEUE_SIZE]
 --work-manager-pool-size value               Size of the work manager pool (default: 4) [$WORK_MANAGER_POOL_SIZE]
 --disable-api, -d                            Disable the agent REST API
@@ -74,6 +75,8 @@ $ snapteld --version
 $ snapteld --log-level 4
 $ snapteld --auto-discover /opt/snap/plugins/
 $ snapteld --log-level 1 --plugin-trust 2 --keyring-paths /etc/snap/keyrings
+$ snapteld --log-level 1 --tls-cert /etc/snap/cert/snapteld.crt --tls-key /etc/snap/key/snapteld.key
+--ca-cert-paths /etc/ssl/certs/sample_organization_CA.crt:/etc/snap/ca/
 ```
 
 ### Debug output
@@ -157,3 +160,4 @@ INFO[2017-01-09T12:55:05-08:00] snapteld started
 * [REST_API.md](REST_API.md)
 * [PLUGIN_SIGNING.md](PLUGIN_SIGNING.md)
 * [TRIBE.md](TRIBE.md)
+* [SECURE_PLUGIN_COMMUNICATION](SECURE_PLUGIN_COMMUNICATION.md)

--- a/docs/SNAPTELD.md
+++ b/docs/SNAPTELD.md
@@ -44,6 +44,8 @@ $ snapteld [global options] command [command options] [arguments...]
 --control-listen-port value                  Listen port for control RPC server (default: 8082) [$SNAP_CONTROL_LISTEN_PORT]
 --control-listen-addr value                  Listen address for control RPC server [$SNAP_CONTROL_LISTEN_ADDR]
 --temp_dir_path value                        Temporary path for loading plugins [$SNAP_TEMP_DIR_PATH]
+--tls-cert value                             A path to PEM-encoded certificate to use for TLS channels
+--tls-key value                              A path to PEM-encoded private key file to use for TLS channels
 --work-manager-queue-size value              Size of the work manager queue (default: 25) [$WORK_MANAGER_QUEUE_SIZE]
 --work-manager-pool-size value               Size of the work manager pool (default: 4) [$WORK_MANAGER_POOL_SIZE]
 --disable-api, -d                            Disable the agent REST API

--- a/docs/SNAPTELD_CONFIGURATION.md
+++ b/docs/SNAPTELD_CONFIGURATION.md
@@ -108,6 +108,17 @@ control:
   # before failing. Snap will not disable a plugin due to failures when this value is -1.
   max_plugin_restarts: 10
 
+  ## Secure plugin communication optional parameters:
+  # tls_cert_path sets the TLS certificate path to enable secure plugin communication
+  # and authenticate itself to plugins. Requires also: tls_key_path.
+  tls_cert_path: /tmp/snaptest-cli.crt
+  # tls_key_path sets the TLS key path to enable secure plugin communication and
+  # authenticate itself to plugins. Requires also: tls_cert_path.
+  tls_key_path: /tmp/snaptest-cli.key
+  # ca_cert_paths sets the list of filesystem paths (files/directories) to CA certificates
+  # for use in validating
+  ca_cert_paths: /tmp/small-setup-ca.crt:/tmp/medium-setup-ca.crt:/tmp/ca-certs/
+
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
   plugins:

--- a/examples/configs/snap-config-sample.json
+++ b/examples/configs/snap-config-sample.json
@@ -15,6 +15,9 @@
         "keyring_paths":"/etc/snap/keyrings",
         "temp_dir_path":"/tmp",
         "plugin_trust_level":0,
+        "tls_cert_path": "/tmp/snaptest-cli.crt",
+        "tls_key_path": "/tmp/snaptest-cli.key",
+        "ca_cert_paths": "/tmp/small-setup-ca.crt:/tmp/medium-setup-ca.crt:/tmp/ca-certs/",
         "plugins":{
             "all":{
                 "password":"p@ssw0rd"

--- a/examples/configs/snap-config-sample.yaml
+++ b/examples/configs/snap-config-sample.yaml
@@ -72,6 +72,17 @@ control:
   # before failing. Snap will not disable a plugin due to failures when this value is -1.
   max_plugin_restarts: 10
 
+  ## Secure plugin communication optional parameters:
+  # tls_cert_path sets the TLS certificate path to enable secure plugin communication
+  # and authenticate itself to plugins. Requires also: tls_key_path.
+  tls_cert_path: /tmp/snaptest-cli.crt
+  # tls_key_path sets the TLS key path to enable secure plugin communication and
+  # authenticate itself to plugins. Requires also: tls_cert_path.
+  tls_key_path: /tmp/snaptest-cli.key
+  # ca_cert_paths sets the list of filesystem paths (files/directories) to CA certificates
+  # for use in validating
+  ca_cert_paths: /tmp/small-setup-ca.crt:/tmp/medium-setup-ca.crt:/tmp/ca-certs/
+
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
   plugins:

--- a/glide.lock
+++ b/glide.lock
@@ -34,7 +34,7 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: db68f6fda248706a71980abc58e969fcd63f5ea6
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: af03307f16e97c41f966b1e00d340d3393d6675d
+  version: 3527311f5c8e6fe9b55fc1f44e1b515a30845e18
   subpackages:
   - v1/plugin
   - v1/plugin/rpc

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -318,7 +318,9 @@ func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, 
 		defer file.Close()
 		bufin := bufio.NewReader(file)
 		bufins = append(bufins, bufin)
-
+		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, "crt.") || strings.HasPrefix(baseName, "key.") {
+			defer os.Remove(pluginPath)
+		}
 		paths = append(paths, filepath.Base(pluginPath))
 	}
 	// with io.Pipe the write needs to be async

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 
+	"github.com/intelsdi-x/snap/mgmt/rest/v1"
 	"github.com/intelsdi-x/snap/mgmt/rest/v1/rbody"
 )
 
@@ -318,7 +319,7 @@ func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, 
 		defer file.Close()
 		bufin := bufio.NewReader(file)
 		bufins = append(bufins, bufin)
-		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, "crt.") || strings.HasPrefix(baseName, "key.") {
+		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, v1.TLSCertPrefix) || strings.HasPrefix(baseName, v1.TLSKeyPrefix) {
 			defer os.Remove(pluginPath)
 		}
 		paths = append(paths, filepath.Base(pluginPath))

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -320,7 +320,7 @@ func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, 
 		bufin := bufio.NewReader(file)
 		bufins = append(bufins, bufin)
 		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, v1.TLSCertPrefix) ||
-			strings.HasPrefix(baseName, v1.TLSKeyPrefix) || strings.HasPrefix(baseName, v1.TLSRootCertsPrefix) {
+			strings.HasPrefix(baseName, v1.TLSKeyPrefix) || strings.HasPrefix(baseName, v1.TLSCACertsPrefix) {
 			defer os.Remove(pluginPath)
 		}
 		paths = append(paths, filepath.Base(pluginPath))

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -319,7 +319,8 @@ func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, 
 		defer file.Close()
 		bufin := bufio.NewReader(file)
 		bufins = append(bufins, bufin)
-		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, v1.TLSCertPrefix) || strings.HasPrefix(baseName, v1.TLSKeyPrefix) {
+		if baseName := filepath.Base(pluginPath); strings.HasPrefix(baseName, v1.TLSCertPrefix) ||
+			strings.HasPrefix(baseName, v1.TLSKeyPrefix) || strings.HasPrefix(baseName, v1.TLSRootCertsPrefix) {
 			defer os.Remove(pluginPath)
 		}
 		paths = append(paths, filepath.Base(pluginPath))

--- a/mgmt/rest/v1/api.go
+++ b/mgmt/rest/v1/api.go
@@ -8,6 +8,11 @@ import (
 )
 
 const (
+	// TLSCertPrefix defines a prefix for file fragment carrying path to TLS certificate
+	TLSCertPrefix = "crt."
+	// TLSKeyPrefix defines a prefix for file fragment carrying path to TLS private key
+	TLSKeyPrefix = "key."
+
 	version = "v1"
 	prefix  = "/" + version
 )

--- a/mgmt/rest/v1/api.go
+++ b/mgmt/rest/v1/api.go
@@ -12,6 +12,8 @@ const (
 	TLSCertPrefix = "crt."
 	// TLSKeyPrefix defines a prefix for file fragment carrying path to TLS private key
 	TLSKeyPrefix = "key."
+	// TLSRootCertsPrefix defines a prefix for file fragment carrying paths to TLS root certificates
+	TLSRootCertsPrefix = "root."
 
 	version = "v1"
 	prefix  = "/" + version

--- a/mgmt/rest/v1/api.go
+++ b/mgmt/rest/v1/api.go
@@ -12,8 +12,8 @@ const (
 	TLSCertPrefix = "crt."
 	// TLSKeyPrefix defines a prefix for file fragment carrying path to TLS private key
 	TLSKeyPrefix = "key."
-	// TLSRootCertsPrefix defines a prefix for file fragment carrying paths to TLS root certificates
-	TLSRootCertsPrefix = "root."
+	// TLSCACertsPrefix defines a prefix for file fragment carrying paths to TLS CA certificates
+	TLSCACertsPrefix = "cacerts."
 
 	version = "v1"
 	prefix  = "/" + version

--- a/mgmt/rest/v1/plugin.go
+++ b/mgmt/rest/v1/plugin.go
@@ -76,7 +76,7 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 	if strings.HasPrefix(mediaType, "multipart/") {
 		var certPath string
 		var keyPath string
-		var rootCertPaths string
+		var caCertPaths string
 		var signature []byte
 		var checkSum [sha256.Size]byte
 		lp := &rbody.PluginsLoaded{}
@@ -120,7 +120,8 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 			// extension, an error is returned.
 			// If we loop around more than twice before receiving io.EOF, then
 			// an error is returned.
-
+			// Reception of TLS security file paths (ceritificate file, private key file, CA certificate files)
+			// is also taking place here. Paths are extracted and used to set up a RequestedPlugin object.
 			switch {
 			case i == 0:
 				if filepath.Ext(p.FileName()) == ".asc" {
@@ -150,8 +151,8 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 						rbody.Write(500, rbody.FromError(e), w)
 						return
 					}
-				} else if strings.HasPrefix(p.FileName(), TLSRootCertsPrefix) {
-					rootCertPaths = string(b)
+				} else if strings.HasPrefix(p.FileName(), TLSCACertsPrefix) {
+					caCertPaths = string(b)
 					// validation will take place later; take it as it is
 				} else {
 					e := errors.New("Error: unrecognized file was passed")
@@ -175,7 +176,7 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 		rp.SetSignature(signature)
 		rp.SetCertPath(certPath)
 		rp.SetKeyPath(keyPath)
-		rp.SetRootCertPaths(rootCertPaths)
+		rp.SetCACertPaths(caCertPaths)
 		if certPath != "" && keyPath != "" {
 			rp.SetTLSEnabled(true)
 		} else if certPath != "" || keyPath != "" {

--- a/mgmt/rest/v1/plugin.go
+++ b/mgmt/rest/v1/plugin.go
@@ -135,14 +135,14 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 			case i < 4:
 				if filepath.Ext(p.FileName()) == ".asc" {
 					signature = b
-				} else if strings.HasPrefix(p.FileName(), "crt.") {
+				} else if strings.HasPrefix(p.FileName(), TLSCertPrefix) {
 					certPath = string(b)
 					if _, err := os.Stat(certPath); os.IsNotExist(err) {
 						e := errors.New("Error: given certificate file is not available")
 						rbody.Write(500, rbody.FromError(e), w)
 						return
 					}
-				} else if strings.HasPrefix(p.FileName(), "key.") {
+				} else if strings.HasPrefix(p.FileName(), TLSKeyPrefix) {
 					keyPath = string(b)
 					if _, err := os.Stat(keyPath); os.IsNotExist(err) {
 						e := errors.New("Error: given key file is not available")

--- a/pkg/rpcutil/rpc.go
+++ b/pkg/rpcutil/rpc.go
@@ -24,15 +24,28 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
+// grpcDialDefaultTimeout is the default timeout for initial gRPC dial
+const grpcDialDefaultTimeout = 2 * time.Second
+
 // GetClientConnection returns a grcp.ClientConn that is unsecured
-// TODO: Add TLS security to connection
 func GetClientConnection(addr string, port int) (*grpc.ClientConn, error) {
+	return GetClientConnectionWithCreds(addr, port, nil)
+}
+
+// GetClientConnectionWithCreds returns a grcp.ClientConn with optional TLS
+// security (if creds != nil)
+func GetClientConnectionWithCreds(addr string, port int, creds credentials.TransportCredentials) (*grpc.ClientConn, error) {
 	grpcDialOpts := []grpc.DialOption{
-		grpc.WithTimeout(2 * time.Second),
+		grpc.WithTimeout(grpcDialDefaultTimeout),
 	}
-	grpcDialOpts = append(grpcDialOpts, grpc.WithInsecure())
+	if creds != nil {
+		grpcDialOpts = append(grpcDialOpts, grpc.WithTransportCredentials(creds))
+	} else {
+		grpcDialOpts = append(grpcDialOpts, grpc.WithInsecure())
+	}
 	conn, err := grpc.Dial(fmt.Sprintf("%v:%v", addr, port), grpcDialOpts...)
 	if err != nil {
 		return nil, err

--- a/plugin/collector/snap-plugin-collector-mock2-grpc/main_small_test.go
+++ b/plugin/collector/snap-plugin-collector-mock2-grpc/main_small_test.go
@@ -22,6 +22,7 @@ limitations under the License.
 package main
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -29,6 +30,7 @@ import (
 
 func TestMain(t *testing.T) {
 	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
 		So(func() { main() }, ShouldNotPanic)
 	})
 }

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/main_small_test.go
@@ -22,6 +22,7 @@ limitations under the License.
 package main
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -29,6 +30,7 @@ import (
 
 func TestMain(t *testing.T) {
 	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
 		So(func() { main() }, ShouldNotPanic)
 	})
 }

--- a/snapteld.go
+++ b/snapteld.go
@@ -856,7 +856,7 @@ func applyCmdLineFlags(cfg *Config, ctx runtimeFlagsContext) {
 	cfg.Control.TempDirPath = setStringVal(cfg.Control.TempDirPath, ctx, "temp_dir_path")
 	cfg.Control.TLSCertPath = setStringVal(cfg.Control.TLSCertPath, ctx, "tls-cert")
 	cfg.Control.TLSKeyPath = setStringVal(cfg.Control.TLSKeyPath, ctx, "tls-key")
-	cfg.Control.RootCertPaths = setStringVal(cfg.Control.RootCertPaths, ctx, "root-cert-paths")
+	cfg.Control.CACertPaths = setStringVal(cfg.Control.CACertPaths, ctx, "ca-cert-paths")
 	// next for the RESTful server related flags
 	cfg.RestAPI.Enable = setBoolVal(cfg.RestAPI.Enable, ctx, "disable-api", invertBoolean)
 	cfg.RestAPI.Port = setIntVal(cfg.RestAPI.Port, ctx, "api-port")

--- a/snapteld_test.go
+++ b/snapteld_test.go
@@ -23,11 +23,102 @@ package main
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
+	"time"
 
-	"github.com/intelsdi-x/snap/pkg/cfgfile"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/vrischmann/jsonutil"
+
+	"github.com/intelsdi-x/snap/control"
+	"github.com/intelsdi-x/snap/mgmt/rest"
+	"github.com/intelsdi-x/snap/mgmt/tribe"
+	"github.com/intelsdi-x/snap/pkg/cfgfile"
+	"github.com/intelsdi-x/snap/scheduler"
 )
+
+var validCmdlineFlags_input = mockFlags{
+	"max-procs":               "11",
+	"log-level":               "1",
+	"log-path":                "/no/logs/allowed",
+	"log-truncate":            "true",
+	"log-colors":              "true",
+	"max-running-plugins":     "12",
+	"plugin-load-timeout":     "20",
+	"plugin-trust":            "1",
+	"auto-discover":           "/no/plugins/here",
+	"keyring-paths":           "/no/keyrings/here",
+	"cache-expiration":        "30ms",
+	"control-listen-addr":     "100.101.102.103",
+	"control-listen-port":     "10400",
+	"pprof":                   "true",
+	"temp_dir_path":           "/no/temp/files",
+	"tls-cert":                "/no/cert/here",
+	"tls-key":                 "/no/key/here",
+	"root-cert-paths":         "/no/root/certs",
+	"disable-api":             "false",
+	"api-port":                "12400",
+	"api-addr":                "120.121.122.123",
+	"rest-https":              "true",
+	"rest-cert":               "/no/rest/cert",
+	"rest-key":                "/no/rest/key",
+	"rest-auth":               "true",
+	"rest-auth-pwd":           "noway",
+	"allowed_origins":         "140.141.142.143",
+	"work-manager-queue-size": "70",
+	"work-manager-pool-size":  "71",
+	"tribe-node-name":         "bonk",
+	"tribe":                   "true",
+	"tribe-addr":              "160.161.162.163",
+	"tribe-port":              "16400",
+	"tribe-seed":              "180.181.182.183",
+}
+
+var validCmdlineFlags_expected = &Config{
+	Control: &control.Config{
+		MaxRunningPlugins: 12,
+		PluginLoadTimeout: 20,
+		PluginTrust:       1,
+		AutoDiscoverPath:  "/no/plugins/here",
+		KeyringPaths:      "/no/keyrings/here",
+		CacheExpiration:   jsonutil.Duration{30 * time.Millisecond},
+		ListenAddr:        "100.101.102.103",
+		ListenPort:        10400,
+		Pprof:             true,
+		TempDirPath:       "/no/temp/files",
+		TLSCertPath:       "/no/cert/here",
+		TLSKeyPath:        "/no/key/here",
+		RootCertPaths:     "/no/root/certs",
+	},
+	RestAPI: &rest.Config{
+		Enable:           true,
+		Port:             12400,
+		Address:          "120.121.122.123:12400",
+		HTTPS:            true,
+		RestCertificate:  "/no/rest/cert",
+		RestKey:          "/no/rest/key",
+		RestAuth:         true,
+		RestAuthPassword: "noway",
+		Pprof:            true,
+		Corsd:            "140.141.142.143",
+	},
+	Tribe: &tribe.Config{
+		Name:     "bonk",
+		Enable:   true,
+		BindAddr: "160.161.162.163",
+		BindPort: 16400,
+		Seed:     "180.181.182.183",
+	},
+	Scheduler: &scheduler.Config{
+		WorkManagerQueueSize: 70,
+		WorkManagerPoolSize:  71,
+	},
+	GoMaxProcs:  11,
+	LogLevel:    1,
+	LogPath:     "/no/logs/allowed",
+	LogTruncate: true,
+	LogColors:   true,
+}
 
 func TestSnapConfig(t *testing.T) {
 	Convey("Test Config", t, func() {
@@ -36,6 +127,271 @@ func TestSnapConfig(t *testing.T) {
 			jb, _ := json.Marshal(cfg)
 			serrs := cfgfile.ValidateSchema(CONFIG_CONSTRAINTS, string(jb))
 			So(len(serrs), ShouldEqual, 0)
+		})
+	})
+}
+
+type mockFlags map[string]string
+
+func (m mockFlags) String(key string) string {
+	return m[key]
+}
+
+func (m mockFlags) Int(key string) int {
+	if v, err := strconv.Atoi(m[key]); err == nil {
+		return v
+	}
+	return 0
+}
+
+func (m mockFlags) Bool(key string) bool {
+	if v, err := strconv.ParseBool(m[key]); err == nil {
+		return v
+	}
+	return false
+}
+
+func (m mockFlags) IsSet(key string) bool {
+	_, gotIt := m[key]
+	return gotIt
+}
+
+func (m mockFlags) getCopy() mockFlags {
+	r := mockFlags{}
+	for k, v := range m {
+		r[k] = v
+	}
+	return r
+}
+
+func (m mockFlags) copyWithout(keys ...string) mockFlags {
+	r := m.getCopy()
+	for _, k := range keys {
+		delete(r, k)
+	}
+	return r
+}
+
+func (m mockFlags) update(key, value string) mockFlags {
+	m[key] = value
+	return m
+}
+
+type mockCfg Config
+
+func (c *mockCfg) setTLSCert(tlsCertPath string) *mockCfg {
+	c.Control.TLSCertPath = tlsCertPath
+	return c
+}
+
+func (c *mockCfg) setTLSKey(tlsKeyPath string) *mockCfg {
+	c.Control.TLSKeyPath = tlsKeyPath
+	return c
+}
+
+func (c *mockCfg) setRootCertPaths(rootCertPaths string) *mockCfg {
+	c.Control.RootCertPaths = rootCertPaths
+	return c
+}
+
+func (c *mockCfg) setApiAddr(apiAddr string) *mockCfg {
+	c.RestAPI.Address = apiAddr
+	return c
+}
+
+func (c *mockCfg) getCopy() (r *mockCfg) {
+	r = &mockCfg{}
+	b, err := json.Marshal(*c)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(b, r)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func (c *mockCfg) export() *Config {
+	return (*Config)(c)
+}
+
+func Test_checkCmdLineFlags(t *testing.T) {
+	testCtx := mockFlags{
+		"tls-cert":        "mock-cli.crt",
+		"tls-key":         "mock-cli.key",
+		"root-cert-paths": "mock-ca.crt",
+		"api-addr":        "localhost",
+		"api-port":        "9000"}
+	tests := []struct {
+		name           string
+		msg            func(func(string))
+		ctx            runtimeFlagsContext
+		wantErr        bool
+		wantPort       int
+		wantPortInAddr bool
+	}{
+		{name: "CmdlineArgsParseWell",
+			msg: func(f func(string)) {
+				f("Having valid command line flags, parsing suceeds")
+			},
+			ctx:            testCtx.getCopy(),
+			wantErr:        false,
+			wantPort:       9000,
+			wantPortInAddr: false},
+		{name: "CmdlineArgsWithoutTLSConfigParseWell",
+			msg: func(f func(string)) {
+				f("Having valid command line flags without any TLS parameters, parsing suceeds")
+			},
+			ctx: testCtx.
+				copyWithout("tls-cert", "tls-key", "root-cert-paths", "api-port").
+				update("api-addr", "127.0.0.1:9002"),
+			wantErr:        false,
+			wantPort:       9002,
+			wantPortInAddr: true},
+		{name: "ArgsWithTLSCertWithoutKey_Fail",
+			msg: func(f func(string)) {
+				f("Having command line flags with TLS cert without key, parsing fails")
+			},
+			ctx:     testCtx.copyWithout("tls-key"),
+			wantErr: true,
+		},
+		{name: "ArgsWithTLSKeyWithoutCert_Fail",
+			msg: func(f func(string)) {
+				f("Having command line flags with TLS key without cert, parsing fails")
+			},
+			ctx:     testCtx.copyWithout("tls-cert"),
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		runThisCase := func(f func(msg string)) {
+			t.Run(tc.name, func(_ *testing.T) {
+				tc.msg(f)
+			})
+		}
+		runThisCase(func(msg string) {
+			Convey(msg, t, func() {
+				gotPort, gotPortInAddr, err := checkCmdLineFlags(tc.ctx)
+				if tc.wantErr {
+					So(err, ShouldNotBeNil)
+					return
+				}
+				So(err, ShouldBeNil)
+				So(gotPort, ShouldEqual, tc.wantPort)
+				So(gotPortInAddr, ShouldEqual, tc.wantPortInAddr)
+			})
+		})
+	}
+}
+
+func Test_checkCfgSettings(t *testing.T) {
+	const DontCheckInt = -99
+	testCfg := &mockCfg{
+		Control: &control.Config{},
+		RestAPI: &rest.Config{},
+	}
+	tests := []struct {
+		name           string
+		msg            func(func(string))
+		cfg            *Config
+		wantErr        bool
+		wantPort       int
+		wantPortInAddr bool
+	}{
+		{name: "DefaultConfigSettingsValidateWell",
+			msg: func(f func(string)) {
+				f("Having all default (empty) values for config, validation succeeds")
+			},
+			cfg:            (&mockCfg{Control: control.GetDefaultConfig(), RestAPI: rest.GetDefaultConfig()}).export(),
+			wantErr:        false,
+			wantPort:       DontCheckInt,
+			wantPortInAddr: false},
+		{name: "ConfigSettingsValidateWell",
+			msg: func(f func(string)) {
+				f("Having correct values, config validation succeeds")
+			},
+			cfg: testCfg.getCopy().
+				setApiAddr("localhost:9000").
+				setTLSCert("mock-cli.crt").
+				setTLSKey("mock-cli.key").
+				setRootCertPaths("mock-ca.crt").
+				export(),
+			wantErr:        false,
+			wantPort:       9000,
+			wantPortInAddr: true},
+		{name: "ConfigSettingsWithoutTLSConfigValidateWell",
+			msg: func(f func(string)) {
+				f("Having correct values without any TLS parameters, config validation succeeds")
+			},
+			cfg: testCfg.getCopy().
+				setApiAddr("localhost:9000").
+				export(),
+			wantErr:        false,
+			wantPort:       9000,
+			wantPortInAddr: true},
+		{name: "ConfigSettingsWithTLSCertWithoutKey_Fail",
+			msg: func(f func(string)) {
+				f("Having config with TLS cert without key, config fails to validate")
+			},
+			cfg: testCfg.getCopy().
+				setApiAddr("localhost:9000").
+				setTLSCert("mock-cli.crt").
+				export(),
+			wantErr:        true,
+			wantPort:       9000,
+			wantPortInAddr: true},
+		{name: "ConfigSettingsWithTLSKeyWithoutCert_Fail",
+			msg: func(f func(string)) {
+				f("Having config with TLS key without cert, config fails to validate")
+			},
+			cfg: testCfg.getCopy().
+				setApiAddr("localhost:9000").
+				setTLSKey("mock-cli.crt").
+				export(),
+			wantErr:        true,
+			wantPort:       9000,
+			wantPortInAddr: true},
+	}
+
+	for _, tc := range tests {
+		runThisCase := func(f func(msg string)) {
+			t.Run(tc.name, func(_ *testing.T) {
+				tc.msg(f)
+			})
+		}
+		runThisCase(func(msg string) {
+			Convey(msg, t, func() {
+				gotPort, gotPortInAddr, err := checkCfgSettings(tc.cfg)
+				if tc.wantErr {
+					So(err, ShouldNotBeNil)
+					return
+				}
+				So(err, ShouldBeNil)
+				if tc.wantPort != DontCheckInt {
+					So(gotPort, ShouldEqual, tc.wantPort)
+				}
+				So(gotPortInAddr, ShouldEqual, tc.wantPortInAddr)
+			})
+		})
+	}
+}
+
+func Test_applyCmdLineFlags(t *testing.T) {
+	Convey("Having arguments given on command line", t, func() {
+		gotConfig := Config{
+			Control:   &control.Config{},
+			RestAPI:   &rest.Config{},
+			Tribe:     &tribe.Config{},
+			Scheduler: &scheduler.Config{},
+		}
+		applyCmdLineFlags(&gotConfig, validCmdlineFlags_input)
+		Convey("config should be filled with correct values", func() {
+			So(*gotConfig.Control, ShouldResemble, *validCmdlineFlags_expected.Control)
+			So(*gotConfig.RestAPI, ShouldResemble, *validCmdlineFlags_expected.RestAPI)
+			So(*gotConfig.Tribe, ShouldResemble, *validCmdlineFlags_expected.Tribe)
+			So(*gotConfig.Scheduler, ShouldResemble, *validCmdlineFlags_expected.Scheduler)
+			So(gotConfig, ShouldResemble, *validCmdlineFlags_expected)
 		})
 	})
 }

--- a/snapteld_test.go
+++ b/snapteld_test.go
@@ -55,7 +55,7 @@ var validCmdlineFlags_input = mockFlags{
 	"temp_dir_path":           "/no/temp/files",
 	"tls-cert":                "/no/cert/here",
 	"tls-key":                 "/no/key/here",
-	"root-cert-paths":         "/no/root/certs",
+	"ca-cert-paths":           "/no/root/certs",
 	"disable-api":             "false",
 	"api-port":                "12400",
 	"api-addr":                "120.121.122.123",
@@ -88,7 +88,7 @@ var validCmdlineFlags_expected = &Config{
 		TempDirPath:       "/no/temp/files",
 		TLSCertPath:       "/no/cert/here",
 		TLSKeyPath:        "/no/key/here",
-		RootCertPaths:     "/no/root/certs",
+		CACertPaths:       "/no/root/certs",
 	},
 	RestAPI: &rest.Config{
 		Enable:           true,
@@ -189,8 +189,8 @@ func (c *mockCfg) setTLSKey(tlsKeyPath string) *mockCfg {
 	return c
 }
 
-func (c *mockCfg) setRootCertPaths(rootCertPaths string) *mockCfg {
-	c.Control.RootCertPaths = rootCertPaths
+func (c *mockCfg) setCACertPaths(caCertPaths string) *mockCfg {
+	c.Control.CACertPaths = caCertPaths
 	return c
 }
 
@@ -218,11 +218,11 @@ func (c *mockCfg) export() *Config {
 
 func Test_checkCmdLineFlags(t *testing.T) {
 	testCtx := mockFlags{
-		"tls-cert":        "mock-cli.crt",
-		"tls-key":         "mock-cli.key",
-		"root-cert-paths": "mock-ca.crt",
-		"api-addr":        "localhost",
-		"api-port":        "9000"}
+		"tls-cert":      "mock-cli.crt",
+		"tls-key":       "mock-cli.key",
+		"ca-cert-paths": "mock-ca.crt",
+		"api-addr":      "localhost",
+		"api-port":      "9000"}
 	tests := []struct {
 		name           string
 		msg            func(func(string))
@@ -244,7 +244,7 @@ func Test_checkCmdLineFlags(t *testing.T) {
 				f("Having valid command line flags without any TLS parameters, parsing suceeds")
 			},
 			ctx: testCtx.
-				copyWithout("tls-cert", "tls-key", "root-cert-paths", "api-port").
+				copyWithout("tls-cert", "tls-key", "ca-cert-paths", "api-port").
 				update("api-addr", "127.0.0.1:9002"),
 			wantErr:        false,
 			wantPort:       9002,
@@ -315,7 +315,7 @@ func Test_checkCfgSettings(t *testing.T) {
 				setApiAddr("localhost:9000").
 				setTLSCert("mock-cli.crt").
 				setTLSKey("mock-cli.key").
-				setRootCertPaths("mock-ca.crt").
+				setCACertPaths("mock-ca.crt").
 				export(),
 			wantErr:        false,
 			wantPort:       9000,


### PR DESCRIPTION
between framework and plugin.

- Snap REST API is accepting additional files upon PluginLoad request;
- Snap PluginLoad accepts paths to plugin certificate and key to be passed inline with request;
- Snap embeds the certificate paths into plugin runtime arguments, so that plugin
may make use of it (fields CertPath, KeyPath);
- `snaptel` extended to accept additional options: `--plugin-cert`, `--plugin-key`, `--plugin-root-certs`; arguments to those
options are packed into a request for Snap REST API.

Addresses #1524 

### Summary of changes
- `snaptel` accepts new arguments to start plugin with a TLS secure server: `--plugin-cert`, `--plugin-key`, `--plugin-root-certs`, being paths to valid X.509 resources
- `snapteld` accepts new arguments to enable TLS security for communication with plugins: `--tls-cert`, `--tls-key`, `--root-cert-paths`, also paths to valid X.509 resources
- Snap REST API is accepting additional arguments: path to X.509 certificate and X.509 key in call to plugin load
- framework is now able to use own certificate and key to authenticate itself and establish connection to plugin,
- framework will refuse to connect to insecure plugins,

### Remarks
- Note that plugin and `snapteld` certificates must be signed by a root CA trusted in the system; see below for instructions
- Note that TLS will only be supported by plugins linked with plugin library `snap-plugin-lib-go`.

### Testing done
- developer tests

@intelsdi-x/snap-maintainers

### Instructions for manual testing

1. Obtain valid certificates proceed with following steps (valid for Ubuntu):
    1. Install tool [certstrap](https://github.com/square/certstrap) for generating test certificates. Further steps will assume that `certstrap` is available under `$PATH` location.
    1. Generate root CA certificate:
       ```
       certstrap init --cn "snaptest-ca" --o "snaptest" --ou "ca" --key-bits 2048 --years 1 --passphrase '
       ```
    1. **optional** Install root CA certificate in the system:
       ```
       sudo cp out/snaptest-ca.crt /usr/local/share/ca-certificates/; sudo update-ca-certificates --verbose --fresh
       ``` 
    1. Generate server certificate and key to use with plugins:
       ```
       certstrap request-cert --cn "snaptest-srv" --ip "127.0.0.1" --domain "localhost" --passphrase '' --key-bits 2048 --o "snaptest" --ou "server"
       certstrap sign "snaptest-srv" --CA "snaptest-ca" --passphrase '' --years 1
       ```
    1. Generate client certificate and key to use with `snapteld`:
       ```
       certstrap request-cert --cn "snaptest-cli" --ip "127.0.0.1" --domain "localhost" --passphrase '' --key-bits 2048 --o "snaptest" --ou "client"
       certstrap sign "snaptest-cli" --CA "snaptest-ca" --passphrase '' --years 1
       ```
    1. Copy server and client certificates into common location, e.g.: `/tmp`:
       ```
       for unit in srv cli; do for fname in crt key; do cp out/snaptest-$unit.$fname /tmp; done; done
       ```
1. Start new shell session and execute `snapteld` with certificate generated for client and path to root CA certificate:
`snapteld -t 0 -l 1 --tls-cert=/tmp/snaptest-cli.crt --tls-key=/tmp/snaptest-cli.key --root-cert-paths=/tmp/snaptest-ca.crt`
    * adding `root-cert-paths` is optional if the root CA certificate was installed in the system
1. Start new shell session and load plugin built with `snap-plugin-lib-go`, for instance: snap-plugin-collector-rand from `snap-plugin-lib-go` examples: 
`snaptel plugin load  --plugin-cert=/tmp/snaptest-srv.crt --plugin-key=/tmp/snaptest-srv.key snap-plugin-collector-rand --plugin-root-certs=/tmp/snaptest-ca.crt`
    * adding `plugin-root-certs` is optional if root CA certificate was installed in the system
1. Launch any example task.
1. Don't forget to clean up removing installed root CA:
   ```
   sudo rm /usr/local/share/ca-certificates/snaptest-ca.crt
   sudo update-ca-certificates --fresh --verbose
   ```
