### PR TITLE
Aarontay/standalone plugin

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -33,9 +33,9 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/intelsdi-x/gomit"
 	"google.golang.org/grpc"
 
+	"github.com/intelsdi-x/gomit"
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/client"
 	"github.com/intelsdi-x/snap/control/strategy"
@@ -587,6 +587,11 @@ func (p *pluginControl) verifySignature(rp *core.RequestedPlugin) (bool, serror.
 }
 
 func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDetails, serror.SnapError) {
+	if rp.Uri() != nil {
+		return &pluginDetails{
+			Uri: rp.Uri(),
+		}, nil
+	}
 	details := &pluginDetails{}
 	var serr serror.SnapError
 	//Check plugin signing
@@ -725,6 +730,13 @@ func (p *pluginControl) UnsubscribeDeps(id string) []serror.SnapError {
 }
 
 func (p *pluginControl) verifyPlugin(lp *loadedPlugin) error {
+	if lp.Details.Uri != nil {
+		// remote plugin
+		if core.IsUri(lp.Details.Uri.String()) {
+			return fmt.Errorf(fmt.Sprintf("Remote plugin failed to load: bad uri: (%x)", lp.Details.Uri))
+		}
+		return nil
+	}
 	b, err := ioutil.ReadFile(lp.Details.Path)
 	if err != nil {
 		return err

--- a/control/monitor.go
+++ b/control/monitor.go
@@ -86,7 +86,9 @@ func (m *monitor) Start(availablePlugins *availablePlugins) {
 				go func() {
 					availablePlugins.RLock()
 					for _, ap := range availablePlugins.all() {
-						go ap.CheckHealth()
+						if !ap.IsRemote() {
+							go ap.CheckHealth()
+						}
 					}
 					availablePlugins.RUnlock()
 				}()

--- a/control/plugin/client/client.go
+++ b/control/plugin/client/client.go
@@ -33,6 +33,7 @@ type PluginClient interface {
 	SetKey() error
 	Ping() error
 	Kill(string) error
+	Close() error
 	GetConfigPolicy() (*cpolicy.ConfigPolicy, error)
 }
 

--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -344,6 +344,14 @@ func (g *grpcClient) Kill(reason string) error {
 	return nil
 }
 
+func (g *grpcClient) Close() error {
+	err := g.conn.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (g *grpcClient) Publish(metrics []core.Metric, config map[string]ctypes.ConfigValue) error {
 	arg := &rpc.PubProcArg{
 		Metrics: NewMetrics(metrics),

--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -95,6 +95,11 @@ func (p *PluginNativeClient) Kill(reason string) error {
 	return err
 }
 
+func (p *PluginNativeClient) Close() error {
+	// Added to conform to interface, but not needed by native
+	return nil
+}
+
 // Used to catch zero values for times and overwrite with current time
 // the 0 value for time.Time is year 1 which isn't a valid value for metric
 // collection (until we get a time machine).

--- a/control/runner.go
+++ b/control/runner.go
@@ -395,12 +395,27 @@ func (r *runner) handleUnsubscription(pType, pName string, pVersion int, taskID 
 		return errors.New("pool not found")
 	}
 	if pool.SubscriptionCount() < pool.Count() {
-		runnerLog.WithFields(log.Fields{
-			"_block":                  "handle-unsubscription",
-			"pool-count":              pool.Count(),
-			"pool-subscription-count": pool.SubscriptionCount(),
-		}).Debug(fmt.Sprintf("killing an available plugin in pool  %s:%s:%d", pType, pName, pVersion))
-		pool.SelectAndKill(taskID, "unsubscription event")
+		lp, err := r.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pType, pName, pVersion))
+		if lp != nil && lp.Details.Uri != nil {
+			if err != nil {
+				runnerLog.WithFields(log.Fields{
+					"_block":                  "handle-unsubscription",
+					"pool-count":              pool.Count(),
+					"pool-subscription-count": pool.SubscriptionCount(),
+					"plugin-name":             pName,
+					"plugin-version":          pVersion,
+					"plugin-type":             pType,
+					"error":                   err.Error(),
+				}).Error("unable to get loaded plugin")
+			}
+			runnerLog.WithFields(log.Fields{
+				"_block":     "handle-unsubscription",
+				"plugin-uri": lp.Details.Uri,
+			}).Debug(fmt.Sprintf("unsubscribe called on standalone plugin"))
+			pool.SelectAndStop(taskID, "remote unsubscription event")
+		} else {
+			pool.SelectAndKill(taskID, "unsubscription event")
+		}
 	}
 	return nil
 }

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -131,6 +131,10 @@ func (mpcc *MockHealthyPluginCollectorClient) Kill(string) error {
 	return nil
 }
 
+func (mpcc *MockHealthyPluginCollectorClient) Close() error {
+	return nil
+}
+
 func (mpcc *MockHealthyPluginCollectorClient) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
 	return nil, errors.New("Fail")
 }
@@ -162,6 +166,10 @@ func (mpcc *MockUnhealthyPluginCollectorClient) Ping() error {
 }
 
 func (mpcc *MockUnhealthyPluginCollectorClient) Kill(string) error {
+	return errors.New("Fail")
+}
+
+func (mpcc *MockUnhealthyPluginCollectorClient) Close() error {
 	return errors.New("Fail")
 }
 

--- a/control/strategy/fixtures/fixtures.go
+++ b/control/strategy/fixtures/fixtures.go
@@ -43,6 +43,7 @@ const (
 	version            = 1
 	name               = "mock"
 	port               = ""
+	remote             = false
 )
 
 var lastHit = time.Unix(1460027570, 0)
@@ -59,6 +60,7 @@ type MockAvailablePlugin struct {
 	pluginType plugin.PluginType
 	version    int
 	port       string
+	isRemote   bool
 }
 
 func NewMockAvailablePlugin() *MockAvailablePlugin {
@@ -74,6 +76,7 @@ func NewMockAvailablePlugin() *MockAvailablePlugin {
 		pluginType: plugin.CollectorPluginType,
 		version:    version,
 		port:       port,
+		isRemote:   remote,
 	}
 	return mock
 }
@@ -192,4 +195,12 @@ func (m MockAvailablePlugin) Version() int {
 
 func (m MockAvailablePlugin) Port() string {
 	return m.port
+}
+
+func (m MockAvailablePlugin) IsRemote() bool {
+	return m.isRemote
+}
+
+func (m MockAvailablePlugin) SetIsRemote(isRemote bool) {
+	m.isRemote = isRemote
 }

--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -59,6 +59,7 @@ type Pool interface {
 	Plugins() MapAvailablePlugin
 	RLock()
 	RUnlock()
+	SelectAndStop(taskID, reason string)
 	SelectAndKill(taskID, reason string)
 	SelectAP(taskID string, configID map[string]ctypes.ConfigValue) (AvailablePlugin, serror.SnapError)
 	Strategy() RoutingAndCaching
@@ -83,6 +84,8 @@ type AvailablePlugin interface {
 	String() string
 	Type() plugin.PluginType
 	Stop(string) error
+	IsRemote() bool
+	SetIsRemote(bool)
 }
 
 type subscription struct {
@@ -301,6 +304,27 @@ func (p *pool) KillAll(reason string) {
 		}
 		p.Kill(id, reason)
 	}
+}
+
+// SelectAndStop selects, stops and removes the available plugin from the pool
+func (p *pool) SelectAndStop(id, reason string) {
+	rp, err := p.Remove(p.plugins.Values(), id)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"_block": "SelectAndStop",
+			"taskID": id,
+			"reason": reason,
+		}).Error(err)
+		return
+	}
+	if err := rp.Stop(reason); err != nil {
+		log.WithFields(log.Fields{
+			"_block": "SelectAndStop",
+			"taskID": id,
+			"reason": reason,
+		}).Error(err)
+	}
+	p.remove(rp.ID())
 }
 
 // SelectAndKill selects, kills and removes the available plugin from the pool

--- a/mgmt/rest/client/client.go
+++ b/mgmt/rest/client/client.go
@@ -31,6 +31,7 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 
+	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/mgmt/rest/v1"
 	"github.com/intelsdi-x/snap/mgmt/rest/v1/rbody"
 )
@@ -261,7 +263,6 @@ func (c *Client) do(method, path string, ct contentType, body ...[]byte) (*rbody
 		}
 		defer rsp.Body.Close()
 	}
-
 	return httpRespToAPIResp(rsp)
 }
 
@@ -297,6 +298,30 @@ func httpRespToAPIResp(rsp *http.Response) (*rbody.APIResponse, error) {
 }
 
 func (c *Client) pluginUploadRequest(pluginPaths []string) (*rbody.APIResponse, error) {
+	if core.IsUri(pluginPaths[0]) {
+		if _, err := url.ParseRequestURI(pluginPaths[0]); err == nil {
+			req, err := http.NewRequest(
+				"POST",
+				c.prefix+"/plugins",
+				strings.NewReader(
+					fmt.Sprintf("{\"uri\": \"%s\"}", pluginPaths[0]),
+				),
+			)
+			if err != nil {
+				return nil, err
+			}
+			addAuth(req, c.Username, c.Password)
+			req.Header.Add("Content-Type", "application/json")
+			rsp, err := c.http.Do(req)
+			if err != nil {
+				if strings.Contains(err.Error(), "tls: oversized record") || strings.Contains(err.Error(), "malformed HTTP response") {
+					return nil, fmt.Errorf("error connecting to API URI: %s. Do you have an http/https mismatch?", c.URL)
+				}
+				return nil, fmt.Errorf("URL target is not available. %v", err)
+			}
+			return httpRespToAPIResp(rsp)
+		}
+	}
 	errChan := make(chan error)
 	pr, pw := io.Pipe()
 	writer := multipart.NewWriter(pw)


### PR DESCRIPTION
Fixes #

Summary of changes:
- Added support for loading standalone plugins remotely
- Added checks to verify if plugin has a remote URI
- Updated unload / unsubscribe to handle remote plugins

Testing done:
- Tested with remote plugin 'snap-plugin-collector-rand' example in snap-plugin-lib-go and was able to load/create tasks/unload/terminate daemon when using remote plugins. Verified non-remote plugins were unaffected by new standalone plugin logic.

@intelsdi-x/snap-maintainers