### PR TITLE
Fixes #1614 - Protect cleanup code of plugin unload

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -218,7 +218,7 @@ func New(cfg *Config) *pluginControl {
 	}).Debug("metric catalog created")
 
 	// Plugin Manager
-	c.pluginManager = newPluginManager(OptSetPprof(cfg.Pprof))
+	c.pluginManager = newPluginManager(OptSetPprof(cfg.Pprof), OptSetTempDirPath(cfg.TempDirPath))
 	controlLogger.WithFields(log.Fields{
 		"_block": "new",
 	}).Debug("plugin manager created")


### PR DESCRIPTION
Fixes #1614 

Summary of changes:
- Added checks before removing temp files where the plugin binaries reside. 

Testing done:
- Manual testing 

@intelsdi-x/snap-maintainers