### PR TITLE
Adds support for streaming collectors

### DIFF
--- a/cmd/snaptel/task.go
+++ b/cmd/snaptel/task.go
@@ -241,6 +241,12 @@ func (t *task) setScheduleFromCliOptions(ctx *cli.Context) error {
 		}
 		duration = &d
 	}
+
+	// It's a streaming collector
+	if strings.Compare(t.Schedule.Type, "streaming") == 0 {
+		return nil
+	}
+
 	// Grab the interval for the schedule (if one was provided). Note that if an
 	// interval value was not passed in and there is no interval defined for the
 	// schedule associated with this task, it's an error

--- a/control/config.go
+++ b/control/config.go
@@ -331,12 +331,12 @@ func (p *pluginConfig) deletePluginConfigDataNodeFieldAll(key string) {
 }
 
 func (p *pluginConfig) switchPluginConfigType(pluginType core.PluginType) *pluginTypeConfigItem {
-	switch pluginType {
-	case core.CollectorPluginType:
+	switch {
+	case pluginType == core.CollectorPluginType || pluginType == core.StreamingCollectorPluginType:
 		return p.Collector
-	case core.ProcessorPluginType:
+	case pluginType == core.ProcessorPluginType:
 		return p.Processor
-	case core.PublisherPluginType:
+	case pluginType == core.PublisherPluginType:
 		return p.Publisher
 	}
 	return nil

--- a/control/control.go
+++ b/control/control.go
@@ -714,8 +714,8 @@ func (p *pluginControl) SwapPlugins(in *core.RequestedPlugin, out core.Cataloged
 	return nil
 }
 
-func (p *pluginControl) ValidateDeps(requested []core.RequestedMetric, plugins []core.SubscribedPlugin, configTree *cdata.ConfigDataTree) []serror.SnapError {
-	return p.subscriptionGroups.ValidateDeps(requested, plugins, configTree)
+func (p *pluginControl) ValidateDeps(requested []core.RequestedMetric, plugins []core.SubscribedPlugin, configTree *cdata.ConfigDataTree, asserts ...core.SubscribedPluginAssert) []serror.SnapError {
+	return p.subscriptionGroups.ValidateDeps(requested, plugins, configTree, asserts...)
 }
 
 // SubscribeDeps will subscribe to collectors, processors and publishers.  The collectors are subscribed by mapping the provided

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -91,7 +91,7 @@ var (
 		"collector",
 		"processor",
 		"publisher",
-		"streamCollector",
+		"streaming-collector",
 	}
 
 	routingStrategyTypes = [...]string{

--- a/control/runner.go
+++ b/control/runner.go
@@ -422,27 +422,19 @@ func (r *runner) handleUnsubscription(pType, pName string, pVersion int, taskID 
 		return errors.New("pool not found")
 	}
 	if pool.SubscriptionCount() < pool.Count() {
-		lp, err := r.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pType, pName, pVersion))
-		if lp != nil && lp.Details.Uri != nil {
-			if err != nil {
-				runnerLog.WithFields(log.Fields{
-					"_block":                  "handle-unsubscription",
-					"pool-count":              pool.Count(),
-					"pool-subscription-count": pool.SubscriptionCount(),
-					"plugin-name":             pName,
-					"plugin-version":          pVersion,
-					"plugin-type":             pType,
-					"error":                   err.Error(),
-				}).Error("unable to get loaded plugin")
-			}
+		_, err := r.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pType, pName, pVersion))
+		if err != nil {
 			runnerLog.WithFields(log.Fields{
-				"_block":     "handle-unsubscription",
-				"plugin-uri": lp.Details.Uri,
-			}).Debug(fmt.Sprintf("unsubscribe called on standalone plugin"))
-			pool.SelectAndStop(taskID, "remote unsubscription event")
-		} else {
-			pool.SelectAndKill(taskID, "unsubscription event")
+				"_block":                  "handle-unsubscription",
+				"pool-count":              pool.Count(),
+				"pool-subscription-count": pool.SubscriptionCount(),
+				"plugin-name":             pName,
+				"plugin-version":          pVersion,
+				"plugin-type":             pType,
+				"error":                   err.Error(),
+			}).Error("unable to get loaded plugin")
 		}
+		pool.SelectAndKill(taskID, "unsubscription event")
 	}
 	return nil
 }

--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -59,7 +59,6 @@ type Pool interface {
 	Plugins() MapAvailablePlugin
 	RLock()
 	RUnlock()
-	SelectAndStop(taskID, reason string)
 	SelectAndKill(taskID, reason string)
 	SelectAP(taskID string, configID map[string]ctypes.ConfigValue) (AvailablePlugin, serror.SnapError)
 	Strategy() RoutingAndCaching
@@ -181,7 +180,7 @@ func (p *pool) IncRestartCount() {
 
 // Insert inserts an AvailablePlugin into the pool
 func (p *pool) Insert(a AvailablePlugin) error {
-	if a.Type() != plugin.CollectorPluginType && a.Type() != plugin.ProcessorPluginType && a.Type() != plugin.PublisherPluginType {
+	if a.Type() != plugin.CollectorPluginType && a.Type() != plugin.ProcessorPluginType && a.Type() != plugin.PublisherPluginType && a.Type() != plugin.StreamCollectorPluginType {
 		return ErrBadType
 	}
 	// If an empty pool is created, it does not have
@@ -304,27 +303,6 @@ func (p *pool) KillAll(reason string) {
 		}
 		p.Kill(id, reason)
 	}
-}
-
-// SelectAndStop selects, stops and removes the available plugin from the pool
-func (p *pool) SelectAndStop(id, reason string) {
-	rp, err := p.Remove(p.plugins.Values(), id)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"_block": "SelectAndStop",
-			"taskID": id,
-			"reason": reason,
-		}).Error(err)
-		return
-	}
-	if err := rp.Stop(reason); err != nil {
-		log.WithFields(log.Fields{
-			"_block": "SelectAndStop",
-			"taskID": id,
-			"reason": reason,
-		}).Error(err)
-	}
-	p.remove(rp.ID())
 }
 
 // SelectAndKill selects, kills and removes the available plugin from the pool

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -35,6 +35,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/pkg/fileutils"
 )
 
@@ -48,9 +49,10 @@ type PluginType int
 
 func ToPluginType(name string) (PluginType, error) {
 	pts := map[string]PluginType{
-		"collector": 0,
-		"processor": 1,
-		"publisher": 2,
+		"collector":           0,
+		"processor":           1,
+		"publisher":           2,
+		"streaming-collector": 3,
 	}
 	t, ok := pts[name]
 	if !ok {
@@ -64,6 +66,7 @@ func CheckPluginType(id PluginType) bool {
 		0: "collector",
 		1: "processor",
 		2: "publisher",
+		3: "streaming-collector",
 	}
 
 	_, ok := pts[id]
@@ -86,6 +89,7 @@ func (pt PluginType) String() string {
 		"collector",
 		"processor",
 		"publisher",
+		"streaming-collector",
 	}[pt]
 }
 
@@ -94,6 +98,7 @@ const (
 	CollectorPluginType PluginType = iota
 	ProcessorPluginType
 	PublisherPluginType
+	StreamingCollectorPluginType
 )
 
 type AvailablePlugin interface {
@@ -124,6 +129,8 @@ type SubscribedPlugin interface {
 	Plugin
 	Config() *cdata.ConfigDataNode
 }
+
+type SubscribedPluginAssert func(plugins []SubscribedPlugin) serror.SnapError
 
 type RequestedPlugin struct {
 	path        string

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 14712d189ae570ecb1e287d5a11120347c831b9b4bb6b2265eecb53acf52dc9d
-updated: 2017-03-03T11:55:17.822848886-08:00
+updated: 2017-05-18T11:52:57.349827646-07:00
 imports:
 - name: github.com/appc/spec
   version: ba99d6b8ccbbed2942e53eb5395fddae113cdf8e
@@ -12,11 +12,11 @@ imports:
   - schema/types
   - schema/types/resource
 - name: github.com/armon/go-metrics
-  version: 3df31a1ada83e310c2e24b267c8e8b68836547b4
+  version: 93f237eba9b0602f3e73710416558854a81d9337
 - name: github.com/asaskevich/govalidator
   version: 9699ab6b38bee2e02cd3fe8b99ecf67665395c96
 - name: github.com/coreos/go-semver
-  version: 6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa
+  version: 294930c1e79c64e7dbe360054274fdad492c8cf5
   subpackages:
   - semver
 - name: github.com/ghodss/yaml
@@ -34,12 +34,12 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: db68f6fda248706a71980abc58e969fcd63f5ea6
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 3527311f5c8e6fe9b55fc1f44e1b515a30845e18
+  version: d1d32a057c0c23169796016876ce89634b2c012f
   subpackages:
   - v1/plugin
   - v1/plugin/rpc
 - name: github.com/intelsdi-x/snap-plugin-utilities
-  version: 925bafffac36edcfaf4aff937dcb7d3d5659782d
+  version: 3c37e3965f3fc2f24714779d3bae7ba7032b87a9
   subpackages:
   - str
 - name: github.com/julienschmidt/httprouter
@@ -49,7 +49,7 @@ imports:
 - name: github.com/robfig/cron
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/rs/cors
-  version: a62a804a8a009876ca59105f7899938a1349f4b3
+  version: 2d7dd2a10331137ae3f931ba08c21fd00cbf208d
 - name: github.com/rs/xhandler
   version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
 - name: github.com/Sirupsen/logrus
@@ -63,7 +63,7 @@ imports:
 - name: github.com/vrischmann/jsonutil
   version: 694784f9315ee9fc763c1d30f28753cba21307aa
 - name: github.com/xeipuuv/gojsonpointer
-  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
+  version: 6fe8760cad3569743d51ddbb243b26f8456742dc
 - name: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - name: github.com/xeipuuv/gojsonschema
@@ -93,7 +93,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
+  version: e62c3de784db939836898e5c19ffd41bece347da
   subpackages:
   - unix
 - name: google.golang.org/grpc

--- a/grpc/controlproxy/controlproxy.go
+++ b/grpc/controlproxy/controlproxy.go
@@ -146,7 +146,7 @@ func (c ControlProxy) StreamMetrics(
 	}
 }
 
-func (c ControlProxy) ValidateDeps(mts []core.RequestedMetric, plugins []core.SubscribedPlugin, _ *cdata.ConfigDataTree) []serror.SnapError {
+func (c ControlProxy) ValidateDeps(mts []core.RequestedMetric, plugins []core.SubscribedPlugin, _ *cdata.ConfigDataTree, _ ...core.SubscribedPluginAssert) []serror.SnapError {
 	// The configDataTree is kept so that we can match the interface provided by control
 	// we do not need it here though since the configDataTree is only used for metrics
 	// and we do not allow remote collection.

--- a/scheduler/scheduler_medium_test.go
+++ b/scheduler/scheduler_medium_test.go
@@ -63,7 +63,7 @@ func (m *mockMetricManager) ProcessMetrics([]core.Metric, map[string]ctypes.Conf
 	return nil, nil
 }
 
-func (m *mockMetricManager) ValidateDeps(mts []core.RequestedMetric, prs []core.SubscribedPlugin, ctree *cdata.ConfigDataTree) []serror.SnapError {
+func (m *mockMetricManager) ValidateDeps(mts []core.RequestedMetric, prs []core.SubscribedPlugin, ctree *cdata.ConfigDataTree, asserts ...core.SubscribedPluginAssert) []serror.SnapError {
 	if m.failValidatingMetrics {
 		return []serror.SnapError{
 			serror.New(errors.New("metric validation error")),

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -62,7 +62,7 @@ func (m *mockMetricManager) PublishMetrics([]core.Metric, map[string]ctypes.Conf
 func (m *mockMetricManager) ProcessMetrics([]core.Metric, map[string]ctypes.ConfigValue, string, string, int) ([]core.Metric, []error) {
 	return nil, nil
 }
-func (m *mockMetricManager) ValidateDeps(mts []core.RequestedMetric, prs []core.SubscribedPlugin, cdt *cdata.ConfigDataTree) []serror.SnapError {
+func (m *mockMetricManager) ValidateDeps(mts []core.RequestedMetric, prs []core.SubscribedPlugin, cdt *cdata.ConfigDataTree, asserts ...core.SubscribedPluginAssert) []serror.SnapError {
 	if m.failValidatingMetrics {
 		return []serror.SnapError{
 			serror.New(errors.New("metric validation error")),

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -308,6 +308,9 @@ func (t *task) stream() {
 				t.state = core.TaskStopped
 				t.Unlock()
 				done = true
+				event := new(scheduler_event.TaskStoppedEvent)
+				event.TaskID = t.id
+				defer t.eventEmitter.Emit(event)
 				return
 			case mts, ok := <-metricsChan:
 				if !ok {

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -134,7 +134,7 @@ func TestTask(t *testing.T) {
 			task.Spin()
 			err = task.Enable()
 			So(err, ShouldNotBeNil)
-			So(task.State(), ShouldEqual, core.TaskSpinning)
+			So(task.State(), ShouldBeIn, []core.TaskState{core.TaskSpinning, core.TaskFiring})
 		})
 
 		Convey("Enable a disabled task", func() {


### PR DESCRIPTION
![img](https://cloud.githubusercontent.com/assets/862968/26699028/1bdc9fde-46cd-11e7-9c5c-e82360c18fcb.gif)
The docker-compose file and task used in this demo can be found [here](https://gist.github.com/jcooklin/5d81a20b852dec2c2e9250030bf7ba68).  

Related:
* PRs
  * https://github.com/intelsdi-x/snap-relay/pull/3
  * https://github.com/intelsdi-x/snap-plugin-lib-go/pull/85
* Issues
  * https://github.com/intelsdi-x/snap/issues/1631 - StreamCollector - active after task stop or remove
  * https://github.com/intelsdi-x/snap/issues/1587 - Plugin Wanted: Graphite Streaming Collector

@intelsdi-x/snap-maintainers