### PR TITLE
Removes make swagger from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ default:
 	$(MAKE) deps
 	$(MAKE) snap
 	$(MAKE) plugins
-	$(MAKE) swagger
 deps:
 	bash -c "./scripts/deps.sh"
 test:
@@ -60,5 +59,3 @@ install:
 	cp build/$(OS)/$(ARCH)/snaptel /usr/local/bin/
 proto:
 	cd `echo $(GOPATH) | cut -d: -f 1`; bash -c "./src/github.com/intelsdi-x/snap/scripts/gen-proto.sh"
-swagger:
-	bash -c "./scripts/swagger.sh"


### PR DESCRIPTION
Related to https://github.com/intelsdi-x/snap/issues/1639

### Summary of changes:
- removed `make swagger` from Makefile

### Reasoning:
 - to allow to make snap from sources ASAP
 - to allow build tests passing
 - to unblock merging existing pull requests (PRs cannot be merged if tests fail)

cc: @candysmurf 

@intelsdi-x/snap-maintainers
