### PR TITLE
Adds stand-alone plugin testing

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -589,11 +589,6 @@ func (p *pluginControl) verifySignature(rp *core.RequestedPlugin) (bool, serror.
 }
 
 func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDetails, serror.SnapError) {
-	if rp.Uri() != nil {
-		return &pluginDetails{
-			Uri: rp.Uri(),
-		}, nil
-	}
 	details := &pluginDetails{}
 	var serr serror.SnapError
 	//Check plugin signing
@@ -609,8 +604,11 @@ func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDe
 	details.KeyPath = rp.KeyPath()
 	details.CACertPaths = rp.CACertPaths()
 	details.TLSEnabled = rp.TLSEnabled()
+	details.Uri = rp.Uri()
 
-	if filepath.Ext(rp.Path()) == ".aci" {
+	if rp.Uri() != nil {
+		// Is a standalone plugin
+	} else if filepath.Ext(rp.Path()) == ".aci" {
 		f, err := os.Open(rp.Path())
 		if err != nil {
 			return nil, serror.New(err)

--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -40,6 +40,10 @@ var (
 
 	PluginNameStreamRand1 = "snap-plugin-stream-collector-rand1"
 	PluginPathStreamRand1 = helper.PluginFilePath(PluginNameStreamRand1)
+
+	PluginNameMock2Grpc = "snap-plugin-collector-mock2-grpc"
+	PluginPathMock2Grpc = helper.PluginFilePath(PluginNameMock2Grpc)
+	PluginUriMock2Grpc  = "http://127.0.0.1:8183"
 )
 
 // mocks a metric type

--- a/glide.lock
+++ b/glide.lock
@@ -34,7 +34,7 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: db68f6fda248706a71980abc58e969fcd63f5ea6
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 3527311f5c8e6fe9b55fc1f44e1b515a30845e18
+  version: d1d32a057c0c23169796016876ce89634b2c012f
   subpackages:
   - v1/plugin
   - v1/plugin/rpc

--- a/mgmt/rest/v1/plugin.go
+++ b/mgmt/rest/v1/plugin.go
@@ -80,7 +80,6 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 		var certPath string
 		var keyPath string
 		var caCertPaths string
-		os.Stdout.WriteString("TEST 2\n")
 
 		var signature []byte
 		var checkSum [sha256.Size]byte


### PR DESCRIPTION
Fixes #

Summary of changes:
- Adds testing support for standalone plugin
-- Needs standalone plugin added to mock plugins build
- Added fixture filename, path, uri to test standalone plugin
- Added asserts to plugin_manager_test and control_test; reviewing source for additional testing
- Minor updates to standalone plugin identified while incorporating tests

Testing done:
- Verified asserts passed in added tests

@intelsdi-x/snap-maintainers