### PR TITLE
Fix plugin load timeout in LoadPlugin and startPlugin 

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -116,6 +116,7 @@ type runsPlugins interface {
 	SetPluginManager(managesPlugins)
 	Monitor() *monitor
 	runPlugin(string, *pluginDetails) error
+	SetPluginLoadTimeout(int)
 }
 
 type managesPlugins interface {
@@ -174,6 +175,7 @@ func OptSetConfig(cfg *Config) PluginControlOpt {
 		c.Config = cfg
 		c.pluginManager.SetPluginConfig(cfg.Plugins)
 		c.pluginManager.SetPluginLoadTimeout(c.Config.PluginLoadTimeout)
+		c.pluginRunner.SetPluginLoadTimeout(c.Config.PluginLoadTimeout)
 	}
 }
 

--- a/control/runner_test.go
+++ b/control/runner_test.go
@@ -333,7 +333,6 @@ func TestRunnerState(t *testing.T) {
 }
 
 func TestRunnerPluginRunning(t *testing.T) {
-	// log.SetLevel(log.DebugLevel)
 	Convey("snap/control", t, func() {
 		Convey("Runner", func() {
 			Convey("startPlugin", func() {
@@ -350,8 +349,6 @@ func TestRunnerPluginRunning(t *testing.T) {
 						}
 
 						So(err, ShouldBeNil)
-
-						// exPlugin := new(MockExecutablePlugin)
 						ap, e := r.startPlugin(exPlugin)
 
 						So(e, ShouldBeNil)

--- a/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2/mock/mock.go
@@ -141,6 +141,13 @@ func (f *Mock) GetMetricTypes(cfg plugin.ConfigType) ([]plugin.MetricType, error
 	if _, ok := cfg.Table()["test-fail"]; ok {
 		return mts, fmt.Errorf("testing")
 	}
+	if d, ok := cfg.Table()["test-sleep-duration"]; ok {
+		duration, err := time.ParseDuration(d.(ctypes.ConfigValueStr).Value)
+		if err != nil {
+			return nil, err
+		}
+		time.Sleep(duration)
+	}
 	if _, ok := cfg.Table()["test"]; ok {
 		mts = append(mts, plugin.MetricType{
 			Namespace_:   core.NewNamespace("intel", "mock", "test"),


### PR DESCRIPTION
Fixes #1618

Summary of changes:
- Fix plugin load timeout in LoadPlugin and startPlugin by blocking until receiving a loaded plugin or timeout expiry. Currently, on master, we execute the plugin and wait for the plugin response or timeout waiting for the plugin's response. In this PR, we handle timeout in LoadPlugin in plugin_manager.go such that: we wait until receiving a channel's response which either has a loaded plugin or error, and then timeout. In control/runner.go, we wait until the channel sends an available plugin or an error and then timeout if we don't receive those. 

- Update runner.go to get the plugin load timeout value from config as opposed to a hardcoded value to make it consistent with other code paths.

Testing:
- Legacy test
- Manual testing

@intelsdi-x/snap-maintainers