### PR TITLE
Fix so plugin will get unloaded and tasks disabled after plugin killed

### DIFF
--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -302,13 +302,6 @@ func (a *availablePlugin) Kill(r string) error {
 // CheckHealth checks the health of a plugin and updates
 // a.failedHealthChecks
 func (a *availablePlugin) CheckHealth() {
-	if a.IsRemote() {
-		runnerLog.WithFields(log.Fields{
-			"_module": "control-aplugin",
-			"_block":  "check-health",
-		}).Debug(fmt.Sprintf("bypassing check-health on standalone plugin"))
-		return
-	}
 	go func() {
 		a.healthChan <- a.client.Ping()
 	}()

--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -538,6 +538,10 @@ func (g *grpcClient) handleInStream(
 		for {
 			in, err := g.stream.Recv()
 			if err != nil {
+				g.conn.Close()
+				if strings.Contains(err.Error(), "transport is closing") {
+					errChan <- errors.New("connection broken")
+				}
 				errChan <- err
 				break
 			}


### PR DESCRIPTION
Fixes #1680

Summary of changes:
- Plugin gets unloaded and relevant tasks get disabled after a stand-alone plugin is killed

To Test:
- Start Snap
- Start plugin in stand-alone mode
- Load plugin to Snap
- Load task
- Manually kill plugin (ctrl+c)

Expected Behavior:  
- Plugin is unloaded, including metrics removed from list
- Relevant tasks are disabled 

Testing done:
- Manual
- Unit

@intelsdi-x/snap-maintainers
