### PR TITLE
Feature: New Relic collector plugin.

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -15,6 +15,7 @@
 # After merging, we will update PLUGIN_CATALOG.md and website where
 # the list is available: http://snap-telemetry.io/plugins.html
 #####################
+- inteleon/snap-plugin-collector-newrelic
 - opsvision/snap-plugin-publisher-awssqs
 - opsvision/snap-plugin-publisher-signalfx
 - opsvision/snap-plugin-collector-syslog


### PR DESCRIPTION
This plugin is only version 0.0.1.

You are able to collect basic information about your New Relic
applications.

Lots more to come in terms of documentation and metrics to collect.

Summary of changes:
- New collector plugin (New Relic)

Testing done:
- Unit tests
- Manual testing

@intelsdi-x/snap-maintainers