### PR TITLE
Fix issue #1721 about snap-plugin--csvreader

### DIFF
--- a/docs/plugins.yml
+++ b/docs/plugins.yml
@@ -129,3 +129,4 @@
 - michep/snap-plugin-processor-maptag
 - intelsdi-x/snap-plugin-collector-pysmart:
     supported: true
+- cuongquay/snap-plugin-collector-csvreader


### PR DESCRIPTION
Fixes #1721

Summary of changes:
- Adding csvreader as a collector plugin
- Read CSV column as metric

Testing done:
- Tested with single and multiple column

@intelsdi-x/snap-maintainers
