### PR TITLE
Add automatic Swagger installation with go get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ go:
 before_install:
 - bash scripts/gitcookie.sh
 - go get github.com/smartystreets/goconvey/convey
-- curl -LO https://github.com/go-swagger/go-swagger/releases/download/0.10.0/swagger_linux_amd64
-- chmod +x swagger_linux_amd64 && sudo mv swagger_linux_amd64 /usr/bin/swagger
 - if [ ! -d $SNAP_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_SOURCE; fi # CI for forks not from intelsdi-x
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -84,17 +84,23 @@ The key features of Snap are:
 
 ### System Requirements
 
-Snap needs Swagger ([http://swagger.io](http://swagger.io)) installed to generate Swagger spec file during build process.
+Snap needs [Swagger for Go](https://github.com/go-swagger/go-swagger)  installed to update OpenAPI specification file after successfull build. Swagger will be installed automatically during build process (`make` or `make deps`).
 
-To install Swagger:
+#### To install Swagger manually
+
+Using `go get` (recommended):
+```sh
+go get -u github.com/go-swagger/go-swagger/cmd/swagger
+```
+
+From Debian package:
 ```sh
 echo "deb https://dl.bintray.com/go-swagger/goswagger-debian ubuntu main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get install swagger
 ```
 
-or from GitHub release:
-
+From GitHub release:
 ```sh
 curl -LO https://github.com/go-swagger/go-swagger/releases/download/0.10.0/swagger_linux_amd64
 chmod +x swagger_linux_amd64 && sudo mv swagger_linux_amd64 /usr/bin/swagger

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -29,6 +29,9 @@ __proj_dir="$(dirname "$__dir")"
 
 _go_path
 
+_info "Installing Swagger..."
+_go_get github.com/go-swagger/go-swagger/cmd/swagger
+_info "Installing Glide..."
 _go_get github.com/Masterminds/glide
 
 _debug "$(glide --version)"

--- a/scripts/swagger.sh
+++ b/scripts/swagger.sh
@@ -18,6 +18,14 @@
 #limitations under the License.
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${__dir}/common.sh"
 
+if ! type swagger 2> /dev/null; then
+    _error "No Swagger found. Your API specification might be out-of-date. Please run 'make deps' to install all dependencies. For more info, see https://github.com/intelsdi-x/snap#system-requirements"
+fi
+
+_info "Updating API specification file..."
 swagger generate spec -o ${__dir}/../swagger.json
+_info "Validating API specification file..."
 swagger validate ${__dir}/../swagger.json
+


### PR DESCRIPTION
Fixes #1655 

Summary of changes:
- Replace downloading swagger binary with `go get`

Testing done:
- Manual testing with and without swagger binary

@intelsdi-x/snap-maintainers
