### PR TITLE
Added RDT collector to plugin catalog

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -110,3 +110,4 @@
 - intelsdi-x/snap-plugin-collector-influxdb-data
 - hstack/snap-plugin-publisher-prometheus
 - intelsdi-x/snap-plugin-collector-diamond
+- intelsdi-x/snap-plugin-collector-rdt


### PR DESCRIPTION
Summary of changes:
- Added RDT collector to plugin catalog

@intelsdi-x/snap-maintainers
