### PR TITLE
Fixes #1598 and #1601 - ability to stop tasks gracefully

### DIFF
--- a/scheduler/fixtures/fixtures.go
+++ b/scheduler/fixtures/fixtures.go
@@ -27,6 +27,7 @@ import "github.com/intelsdi-x/snap/core/scheduler_event"
 type listenToSchedulerEvent struct {
 	Ended                    chan struct{}
 	UnsubscribedPluginEvents chan *scheduler_event.PluginsUnsubscribedEvent
+	TaskStoppedEvents        chan struct{}
 }
 
 // NewListenToSchedulerEvent
@@ -34,6 +35,7 @@ func NewListenToSchedulerEvent() *listenToSchedulerEvent {
 	return &listenToSchedulerEvent{
 		Ended: make(chan struct{}),
 		UnsubscribedPluginEvents: make(chan *scheduler_event.PluginsUnsubscribedEvent),
+		TaskStoppedEvents:        make(chan struct{}),
 	}
 }
 
@@ -43,5 +45,7 @@ func (l *listenToSchedulerEvent) HandleGomitEvent(e gomit.Event) {
 		l.Ended <- struct{}{}
 	case *scheduler_event.PluginsUnsubscribedEvent:
 		l.UnsubscribedPluginEvents <- msg
+	case *scheduler_event.TaskStoppedEvent:
+		l.TaskStoppedEvents <- struct{}{}
 	}
 }


### PR DESCRIPTION
Fixes #1598 and #1601 

Summary of changes:
- Plugins are unsubscribed by the event handler after the task state is Stopped
- Increment hitCount after the workflow finishes executing
- TaskStoppedEvent is emitted after the task state is Stopped

Testing done:
- manual test using mock
- legacy tests

@intelsdi-x/snap-maintainers