### PR TITLE
Added checking the value of set `password` flag

### DIFF
--- a/cmd/snaptel/main.go
+++ b/cmd/snaptel/main.go
@@ -122,7 +122,7 @@ func checkTribeCommand(ctx *cli.Context) error {
 // Checks for authentication flags and returns a username/password
 // from the specified settings
 func checkForAuth(ctx *cli.Context) (username, password string) {
-	if ctx.IsSet("password") {
+	if ctx.Bool("password") {
 		username = "snap" // for now since username is unused but needs to exist for basicAuth
 		// Prompt for password
 		fmt.Print("Password:")
@@ -143,6 +143,7 @@ func checkForAuth(ctx *cli.Context) (username, password string) {
 			fmt.Println(err)
 		}
 		if cfg.RestAPI.Password != nil {
+			// use password declared in config file
 			password = *cfg.RestAPI.Password
 		} else {
 			fmt.Println("Error config password field 'rest-auth-pwd' is empty")


### PR DESCRIPTION
Related to #1669 

### Summary of changes:
 - Added checking the value of set `password` flag, expressed by usage `-p` or `SNAP_REST_PASSWORD` env var

### Before:
- there was only checking if `SNAP_REST_PASSWORD` is set or not, the set value was not checked

### After:
- `SNAP_REST_PASSWORD` sets to true means that user will be asked to provide a password
- `SNAP_REST_PASSWORD` sets to false means that user won't be asked to provide a password. However, if rest-auth is required by snap daemon, the password must be provided in snaptel config file.


### How to check it:
In one terminal:
```
$ snapteld -l 1 -t 0 --rest-auth
```

In another terminal:
**case 1:** use flag `-p` to be prompted for password
```
$ snaptel -p plugin list
Password:
```
**case 2:** set env variable to true to be prompted for password
```
$ export SNAP_REST_PASSWORD=true
$ snaptel plugin list
Password:
```
**case 3a:** set env variable to false without providing any credentials
```
$ export SNAP_REST_PASSWORD=false
$ snaptel plugin list
Error: Invalid credentials
```
No prompt for providing a password which is required by snap daemon, so getting error here is expected.

**case 3b:** set env variable to false with credential in config file
```
$ export SNAP_REST_PASSWORD=false
$ snaptel -c ./examples/configs/snaptel-config-sample.json plugin list
No plugins found. Have you loaded a plugin?
```

@intelsdi-x/snap-maintainers
