### PR TITLE
Added default config file - snapteld.conf

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -1,0 +1,32 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+This directory contains examplary global configuration files for Snap:
+
+* [snapteld.conf](./snapteld.conf), default global config file easy to customize (uncomment needed parameters and adjust their values)
+* [snap-config-sample.yaml](./snap-config-sample.yaml), a sample of global config file in YAML format
+* [snap-config-sample.json](./snap-config-sample.json), a sample of global config file in JSON format
+
+* [snaptel-config-sample.json](./snaptel-config-sample.json), snaptel config file. **Notice, it is deprecated and using that is not recommended.**
+
+Read more about [snapteld configuration file](https://github.com/intelsdi-x/snap/blob/master/docs/SNAPTELD_CONFIGURATION.md#snapteld-configuration-file).
+
+ 
+
+

--- a/examples/configs/snapteld.conf
+++ b/examples/configs/snapteld.conf
@@ -1,66 +1,65 @@
 ---
 #
 # ** Notice **
-# This file is a config file template to present all possible config parameters to customize.
-# Before you use this config file, please adjust it to your use case.
+# This is a default snapteld config file.
+# Before you use this, please uncomment parameter that you need
+# and adjust its value to your use case.
 #
-
 # log_level for the snap daemon. Supported values are
 # 1 - Debug, 2 - Info, 3 - Warning, 4 - Error, 5 - Fatal.
 # Default value is 3.
-log_level: 2
+# log_level: 1
 
 # log_path sets the path for logs for the snap daemon. By
 # default snapteld prints all logs to stdout. Any provided
 # path will send snapteld logs to a file called snapteld.log in
-# the provided directory. By default log path is empty
-# and snapteld logs to stdout.
-log_path: /var/log/snap
+# the provided directory.
+# log_path: /var/log/snap
 
 # log_truncate specifies how the log file with be opened
 # false => append (default)
 # true  => truncate
-log_truncate: false
+# log_truncate: false
 
 # log_colors specifies if log file output is colorified
 # false => no colors (default)
 # true  => colors
-log_colors: true
+# log_colors: true
 
 # Gomaxprocs sets the number of cores to use on the system
 # for snapteld to use. Default for gomaxprocs is 1
-gomaxprocs: 2
+# gomaxprocs: 1
 
 # Control sections for configuration settings for the plugin
 # control module of snapteld.
 control:
   # auto_discover_path sets the directory(s) to auto load plugins and tasks on
-  # the start of the snap daemon. This can be a colon separated list of directories.
-  auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
+  # the start of the snap daemon. This can be a comma separated list of directories.
+  # auto_discover_path: /opt/snap/plugins:/opt/snap/tasks
 
   # cache_expiration sets the time interval for the plugin cache to use before
   # expiring collection results from collect plugins. Default value is 500ms
-  cache_expiration: 750ms
+  # cache_expiration: 500ms
 
   # listen_addr is the bind address for the control rpc server. Default address
   # is 127.0.0.1
-  listen_addr: 0.0.0.0
+  # listen_addr: 127.0.0.1
 
   # listen_port is the bind port for the control rpc server. Default port is
   # 8082.
-  listen_port: 10082
+  # listen_port: 8082
 
   # max_running_plugins sets the size of the available plugin pool for each
   # plugin loaded in the system. Default value is 3
-  max_running_plugins: 1
+  # max_running_plugins: 3
 
   # plugin_load_timeout sets the maximal time allowed for a plugin to load
   # Default value is 3
-  plugin_load_timeout: 10
+  # plugin_load_timeout: 3
 
   # keyring_paths sets the directory(s) to search for keyring files for signed
   # plugins. This can be a comma separated list of directories
-  keyring_paths: /etc/snap/keyrings
+  # keyring_paths: /etc/snap/keyrings
 
   # plugin_trust_level sets the plugin trust level for snapteld. The default state
   # for plugin trust level is enabled (1). When enabled, only signed plugins that can
@@ -73,124 +72,68 @@ control:
   plugin_trust_level: 0
 
   # temp_dir_path sets the temporary directory which houses the temporary files
-  temp_dir_path: /tmp
+  # temp_dir_path: /tmp
 
   # max_plugin_restarts controls how many times a plugin is allowed to be restarted before failing.
   # By default it is 10 times. Snap will not disable a plugin due to failures when this value is -1.
-  max_plugin_restarts: 10
-
-  # Secure plugin communication optional parameters:
-  # tls_cert_path sets the TLS certificate path to enable secure plugin communication
-  # and authenticate itself to plugins. Requires also: tls_key_path.
-  tls_cert_path: /tmp/snaptest-cli.crt
-  # tls_key_path sets the TLS key path to enable secure plugin communication and
-  # authenticate itself to plugins. Requires also: tls_cert_path.
-  tls_key_path: /tmp/snaptest-cli.key
-  # ca_cert_paths sets the list of filesystem paths (files/directories) to CA certificates
-  # for use in validating
-  ca_cert_paths: /tmp/small-setup-ca.crt:/tmp/medium-setup-ca.crt:/tmp/ca-certs/
+  # max_plugin_restarts: 10
 
   # plugins section contains plugin config settings that will be applied for
   # plugins across tasks.
-  plugins:
-    all:
-      password: p@ssw0rd
-    collector:
-      all:
-        user: jane
-      pcm:
-        all:
-          path: /usr/local/pcm/bin
-        versions:
-          1:
-            user: john
-            someint: 1234
-            somefloat: 3.14
-            somebool: true
-      psutil:
-        all:
-          path: /usr/local/bin/psutil
-    publisher:
-      influxdb:
-        all:
-          server: xyz.local
-          password: password
-    processor:
-      movingaverage:
-        all:
-          user: jane
-        versions:
-          1:
-            user: tiffany
-            password: new password
-
-  # tags section contains global tags that will be applied on collected metrics
-  # across tasks.
-  tags:
-    /intel/psutil:
-      datacenter: rennes
-    # tags all metrics
-    /:
-      country: france
+  # plugins:
 
 # scheduler configuration settings contains all settings for scheduler
 # module
-scheduler:
+# scheduler:
   # work_manager_queue_size sets the size of the worker queue inside snapteld scheduler.
   # Default value is 25.
-  work_manager_queue_size: 10
+  # work_manager_queue_size: 25
 
   # work_manager_pool_size sets the size of the worker pool inside snapteld scheduler.
   # Default value is 4.
-  work_manager_pool_size: 2
+  # work_manager_pool_size: 4
 
 # rest sections contains all the configuration items for the REST API server.
-restapi:
+# restapi:
   # enable controls enabling or disabling the REST API for snapteld. Default value is enabled.
-  enable: true
+  # enable: true
 
   # https enables HTTPS for the REST API. If no default certificate and key are provided, then
   # the REST API will generate a private and public key to use for communication. Default
   # value is false
-  https: true
+  # https: false
 
   # rest_auth enables authentication for the REST API. Default value is false
-  rest_auth: true
+  # rest_auth: false
 
   # rest_auth_password sets the password to use for the REST API. Currently user and password
   # combinations are not supported.
-  rest_auth_password: changeme
+  # rest_auth_password: changeme
 
   # rest_certificate is the path to the certificate to use for REST API when HTTPS is also enabled.
-  rest_certificate: /etc/snap/cert.pem
+  # rest_certificate: /etc/snap/cert.pem
 
   # rest_key is the path to the private key for the certificate in use by the REST API
   # when HTTPs is enabled.
-  rest_key: /etc/snap/cert.key
+  # rest_key: /etc/snap/cert.key
 
   # port sets the port to start the REST API server on. Default is 8181
-  port: 8282
-
-  # REST API in address[:port] format to bind to/listen on. Default is an empty string => listen on all interfaces
-  addr: 127.0.0.1:12345
-
-  # corsd sets the cors allowed domains in a comma separated list. It is the same origin if it's empty.
-  allowed_origins: http://127.0.0.1:88888, https://snap-telemetry.io
+  # port: 8181
 
 # tribe section contains all configuration items for the tribe module
-tribe:
+# tribe:
   # enable controls enabling tribe for the snapteld instance. Default value is false.
-  enable: true
+  # enable: false
 
   # bind_addr sets the IP address for tribe to bind.
-  bind_addr: 127.0.0.1
+  # bind_addr: 127.0.0.1
 
   # bind_port sets the port for tribe to listen on. Default value is 6000
-  bind_port: 16000
+  # bind_port: 6000
 
   # name sets the name to use for this snapteld instance in the tribe
-  # membership. Default value is hostname of the system.
-  name: localhost
+  # membership. Default value defaults to local hostname of the system.
+  # name: localhost
 
   # seed sets the snapteld instance to use as the seed for tribe communications
-  seed: 1.1.1.1:16000
+  # seed: localhost:6000


### PR DESCRIPTION
Related to #1421

Addressing @katarzyna-z's idea:
> What do you thing about creating config file with default values to give users the possibility to modify just several parameters in config file? Sometime is easier to use the config file instead of several arguments from command line.

Summary of changes:
-  added default config (snapteld.conf) -  it's exactly the same as we use use to package snap (RPM/Deb) available here: https://github.com/intelsdi-x/snap-packaging/blob/master/support/snapteld.conf
- added README - please provide feedback especially on that, because I am not really sure if the README is needed here or not


cc: @katarzyna-z 
