### PR TITLE
Fix #1393 change namespace used in ConfigPolicy in mock2-grpc

### DIFF
--- a/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
+++ b/plugin/collector/snap-plugin-collector-mock2-grpc/mock/mock.go
@@ -159,12 +159,12 @@ func (f *Mock) GetMetricTypes(cfg plugin.Config) ([]plugin.Metric, error) {
 func (f *Mock) GetConfigPolicy() (plugin.ConfigPolicy, error) {
 	p := plugin.NewConfigPolicy()
 
-	err := p.AddNewStringRule([]string{"intel", "mock", "foo"}, "name", false, plugin.SetDefaultString("bob"))
+	err := p.AddNewStringRule([]string{"intel", "mock", "test%>"}, "name", false, plugin.SetDefaultString("bob"))
 	if err != nil {
 		return *p, err
 	}
 
-	err = p.AddNewStringRule([]string{"intel", "mock", "foo"}, "password", true)
+	err = p.AddNewStringRule([]string{"intel", "mock", "/foo=㊽"}, "password", true)
 
 	return *p, err
 }


### PR DESCRIPTION
Fixes #1393 

Changed namespace in ConfigPolicy, so they match namepsaces in Metric Catalog