### PR TITLE
Remove duplicate function for getPluginType in config.go v1 and v2

### DIFF
--- a/core/plugin.go
+++ b/core/plugin.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
@@ -64,6 +65,16 @@ func CheckPluginType(id PluginType) bool {
 	_, ok := pts[id]
 
 	return ok
+}
+
+func GetPluginType(t string) (PluginType, error) {
+	if ityp, err := strconv.Atoi(t); err == nil {
+		if !CheckPluginType(PluginType(ityp)) {
+			return PluginType(-1), fmt.Errorf("invalid plugin type id given %d", ityp)
+		}
+		return PluginType(ityp), nil
+	}
+	return ToPluginType(t)
 }
 
 func (pt PluginType) String() string {

--- a/mgmt/rest/v1/config.go
+++ b/mgmt/rest/v1/config.go
@@ -20,7 +20,6 @@ limitations under the License.
 package v1
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -40,7 +39,7 @@ func (s *apiV1) getPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 		return
 	}
 
-	typ, err := getPluginType(styp)
+	typ, err := core.GetPluginType(styp)
 	if err != nil {
 		rbody.Write(400, rbody.FromError(err), w)
 		return
@@ -68,7 +67,7 @@ func (s *apiV1) deletePluginConfigItem(w http.ResponseWriter, r *http.Request, p
 	var typ core.PluginType
 	styp := p.ByName("type")
 	if styp != "" {
-		typ, err = getPluginType(styp)
+		typ, err = core.GetPluginType(styp)
 		if err != nil {
 			rbody.Write(400, rbody.FromError(err), w)
 			return
@@ -110,7 +109,7 @@ func (s *apiV1) setPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 	var typ core.PluginType
 	styp := p.ByName("type")
 	if styp != "" {
-		typ, err = getPluginType(styp)
+		typ, err = core.GetPluginType(styp)
 		if err != nil {
 			rbody.Write(400, rbody.FromError(err), w)
 			return
@@ -145,18 +144,4 @@ func (s *apiV1) setPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 
 	item := &rbody.SetPluginConfigItem{ConfigDataNode: res}
 	rbody.Write(200, item, w)
-}
-
-func getPluginType(t string) (core.PluginType, error) {
-	if ityp, err := strconv.Atoi(t); err == nil {
-		if !core.CheckPluginType(core.PluginType(ityp)) {
-			return core.PluginType(-1), fmt.Errorf("invalid plugin type id given %d", ityp)
-		}
-		return core.PluginType(ityp), nil
-	}
-	ityp, err := core.ToPluginType(t)
-	if err != nil {
-		return core.PluginType(-1), err
-	}
-	return ityp, nil
 }

--- a/mgmt/rest/v2/config.go
+++ b/mgmt/rest/v2/config.go
@@ -48,7 +48,7 @@ func (s *apiV2) getPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 		return
 	}
 
-	typ, err := getPluginType(styp)
+	typ, err := core.GetPluginType(styp)
 	if err != nil {
 		Write(400, FromError(err), w)
 		return
@@ -74,7 +74,7 @@ func (s *apiV2) deletePluginConfigItem(w http.ResponseWriter, r *http.Request, p
 	var typ core.PluginType
 	styp := p.ByName("type")
 	if styp != "" {
-		typ, err = getPluginType(styp)
+		typ, err = core.GetPluginType(styp)
 		if err != nil {
 			Write(400, FromError(err), w)
 			return
@@ -114,7 +114,7 @@ func (s *apiV2) setPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 	var typ core.PluginType
 	styp := p.ByName("type")
 	if styp != "" {
-		typ, err = getPluginType(styp)
+		typ, err = core.GetPluginType(styp)
 		if err != nil {
 			Write(400, FromError(err), w)
 			return
@@ -147,15 +147,4 @@ func (s *apiV2) setPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 
 	item := &PluginConfigItem{ConfigDataNode: res}
 	Write(200, item, w)
-}
-
-func getPluginType(t string) (core.PluginType, error) {
-	if ityp, err := strconv.Atoi(t); err == nil {
-		return core.PluginType(ityp), nil
-	}
-	ityp, err := core.ToPluginType(t)
-	if err != nil {
-		return core.PluginType(-1), err
-	}
-	return ityp, nil
 }


### PR DESCRIPTION
Fixes #1602 

Summary of changes:
- removed getPluginType from config.go  v1 and v2 (duplicated code)
- moved getPluginType to plugin.go so it can be reused by both V1 and V2
- simplified function to reduce duplicate error handling

Testing done:
- make test-all

@intelsdi-x/snap-maintainers
