### PR TITLE
fixed #1669: Remove env var SNAP_REST_PASSWORD

### DIFF
--- a/cmd/snaptel/flags.go
+++ b/cmd/snaptel/flags.go
@@ -50,9 +50,8 @@ var (
 		Usage: "Shows running plugins",
 	}
 	flPassword = cli.BoolFlag{
-		Name:   "password, p",
-		Usage:  "Require password for REST API authentication",
-		EnvVar: "SNAP_REST_PASSWORD",
+		Name:  "password, p",
+		Usage: "Require password for REST API authentication, e.g. snaptel -p plugin list",
 	}
 	flConfig = cli.StringFlag{
 		Name:   "config, c",


### PR DESCRIPTION
Fixes #1669 

Summary of changes:
- removed the env var SNAP_REST_PASSWORD

Testing done:
- all

@intelsdi-x/snap-maintainers
