### PR TITLE
Made Snap work with go-swagger only

### DIFF
--- a/mgmt/rest/v2/config.go
+++ b/mgmt/rest/v2/config.go
@@ -50,7 +50,7 @@ type PluginConfigResponse struct {
 //swagger:parameters setPluginConfigItem
 type PluginConfigParam struct {
 	// in: body
-	Config string `json:"config"`
+	Config map[string]interface{} `json:"config"`
 }
 
 // PluginConfigDeleteParams defines parameters for deleting a config.
@@ -69,7 +69,7 @@ type PluginConfigDeleteParams struct {
 	PType string `json:"ptype"`
 	// in: body
 	// required: true
-	Config string `json:"config"`
+	Config []string `json:"config"`
 }
 
 func (s *apiV2) getPluginConfigItem(w http.ResponseWriter, r *http.Request, p httprouter.Params) {

--- a/mgmt/rest/v2/task.go
+++ b/mgmt/rest/v2/task.go
@@ -81,7 +81,7 @@ type TaskPostParams struct {
 	// in: body
 	//
 	// required: true
-	Task string `json:"task"yaml:"task"`
+	Task Task `json:"task"yaml:"task"`
 }
 
 // TaskPutParams defines a task state

--- a/swagger.json
+++ b/swagger.json
@@ -359,7 +359,10 @@
             "name": "config",
             "in": "body",
             "schema": {
-              "type": "string"
+              "type": "object",
+              "additionalProperties": {
+                "type": "object"
+              }
             }
           },
           {
@@ -450,7 +453,10 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -510,7 +516,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "string"
+              "$ref": "#/definitions/Task"
             }
           }
         ],


### PR DESCRIPTION
Fixes #1600 - Go Swagger generated client does not work with Snap perfectly

Summary of changes:
- Changed set/delete config definition
- Changed create task definition


Testing done:
- small, medium and legacy

@intelsdi-x/snap-maintainers
