### PR TITLE
Nominating Klaudiusz Dembler for snap maintainer

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -22,6 +22,7 @@ Below is the list of Snap Maintainers, they are largely responsible for approvin
 | Joel Cooklin      | @jcooklin        |
 | Katarzyna Kujawa  | @katarzyna-z     |
 | Kelly Lyon        | @kjlyon          |
+| Klaudiusz Dembler | @kdembler        |
 | Lukasz Mroz       | @lmroz           |
 | Marcin Krolik     | @marcin-krolik   |
 | Marcin Olszewski  | @marcintao       |
@@ -31,7 +32,6 @@ Below is the list of Snap Maintainers, they are largely responsible for approvin
 | Matt Broberg      | @mbbroberg       |
 | Patryk Matyjasek  | @PatrykMatyjasek |
 | Rashmi Gottipati  | @rashmigottipati |
-| Klaudiusz Dembler | @kdembler        |
 
 ### Responsibilities of Snap Maintainers
 Maintainers are expected to contribute regularly in at least one of the following capacities:

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -31,6 +31,7 @@ Below is the list of Snap Maintainers, they are largely responsible for approvin
 | Matt Broberg      | @mbbroberg       |
 | Patryk Matyjasek  | @PatrykMatyjasek |
 | Rashmi Gottipati  | @rashmigottipati |
+| Klaudiusz Dembler | @kdembler        |
 
 ### Responsibilities of Snap Maintainers
 Maintainers are expected to contribute regularly in at least one of the following capacities:


### PR DESCRIPTION
For Klaudiusz's outstanding work as part of the team and continued support of the project.

Klaudiusz is engaged in framework improvements and bug fixes. He is an active contributor of 
[snap-plugin-lib-py](https://github.com/intelsdi-x/snap-plugin-lib-py/pulls?q=is%3Apr+author%3Akdembler+is%3Aclosed). Also, he has delivered among others [snap-plugin-processor-tags-filter](https://github.com/intelsdi-x/snap-plugin-processor-tags-filter). Also, He is involved in supporting other plugins by bug fixing and implementing, updating documentation and releasing them.

Thank You @kdembler for your contribution!

@intelsdi-x/snap-maintainers
