### PR TITLE
Block unloading plugin which is used in a running task

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -555,7 +555,7 @@ func (ap *availablePlugins) streamMetrics(
 }
 
 func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) []error {
-	key := strings.Join([]string{plugin.PublisherPluginType.String(), pluginName, strconv.Itoa(pluginVersion)}, core.Separator)
+	key := fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", plugin.PublisherPluginType.String(), pluginName, pluginVersion)
 	pool, serr := ap.getPool(key)
 	if serr != nil {
 		return []error{serr}
@@ -588,7 +588,7 @@ func (ap *availablePlugins) publishMetrics(metrics []core.Metric, pluginName str
 
 func (ap *availablePlugins) processMetrics(metrics []core.Metric, pluginName string, pluginVersion int, config map[string]ctypes.ConfigValue, taskID string) ([]core.Metric, []error) {
 	var errs []error
-	key := strings.Join([]string{plugin.ProcessorPluginType.String(), pluginName, strconv.Itoa(pluginVersion)}, core.Separator)
+	key := fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", plugin.ProcessorPluginType.String(), pluginName, pluginVersion)
 	pool, serr := ap.getPool(key)
 	if serr != nil {
 		errs = append(errs, serr)

--- a/control/control.go
+++ b/control/control.go
@@ -146,6 +146,7 @@ type catalogsMetrics interface {
 	Subscribe([]string, int) error
 	Unsubscribe([]string, int) error
 	GetPlugin(core.Namespace, int) (core.CatalogedPlugin, error)
+	GetPlugins(core.Namespace) ([]core.CatalogedPlugin, error)
 }
 
 type managesSigning interface {
@@ -637,8 +638,34 @@ func (p *pluginControl) returnPluginDetails(rp *core.RequestedPlugin) (*pluginDe
 }
 
 func (p *pluginControl) Unload(pl core.Plugin) (core.CatalogedPlugin, serror.SnapError) {
-	up, err := p.pluginManager.UnloadPlugin(pl)
+	up, err := p.pluginManager.get(fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", pl.TypeName(), pl.Name(), pl.Version()))
 	if err != nil {
+		se := serror.New(ErrPluginNotFound, map[string]interface{}{
+			"plugin-name":    pl.Name(),
+			"plugin-version": pl.Version(),
+			"plugin-type":    pl.TypeName(),
+		})
+		return nil, se
+	}
+
+	if errs := p.subscriptionGroups.validatePluginUnloading(up); errs != nil {
+		impactOnTasks := []string{}
+		for _, err := range errs {
+			taskId := err.Fields()["task-id"].(string)
+			impactOnTasks = append(impactOnTasks, taskId)
+		}
+		se := serror.New(errorPluginCannotBeUnloaded(impactOnTasks), map[string]interface{}{
+			"plugin-name":    pl.Name(),
+			"plugin-version": pl.Version(),
+			"plugin-type":    pl.TypeName(),
+			"impacted-tasks": impactOnTasks,
+		})
+		return nil, se
+	}
+
+	// unload the plugin means removing it from plugin catalog
+	// and, for collector plugins, removing its metrics from metric catalog
+	if _, err := p.pluginManager.UnloadPlugin(pl); err != nil {
 		return nil, err
 	}
 
@@ -685,7 +712,6 @@ func (p *pluginControl) SwapPlugins(in *core.RequestedPlugin, out core.Cataloged
 		}
 		return serr
 	}
-
 	up, err := p.pluginManager.UnloadPlugin(out)
 	if err != nil {
 		_, err2 := p.pluginManager.UnloadPlugin(lp)
@@ -941,6 +967,10 @@ func (p *pluginControl) GetMetricVersions(ns core.Namespace) ([]core.CatalogedMe
 		rmts[i] = m
 	}
 	return rmts, nil
+}
+
+func (p *pluginControl) GetPlugins(ns core.Namespace) ([]core.CatalogedPlugin, error) {
+	return p.metricCatalog.GetPlugins(ns)
 }
 
 func (p *pluginControl) MetricExists(mns core.Namespace, ver int) bool {

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -763,6 +763,10 @@ func (m *mc) GetPlugin(core.Namespace, int) (core.CatalogedPlugin, error) {
 	return nil, nil
 }
 
+func (m *mc) GetPlugins(core.Namespace) ([]core.CatalogedPlugin, error) {
+	return nil, nil
+}
+
 func (m *mc) GetVersions(core.Namespace) ([]*metricType, error) {
 	return nil, nil
 }

--- a/control/fixtures/fixtures.go
+++ b/control/fixtures/fixtures.go
@@ -22,6 +22,7 @@ package fixtures
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/intelsdi-x/snap/core"
@@ -142,6 +143,9 @@ func (m MockPlugin) Name() string                  { return m.name }
 func (m MockPlugin) TypeName() string              { return m.pluginType.String() }
 func (m MockPlugin) Version() int                  { return m.ver }
 func (m MockPlugin) Config() *cdata.ConfigDataNode { return m.config }
+func (m MockPlugin) Key() string {
+	return fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", m.pluginType.String(), m.name, m.ver)
+}
 
 type MockRequestedMetric struct {
 	namespace core.Namespace

--- a/control/strategy/fixtures/fixtures.go
+++ b/control/strategy/fixtures/fixtures.go
@@ -19,8 +19,7 @@ limitations under the License.
 package fixtures
 
 import (
-	"strconv"
-	"strings"
+	"fmt"
 	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin"
@@ -140,7 +139,7 @@ func (m MockAvailablePlugin) LastHit() time.Time {
 }
 
 func (m MockAvailablePlugin) String() string {
-	return strings.Join([]string{m.pluginType.String(), m.pluginName, strconv.Itoa(m.Version())}, core.Separator)
+	return fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", m.pluginType.String(), m.pluginName, m.Version())
 }
 
 func (m MockAvailablePlugin) Kill(string) error {

--- a/control/subscription_group_medium_test.go
+++ b/control/subscription_group_medium_test.go
@@ -146,7 +146,7 @@ func TestSubscriptionGroups_Process_GlobalPluginConfig(t *testing.T) {
 
 				sg := newSubscriptionGroups(c)
 				So(sg, ShouldNotBeNil)
-				sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{subsPlugin})
+				sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 				<-lpe.sub
 				So(len(sg.subscriptionMap), ShouldEqual, 1)
 				group, ok := sg.subscriptionMap["task-id"]
@@ -190,7 +190,7 @@ func TestSubscriptionGroups_ProcessStaticNegative(t *testing.T) {
 
 			sg := newSubscriptionGroups(c)
 			So(sg, ShouldNotBeNil)
-			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{subsPlugin})
+			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 			<-lpe.sub
 			So(len(sg.subscriptionMap), ShouldEqual, 1)
 			group, ok := sg.subscriptionMap["task-id"]
@@ -260,7 +260,7 @@ func TestSubscriptionGroups_ProcessStaticPositive(t *testing.T) {
 
 			sg := newSubscriptionGroups(c)
 			So(sg, ShouldNotBeNil)
-			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{mock1})
+			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 			<-lpe.sub
 			So(len(sg.subscriptionMap), ShouldEqual, 1)
 			group, ok := sg.subscriptionMap["task-id"]
@@ -336,7 +336,7 @@ func TestSubscriptionGroups_ProcessDynamicPositive(t *testing.T) {
 			errs := sg.ValidateDeps([]core.RequestedMetric{requested}, []core.SubscribedPlugin{mock1}, ctree)
 			So(errs, ShouldBeNil)
 			Convey("Subscription group created for requested metric with wildcards", func() {
-				sg.Add("task-id", []core.RequestedMetric{requested}, ctree, []core.SubscribedPlugin{mock1})
+				sg.Add("task-id", []core.RequestedMetric{requested}, ctree, []core.SubscribedPlugin{})
 				<-lpe.sub
 				So(len(sg.subscriptionMap), ShouldEqual, 1)
 				group, ok := sg.subscriptionMap["task-id"]
@@ -411,7 +411,7 @@ func TestSubscriptionGroups_ProcessDynamicNegative(t *testing.T) {
 
 			sg := newSubscriptionGroups(c)
 			So(sg, ShouldNotBeNil)
-			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{mock1})
+			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 			<-lpe.sub
 			So(len(sg.subscriptionMap), ShouldEqual, 1)
 			group, ok := sg.subscriptionMap["task-id"]
@@ -486,9 +486,8 @@ func TestSubscriptionGroups_ProcessSpecifiedDynamicPositive(t *testing.T) {
 			serrs := sg.ValidateDeps([]core.RequestedMetric{requested}, []core.SubscribedPlugin{mock1}, cdata.NewTree())
 			So(serrs, ShouldBeNil)
 			Convey("Subscription group created for requested metric with specified instance of dynamic element and with wildcards", func() {
-				sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{mock1})
+				sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 				<-lpe.sub
-
 				So(len(sg.subscriptionMap), ShouldEqual, 1)
 				group, ok := sg.subscriptionMap["task-id"]
 				So(ok, ShouldBeTrue)
@@ -567,7 +566,7 @@ func TestSubscriptionGroups_ProcessSpecifiedDynamicNegative(t *testing.T) {
 
 			sg := newSubscriptionGroups(c)
 			So(sg, ShouldNotBeNil)
-			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{mock1})
+			sg.Add("task-id", []core.RequestedMetric{requested}, cdata.NewTree(), []core.SubscribedPlugin{})
 			<-lpe.sub
 			So(len(sg.subscriptionMap), ShouldEqual, 1)
 			group, ok := sg.subscriptionMap["task-id"]

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -119,6 +119,7 @@ type CatalogedPlugin interface {
 	PluginPath() string
 	LoadedTimestamp() *time.Time
 	Policy() *cpolicy.ConfigPolicy
+	Key() string
 }
 
 // the collection of cataloged plugins used

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -605,45 +605,6 @@ func TestSnapClient(t *testing.T) {
 				})
 			})
 		})
-		Convey("UnloadPlugin", func() {
-			Convey("unload unknown plugin", func() {
-				p := c.UnloadPlugin("not a type", "foo", 3)
-				So(p.Err, ShouldNotBeNil)
-				So(p.Err.Error(), ShouldEqual, "plugin not found")
-			})
-			Convey("unload already unloaded plugin", func() {
-				p := c.UnloadPlugin("collector", "mock", 2)
-				So(p.Err, ShouldNotBeNil)
-				So(p.Err.Error(), ShouldEqual, "plugin not found")
-			})
-			Convey("unload one of multiple", func() {
-				p1 := c.GetPlugins(false)
-				So(p1.Err, ShouldBeNil)
-				So(len(p1.LoadedPlugins), ShouldEqual, 2)
-
-				p3 := c.UnloadPlugin("publisher", "mock-file", 3)
-				So(p3.Err, ShouldBeNil)
-				So(p3.Name, ShouldEqual, "mock-file")
-				So(p3.Version, ShouldEqual, 3)
-				So(p3.Type, ShouldEqual, "publisher")
-			})
-			Convey("unload when only one plugin loaded", func() {
-				p1 := c.GetPlugins(false)
-				So(p1.Err, ShouldBeNil)
-				So(len(p1.LoadedPlugins), ShouldEqual, 1)
-				So(p1.LoadedPlugins[0].Name, ShouldEqual, "mock")
-
-				p2 := c.UnloadPlugin("collector", "mock", 1)
-				So(p2.Err, ShouldBeNil)
-				So(p2.Name, ShouldEqual, "mock")
-				So(p2.Version, ShouldEqual, 1)
-				So(p2.Type, ShouldEqual, "collector")
-
-				p3 := c.GetPlugins(false)
-				So(p3.Err, ShouldBeNil)
-				So(len(p3.LoadedPlugins), ShouldEqual, 0)
-			})
-		})
 	})
 
 	c, err := New("http://localhost:-1", "v1", true)
@@ -676,6 +637,73 @@ func TestSnapClient(t *testing.T) {
 		So(err, ShouldBeNil)
 		r := c.GetTasks()
 		So(r.Err, ShouldNotBeNil)
+	})
+}
+
+func TestClient_UnloadPlugin(t *testing.T) {
+	CompressUpload = false
+
+	Convey("Client should exist", t, func() {
+		uri := startAPI()
+		c, cerr := New(uri, "v1", true)
+		wf := getWMFromSample("1.json")
+		sch := &Schedule{Type: "simple", Interval: "1s"}
+		So(cerr, ShouldBeNil)
+		if cerr == nil {
+			p1 = c.LoadPlugin(MOCK_PLUGIN_PATH1)
+			p2 = c.LoadPlugin(MOCK_PLUGIN_PATH2)
+			p3 = c.LoadPlugin(FILE_PLUGIN_PATH)
+		}
+		Convey("UnloadPlugin", func() {
+			Convey("unload unknown plugin", func() {
+				p := c.UnloadPlugin("not a type", "foo", 3)
+				So(p.Err, ShouldNotBeNil)
+				So(p.Err.Error(), ShouldEqual, "plugin not found")
+			})
+			Convey("unload loaded plugin", func() {
+				p := c.UnloadPlugin("publisher", "mock-file", 3)
+				So(p.Err, ShouldBeNil)
+				So(p.Name, ShouldEqual, "mock-file")
+				So(p.Version, ShouldEqual, 3)
+				So(p.Type, ShouldEqual, "publisher")
+
+				Convey("unload already unloaded plugin", func() {
+					p := c.UnloadPlugin("publisher", "mock-file", 3)
+					So(p.Err, ShouldNotBeNil)
+					So(p.Err.Error(), ShouldEqual, "plugin not found")
+				})
+			})
+			Convey("unload plugin used by task", func() {
+				tf := c.CreateTask(sch, wf, "baron", "", true, 0)
+				So(tf.Err, ShouldBeNil)
+				plgs := c.GetPlugins(false)
+				So(plgs.Err, ShouldBeNil)
+				So(len(plgs.LoadedPlugins), ShouldEqual, 3)
+
+				Convey("unload one of multiple", func() {
+					p2 := c.UnloadPlugin("collector", "mock", 2)
+					So(p2.Err, ShouldBeNil)
+					So(p2.Name, ShouldEqual, "mock")
+					So(p2.Version, ShouldEqual, 2)
+					So(p2.Type, ShouldEqual, "collector")
+
+					Convey("unload when only one left", func() {
+						p1 := c.UnloadPlugin("collector", "mock", 1)
+						So(p1.Err, ShouldNotBeNil)
+						So(p1.Err.Error(), ShouldStartWith, control.ErrPluginCannotBeUnloaded.Error())
+
+						Convey("unload after stopping the task", func() {
+							t := c.StopTask(tf.ID)
+							So(t.Err, ShouldBeNil)
+							p1 := c.UnloadPlugin("collector", "mock", 1)
+							So(p1.Name, ShouldEqual, "mock")
+							So(p1.Version, ShouldEqual, 1)
+							So(p1.Type, ShouldEqual, "collector")
+						})
+					})
+				})
+			})
+		})
 	})
 }
 

--- a/mgmt/rest/v1/fixtures/mock_metric_manager.go
+++ b/mgmt/rest/v1/fixtures/mock_metric_manager.go
@@ -22,6 +22,7 @@ package fixtures
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
@@ -50,10 +51,13 @@ type MockLoadedPlugin struct {
 	MyVersion int
 }
 
-func (m MockLoadedPlugin) Name() string       { return m.MyName }
-func (m MockLoadedPlugin) Port() string       { return "" }
-func (m MockLoadedPlugin) TypeName() string   { return m.MyType }
-func (m MockLoadedPlugin) Version() int       { return m.MyVersion }
+func (m MockLoadedPlugin) Name() string     { return m.MyName }
+func (m MockLoadedPlugin) Port() string     { return "" }
+func (m MockLoadedPlugin) TypeName() string { return m.MyType }
+func (m MockLoadedPlugin) Version() int     { return m.MyVersion }
+func (m MockLoadedPlugin) Key() string {
+	return fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", m.MyType, m.MyName, m.MyVersion)
+}
 func (m MockLoadedPlugin) Plugin() string     { return "" }
 func (m MockLoadedPlugin) IsSigned() bool     { return false }
 func (m MockLoadedPlugin) Status() string     { return "" }

--- a/mgmt/rest/v2/mock/mock_metric_manager.go
+++ b/mgmt/rest/v2/mock/mock_metric_manager.go
@@ -22,6 +22,7 @@ package mock
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
@@ -50,10 +51,13 @@ type MockLoadedPlugin struct {
 	MyVersion int
 }
 
-func (m MockLoadedPlugin) Name() string       { return m.MyName }
-func (m MockLoadedPlugin) Port() string       { return "" }
-func (m MockLoadedPlugin) TypeName() string   { return m.MyType }
-func (m MockLoadedPlugin) Version() int       { return m.MyVersion }
+func (m MockLoadedPlugin) Name() string     { return m.MyName }
+func (m MockLoadedPlugin) Port() string     { return "" }
+func (m MockLoadedPlugin) TypeName() string { return m.MyType }
+func (m MockLoadedPlugin) Version() int     { return m.MyVersion }
+func (m MockLoadedPlugin) Key() string {
+	return fmt.Sprintf("%s"+core.Separator+"%s"+core.Separator+"%d", m.MyType, m.MyName, m.MyVersion)
+}
 func (m MockLoadedPlugin) Plugin() string     { return "" }
 func (m MockLoadedPlugin) IsSigned() bool     { return false }
 func (m MockLoadedPlugin) Status() string     { return "" }


### PR DESCRIPTION
Related with https://github.com/intelsdi-x/snap/issues/1659
### TO DO:
- [x] Adding tests

### Reasoning
Not allowing for unloading the plugin which is used in a running task with providing an appropriate error message to point which of tasks use it. 
Exemplary:
```
$ snaptel plugin unload collector mock 1
Error unloading plugin:
Plugin is used by running task(s). Stop the task(s) to be able to unload the plugin:
d6f836d7-87ad-4ada-86a1-1f7a98db8444
593db750-932b-43cb-a123-902fbfbc1485
```

**Notice** - at the moment it applies only for collector (or streaming-collector) plugins. Publisher and processor plugins are out of scope because the issue https://github.com/intelsdi-x/snap/issues/1676 must be fixed as first.

### Summary of changes:
- added `validatePluginUnloading` preceding plugin unloading
- added `GetPlugins` as a method to retrieve all plugins (in all version) exposing a given metric
- unification of the way of creating plugin_key (changed usage of `Join` to `Sprintf`) - @marcintao's suggestion, does not impact on how it works

### How to check
1. Load plugins: 
 - snap-plugin-collector-mock2, 
 - snap-plugin-collector-disk, 
 - snap-plugin-processor-passthru, 
 - snap-plugin-publisher-mock-file

```
$ snaptel plugin load ./snap/build/linux/x86_64/plugins/snap-plugin-collector-mock2
$ snaptel plugin load ./snap/build/linux/x86_64/plugins/snap-plugin-collector-mock1
$ snaptel plugin load ./snap-plugin-collector-disk/build/linux/x86_64/snap-plugin-collector-disk
$ snaptel plugin load ./snap/build/linux/x86_64/plugins/snap-plugin-processor-passthru
$ snaptel plugin load ./snap/build/linux/x86_64/plugins/snap-plugin-publisher-mock-file
```
2. Create task manifest:
```json
{
    "version": 1,
    "schedule": {
        "type": "simple",
        "interval": "1s"
    },
    "workflow": {
        "collect": {
            "metrics": {
                "/intel/*": {}
            },
            "config": {
                "/intel/mock": {
                    "user": "root",
                    "password": "secret"
                }
            },
            "process": [
                {
                 "plugin_name": "passthru",
                "publish": [
                 {
                   "plugin_name": "mock-file",
                   "config": {
                         "file": "/tmp/snap_published_mock_file.log"
                          }
                 }
                ]
              }
            ]
        }
    }
}
```
3. Create task(s) (they may be exactly the same)
```
$ snaptel task create -t task.json
```

4. Verify loaded plugins and running tasks:
```
$ snaptel plugin list
NAME             VERSION         TYPE            SIGNED          STATUS          LOADED TIME
mock             2               collector       false           loaded          Wed, 05 Jul 2017 10:54:58 CEST
mock             1               collector       false           loaded          Wed, 05 Jul 2017 10:54:58 CEST
disk             4               collector       false           loaded          Wed, 05 Jul 2017 10:54:59 CEST
passthru         1               processor       false           loaded          Wed, 05 Jul 2017 10:55:00 CEST
mock-file        3               publisher       false           loaded          Wed, 05 Jul 2017 10:55:00 CEST

```
```
$ snaptel task list
ID                                       NAME                                            STATE           HIT     MISS    FAIL    CREATED                 LAST FAILURE
593db750-932b-43cb-a123-902fbfbc1485     Task-593db750-932b-43cb-a123-902fbfbc1485       Running         50      0       0       10:55AM 7-05-2017
d6f836d7-87ad-4ada-86a1-1f7a98db8444     Task-d6f836d7-87ad-4ada-86a1-1f7a98db8444       Running         9       0       0       10:55AM 7-05-2017
```
5. Unload collector plugins (one by one)
```
snaptel plugin unload collector disk 4
snaptel plugin unload collector mock 2
snaptel plugin unload collector mock 1
```


### Before

After unloading the last collector, running tasks fail with error `Metric not found: /intel/* (version: 0)`
```
$ snaptel plugin unload collector disk 4
Plugin unloaded
Name: disk
Version: 4
Type: collector

$ snaptel plugin unload collector mock 2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snaptel plugin unload collector mock 1
Plugin unloaded
Name: mock
Version: 1
Type: collector

$ snaptel task list
ID                                       NAME                                            STATE           HIT     MISS    FAIL    CREATED                 LAST FAILURE
23722552-1558-4589-9a65-098191a7d2c7     Task-23722552-1558-4589-9a65-098191a7d2c7       Running         27      0       7       11:03AM 7-05-2017       Metric not found: /intel/* (version: 0)
2a42ba28-de19-4a59-83d4-0c4817faf6be     Task-2a42ba28-de19-4a59-83d4-0c4817faf6be       Running         23      0       8       11:03AM 7-05-2017       Metric not found: /intel/* (version: 0)

```

### After
Unloading the last collector would cause task failing, so unloading it is blocked until tasks which use the plugin are running. That allows avoiding unloading plugin by mistaken.
```
$ snaptel plugin unload collector disk 4
Plugin unloaded
Name: disk
Version: 4
Type: collector

$ snaptel plugin unload collector mock 2
Plugin unloaded
Name: mock
Version: 2
Type: collector

$ snaptel plugin unload collector mock 1
Error unloading plugin:
Plugin is used by running task(s). Stop the task(s) to be able to unload the plugin:
d6f836d7-87ad-4ada-86a1-1f7a98db8444
593db750-932b-43cb-a123-902fbfbc1485
```


### Testing done:
- manual tests
- small, medium and legacy tests passed

@intelsdi-x/snap-maintainers
