### PR TITLE
Fixes #1654 - now additional `serror` fields are used and presented

### DIFF
--- a/cmd/snaptel/task.go
+++ b/cmd/snaptel/task.go
@@ -387,7 +387,7 @@ func createTaskUsingTaskManifest(ctx *cli.Context) error {
 
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
-		errString := "Error creating task:"
+		errString := "Error creating task: "
 		for _, err := range errors {
 			errString += fmt.Sprintf("%v\n", err)
 		}
@@ -448,7 +448,7 @@ func createTaskUsingWFManifest(ctx *cli.Context) error {
 	r := pClient.CreateTask(t.Schedule, wf, t.Name, t.Deadline, !ctx.IsSet("no-start"), t.MaxFailures)
 	if r.Err != nil {
 		errors := strings.Split(r.Err.Error(), " -- ")
-		errString := "Error creating task:"
+		errString := "Error creating task: "
 		for _, err := range errors {
 			errString += fmt.Sprintf("%v\n", err)
 		}

--- a/core/task.go
+++ b/core/task.go
@@ -308,7 +308,15 @@ func CreateTaskFromContent(body io.ReadCloser,
 		var errMsg string
 		for _, e := range errs.Errors() {
 			errMsg = errMsg + e.Error() + " -- "
+
+			log.WithFields(log.Fields{
+				"_file":     "core/task.go",
+				"_function": "CreateTaskFromContent",
+				"_error":    e.Error(),
+				"_fields":   e.Fields(),
+			}).Error("error creating task")
 		}
+
 		return nil, errors.New(errMsg[:len(errMsg)-4])
 	}
 	return task, nil


### PR DESCRIPTION
Fixes #1654 - Additional 'serror' fields are not presented in error message
-
Short information: There is a possibility to set 'serror' fields to provide more details about occurring error, however, it is not presented in error message.

Summary of changes:
- 
- additional information is shown in logs
- updated medium test

How to verify it:
-
1) Create exemplary task manifest, which will result an error, for example:
a) error: `ErrPluginIncompatibleWithScheduleType`
Reason: Schedule type should be `simple` not `streaming`
```
{
  "version": 1,
  "schedule": {
    "type": "streaming",
    "interval": "1s"
  },
  "max-failures": 1,
  "workflow": {
    "collect": {
      "metrics": {
        "/intel/psutil/load/load15": {},
        "/intel/psutil/load/load5": {},
        "/intel/psutil/vm/available": {},
        "/intel/psutil/vm/free": {},
        "/intel/psutil/vm/used": {}
      },
      "publish": [
        {
          "plugin_name": "influxdb",
          "config": {
            "host": "${INFLUXDB_HOST}",
            "port": 8086,
            "database": "test",
            "user": "admin",
            "password": "admin",
            "scheme": "http",
            "skip-verify": false,
            "isMultiFields": true
          }
        }
      ]
    }
  }
}
```
b) error: `ErrMultipleStreamingPlugins`
Reason: Only one streaming collector can be used in task manifest (here task wants to use metrics from two streaming collectors)
```
{
  "version": 1,
  "schedule": {
    "type": "streaming",
    "interval": "5s"
  },
  "max-failures": 1,
  "workflow": {
    "collect": {
      "metrics": {
        "/intel/streaming/random/float": {},
        "/intel/streaming/random/int": {},
        "/intel/streaming2/random2/float": {},
        "/intel/streaming2/random2/int": {}       
      },
      "publish": [
        {
          "plugin_name": "influxdb",
          "config": {
            "host": "${INFLUXDB_HOST}",
            "port": 8086,
            "database": "test3",
            "user": "admin",
            "password": "admin",
            "scheme": "http",
            "skip-verify": false,
            "isMultiFields": true
          }
        }
      ]
    }
  }
}
```

2) Create task (below are examples used in tests)
a) from exemplary task manifest (1a)
```
$ snaptel task create -t test.json --name="Wrong_types"
Using task manifest to create task
Error creating task: Plugin is incompatible with the tasks schedule type.
```

Logs:
```
DEBU[2017-08-17T16:02:01+02:00] API request                                   _module=_mgmt-rest index=6 method=POST url=/v1/tasks
DEBU[2017-08-17T16:02:01+02:00] Setting stop-on-failure limit for task        _block=OptionStopOnFailure _module=core consecutive failure limit=1 task-id=3aa3cc86-edef-48f5-b10f-421465aded4a task-name=Task-3aa3cc86-edef-48f5-b10f-421465aded4a
ERRO[2017-08-17T16:02:01+02:00] error creating task                           _error=Plugin is incompatible with the tasks schedule type. _fields=map[plugin_name:psutil plugin_type:collector schedule_type:*schedule.StreamingSchedule] _file=core/task.go _function=CreateTaskFromContent
DEBU[2017-08-17T16:02:01+02:00] API response                                  _module=_mgmt-rest index=6 method=POST status=Internal Server Error status-code=500 url=/v1/tasks
```


b) from exemplary task manifest (1b)
```
$ snaptel task create -t test2.json --name="2_streaming_collectors"
Using task manifest to create task
Error creating task: Multiple streaming plugins within the same task is not supported.
schedule_type: *schedule.StreamingSchedule
num_of_collectors: 2
```

Logs:
```
DEBU[2017-08-17T16:04:44+02:00] API request                                   _module=_mgmt-rest index=7 method=POST url=/v1/tasks
DEBU[2017-08-17T16:04:44+02:00] Setting stop-on-failure limit for task        _block=OptionStopOnFailure _module=core consecutive failure limit=1 task-id=0cbb08a4-8c6f-4119-94d4-2309baf650b0 task-name=Task-0cbb08a4-8c6f-4119-94d4-2309baf650b0
ERRO[2017-08-17T16:04:44+02:00] error creating task                           _error=Multiple streaming plugins within the same task is not supported. _fields=map[num_of_collectors:2 schedule_type:*schedule.StreamingSchedule] _file=core/task.go _function=CreateTaskFromContent
DEBU[2017-08-17T16:04:44+02:00] API response                                  _module=_mgmt-rest index=7 method=POST status=Internal Server Error status-code=500 url=/v1/tasks
```

Testing done:
- 
- small test passed
- medium test passed
- large test passed
- legacy test passed
- manual test satisfying


@intelsdi-x/snap-maintainers
