### PR TITLE
Add standalone support to API v2

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -168,6 +168,13 @@
             "description": "CA root certification",
             "name": "ca_certs",
             "in": "formData"
+          },
+          {
+            "type": "string",
+            "x-go-name": "PluginURI",
+            "description": "Stand-alone plugin URI",
+            "name": "plugin_uri",
+            "in": "formData"
           }
         ],
         "responses": {


### PR DESCRIPTION
Fixes #1714

Summary of changes:
- Added PluginURI field to plugin load POST parameters
- Added support for receiving form data in two different formats (multipart and URL-encoded), according to OpenAPI behavior 
- Added loading standalone plugins using plugin listen address

Testing done:
- Manual testing

@intelsdi-x/snap-maintainers
