### PR TITLE
Fixes #1582: Snap framework panics when using autoload feature and REST API is down

### DIFF
--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -252,7 +252,7 @@ func (s *Server) run(addrString string) {
 		config := &tls.Config{Certificates: []tls.Certificate{cer}}
 		ln, err := tls.Listen("tcp", addrString, config)
 		if err != nil {
-			s.err <- err
+			log.Fatal(err)
 		}
 		s.serverListener = ln
 		s.wg.Add(1)
@@ -260,7 +260,7 @@ func (s *Server) run(addrString string) {
 	} else {
 		ln, err := net.Listen("tcp", addrString)
 		if err != nil {
-			s.err <- err
+			log.Fatal(err)
 		}
 		s.serverListener = ln
 		s.addr = ln.Addr()


### PR DESCRIPTION
Fixes #1582 

Summary of changes:
- Log the bind error as a fatal message thereby avoiding the panic to occur. This log message is consistent with/without using the autoload feature.

Steps to reproduce:

1) `snapteld -l 1 -t 0 --control-listen-port 8084`

2) In another terminal, run snapteld without auto-discovery: 
`snapteld -l 1 -t 0`
You should receive the following error:
FATA[2017-04-18T14:49:14-07:00] listen tcp :8181: bind: address already in use
This is expected behavior. 

Let's try to do the same with autodiscovery option:
`snapteld -a "/opt/snap/plugins" -t 0 -l 1`
This causes a panic:
INFO[2017-04-18T14:23:13-07:00] Starting REST API on :8181                    _module=_mgmt-rest
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x17937c]

As I user, I expect to receive an error with appropriate message that port 8181 is already in use, without causing panic.

Testing done:
- Manual testing

@intelsdi-x/snap-maintainers