### PR TITLE
Added deprecation tags to v1 functions; added deprecation comments

### DIFF
--- a/docs/REST_API.md
+++ b/docs/REST_API.md
@@ -1,4 +1,7 @@
-# Snap API
+ # Rest API v1 is being deprecated; update to [API v2](https://github.com/intelsdi-x/snap-client-go). 
+ Find more information here: https://github.com/intelsdi-x/snap/issues/1637
+ 
+ # Snap API
 Snap exposes a list of RESTful APIs to perform various actions. All of Snap's API requests return `JSON`-formatted responses, including errors. Any non-2xx HTTP status code may contain an error message. All API URLs listed in this documentation have the endpoint:
 > http://localhost:8181
 

--- a/mgmt/rest/log_handler.go
+++ b/mgmt/rest/log_handler.go
@@ -52,4 +52,12 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		"status-code": res.Status(),
 		"status":      http.StatusText(res.Status()),
 	}).Debug("API response")
+
+	if deprecationInfo := rw.Header().Get("Deprecated"); len(deprecationInfo) != 0 {
+		restLogger.WithFields(log.Fields{
+			"method": r.Method,
+			"url":    r.URL.Path,
+		}).Warning(deprecationInfo)
+	}
+
 }

--- a/mgmt/rest/v1/api.go
+++ b/mgmt/rest/v1/api.go
@@ -39,6 +39,8 @@ func New(wg *sync.WaitGroup, killChan chan struct{}, protocol string) *apiV1 {
 	return &apiV1{wg: wg, killChan: killChan}
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) GetRoutes() []api.Route {
 	routes := []api.Route{
 		// plugin routes
@@ -82,18 +84,26 @@ func (s *apiV1) GetRoutes() []api.Route {
 	return routes
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) BindMetricManager(metricManager api.Metrics) {
 	s.metricManager = metricManager
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) BindTaskManager(taskManager api.Tasks) {
 	s.taskManager = taskManager
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) BindTribeManager(tribeManager api.Tribe) {
 	s.tribeManager = tribeManager
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) BindConfigManager(configManager api.Config) {
 	s.configManager = configManager
 }

--- a/mgmt/rest/v1/config.go
+++ b/mgmt/rest/v1/config.go
@@ -29,6 +29,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getPluginConfigItem(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	var err error
 	styp := p.ByName("type")
@@ -62,6 +64,8 @@ func (s *apiV1) getPluginConfigItem(w http.ResponseWriter, r *http.Request, p ht
 	rbody.Write(200, item, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) deletePluginConfigItem(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	var err error
 	var typ core.PluginType
@@ -104,6 +108,8 @@ func (s *apiV1) deletePluginConfigItem(w http.ResponseWriter, r *http.Request, p
 	rbody.Write(200, item, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) setPluginConfigItem(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	var err error
 	var typ core.PluginType

--- a/mgmt/rest/v1/metric.go
+++ b/mgmt/rest/v1/metric.go
@@ -33,6 +33,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getMetrics(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	ver := 0 // 0: get all metrics
 
@@ -75,6 +77,8 @@ func (s *apiV1) getMetrics(w http.ResponseWriter, r *http.Request, _ httprouter.
 	respondWithMetrics(r.Host, mts, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getMetricsFromTree(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	namespace := params.ByName("namespace")
 

--- a/mgmt/rest/v1/plugin.go
+++ b/mgmt/rest/v1/plugin.go
@@ -67,6 +67,8 @@ func (p *plugin) TypeName() string {
 	return p.pluginType
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	lp := &rbody.PluginsLoaded{}
 	lp.LoadedPlugins = make([]rbody.LoadedPlugin, 0)
@@ -80,8 +82,6 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 		var certPath string
 		var keyPath string
 		var caCertPaths string
-		os.Stdout.WriteString("TEST 2\n")
-
 		var signature []byte
 		var checkSum [sha256.Size]byte
 		mr := multipart.NewReader(r.Body, params["boundary"])
@@ -236,6 +236,8 @@ func (s *apiV1) loadPlugin(w http.ResponseWriter, r *http.Request, _ httprouter.
 	}
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) unloadPlugin(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	plName := p.ByName("name")
 	plType := p.ByName("type")
@@ -283,6 +285,8 @@ func (s *apiV1) unloadPlugin(w http.ResponseWriter, r *http.Request, p httproute
 	rbody.Write(200, pr, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getPlugins(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	var detail bool
 	for k := range r.URL.Query() {
@@ -372,6 +376,8 @@ func catalogedPluginToLoaded(host string, c core.CatalogedPlugin) rbody.LoadedPl
 	}
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getPlugin(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	plName := p.ByName("name")
 	plType := p.ByName("type")

--- a/mgmt/rest/v1/rbody/body.go
+++ b/mgmt/rest/v1/rbody/body.go
@@ -32,7 +32,7 @@ import (
 	"github.com/urfave/negroni"
 )
 
-const deprecationInfo = "The client API V1 has been depricated. Find more information here: https://github.com/intelsdi-x/snap/issues/1637"
+const deprecationInfo = "The client API V1 is being deprecated; switch to API v2. Find more information here: https://github.com/intelsdi-x/snap/issues/1637"
 
 type Body interface {
 	// These function names are rather verbose to avoid field vs function namespace collisions

--- a/mgmt/rest/v1/rbody/body.go
+++ b/mgmt/rest/v1/rbody/body.go
@@ -32,6 +32,8 @@ import (
 	"github.com/urfave/negroni"
 )
 
+const deprecationInfo = "The client API V1 has been depricated. Find more information here: https://github.com/intelsdi-x/snap/issues/1637"
+
 type Body interface {
 	// These function names are rather verbose to avoid field vs function namespace collisions
 	// with varied object types that use them.
@@ -40,7 +42,8 @@ type Body interface {
 }
 
 func Write(code int, b Body, w http.ResponseWriter) {
-	w.Header().Set("Deprecated", "true")
+	w.Header().Set("Deprecated", deprecationInfo)
+
 	resp := &APIResponse{
 		Meta: &APIResponseMeta{
 			Code:    code,

--- a/mgmt/rest/v1/task.go
+++ b/mgmt/rest/v1/task.go
@@ -44,6 +44,8 @@ var (
 	ErrWrongAction             = errors.New("Wrong action requested")
 )
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	task, err := core.CreateTaskFromContent(r.Body, nil, s.taskManager.CreateTask)
 	if err != nil {
@@ -55,6 +57,8 @@ func (s *apiV1) addTask(w http.ResponseWriter, r *http.Request, _ httprouter.Par
 	rbody.Write(201, taskB, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getTasks(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	sts := s.taskManager.GetTasks()
 
@@ -71,6 +75,8 @@ func (s *apiV1) getTasks(w http.ResponseWriter, r *http.Request, _ httprouter.Pa
 	rbody.Write(200, tasks, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	id := p.ByName("id")
 	t, err1 := s.taskManager.GetTask(id)
@@ -84,6 +90,8 @@ func (s *apiV1) getTask(w http.ResponseWriter, r *http.Request, p httprouter.Par
 	rbody.Write(200, task, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	s.wg.Add(1)
 	defer s.wg.Done()
@@ -190,6 +198,8 @@ func (s *apiV1) watchTask(w http.ResponseWriter, r *http.Request, p httprouter.P
 	}
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) startTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	id := p.ByName("id")
 	errs := s.taskManager.StartTask(id)
@@ -209,6 +219,8 @@ func (s *apiV1) startTask(w http.ResponseWriter, r *http.Request, p httprouter.P
 	rbody.Write(200, &rbody.ScheduledTaskStarted{ID: id}, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) stopTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	id := p.ByName("id")
 	errs := s.taskManager.StopTask(id)
@@ -223,6 +235,8 @@ func (s *apiV1) stopTask(w http.ResponseWriter, r *http.Request, p httprouter.Pa
 	rbody.Write(200, &rbody.ScheduledTaskStopped{ID: id}, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) removeTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	id := p.ByName("id")
 	err := s.taskManager.RemoveTask(id)
@@ -237,6 +251,8 @@ func (s *apiV1) removeTask(w http.ResponseWriter, r *http.Request, p httprouter.
 	rbody.Write(200, &rbody.ScheduledTaskRemoved{ID: id}, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 //enableTask changes the task state from Disabled to Stopped
 func (s *apiV1) enableTask(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	id := p.ByName("id")

--- a/mgmt/rest/v1/tribe.go
+++ b/mgmt/rest/v1/tribe.go
@@ -42,12 +42,16 @@ var (
 	ErrMemberNotFound        = errors.New("Member not found")
 )
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getAgreements(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	res := &rbody.TribeListAgreement{}
 	res.Agreements = s.tribeManager.GetAgreements()
 	rbody.Write(200, res, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getAgreement(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "getAgreement")
 	name := p.ByName("name")
@@ -70,6 +74,8 @@ func (s *apiV1) getAgreement(w http.ResponseWriter, r *http.Request, p httproute
 	rbody.Write(200, a, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) deleteAgreement(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "deleteAgreement")
 	name := p.ByName("name")
@@ -95,6 +101,8 @@ func (s *apiV1) deleteAgreement(w http.ResponseWriter, r *http.Request, p httpro
 	rbody.Write(200, a, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) joinAgreement(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "joinAgreement")
 	name := p.ByName("name")
@@ -140,6 +148,8 @@ func (s *apiV1) joinAgreement(w http.ResponseWriter, r *http.Request, p httprout
 
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) leaveAgreement(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "leaveAgreement")
 	name := p.ByName("name")
@@ -184,11 +194,15 @@ func (s *apiV1) leaveAgreement(w http.ResponseWriter, r *http.Request, p httprou
 	rbody.Write(200, &rbody.TribeLeaveAgreement{Agreement: agreement}, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getMembers(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	members := s.tribeManager.GetMembers()
 	rbody.Write(200, &rbody.TribeMemberList{Members: members}, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) getMember(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "getMember")
 	name := p.ByName("name")
@@ -216,6 +230,8 @@ func (s *apiV1) getMember(w http.ResponseWriter, r *http.Request, p httprouter.P
 	rbody.Write(200, resp, w)
 }
 
+// Deprecated: Update to apiV2(https://github.com/intelsdi-x/snap-client-go).
+// Find more information here: https://github.com/intelsdi-x/snap/issues/1637
 func (s *apiV1) addAgreement(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	tribeLogger = tribeLogger.WithField("_block", "addAgreement")
 	b, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
Fixes #

Summary of changes:
- Added support to log_handle to check if client has been deprecated
- Added comments to v1 source to indicate deprecated API with link to Github issue and v2 repo
- Created issue [1637](https://github.com/intelsdi-x/snap/issues/1637) to address deprecated API additional information

Testing done:
- Verified that snapteld printed the deprecated API info to the debug log 

@intelsdi-x/snap-maintainers