### PR TITLE
fixed issue 1716: No third party error handling in loading plugin RES…

### DIFF
--- a/mgmt/rest/v2/api.go
+++ b/mgmt/rest/v2/api.go
@@ -110,6 +110,7 @@ func (s *apiV2) GetRoutes() []api.Route {
 		// 415: ErrorResponse
 		// 500: ErrorResponse
 		// 401: UnauthResponse
+		// default: ErrorStringResponse
 		api.Route{Method: "POST", Path: prefix + "/plugins", Handle: s.loadPlugin},
 		// swagger:route DELETE /plugins/{ptype}/{pname}/{pversion} plugins unloadPlugin
 		//

--- a/mgmt/rest/v2/error.go
+++ b/mgmt/rest/v2/error.go
@@ -63,6 +63,15 @@ type UnauthError struct {
 	Message string `json:"message"`
 }
 
+// ErrorStringResponse represents an error in the string format.
+//
+// It includes an error message only.
+//
+// swagger:response ErrorStringResponse
+type ErrorStringResponse struct {
+	Message string `json:"message"`
+}
+
 // Unsuccessful generic response to a failed API call
 type Error struct {
 	ErrorMessage string            `json:"message"`

--- a/swagger.json
+++ b/swagger.json
@@ -188,6 +188,9 @@
           },
           "500": {
             "$ref": "#/responses/ErrorResponse"
+          },
+          "default": {
+            "$ref": "#/responses/ErrorStringResponse"
           }
         }
       }
@@ -1290,6 +1293,14 @@
       "description": "ErrorResponse represents the Snap error response type.\n\nIt includes an error message and a map of fields.",
       "schema": {
         "$ref": "#/definitions/Error"
+      }
+    },
+    "ErrorStringResponse": {
+      "description": "ErrorStringResponse represents an error in the string format.\n\nIt includes an error message only.",
+      "headers": {
+        "message": {
+          "type": "string"
+        }
       }
     },
     "MetricsResponse": {


### PR DESCRIPTION


Fixes #1716 

Summary of changes:
- Added default loading plugin error response

Testing done:
- small, medium and legacy

@intelsdi-x/snap-maintainers
