### PR TITLE
update sirupsen logrus import path

### DIFF
--- a/cmd/snaptel/config.go
+++ b/cmd/snaptel/config.go
@@ -28,8 +28,8 @@ import (
 	"strconv"
 	"text/tabwriter"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core/ctypes"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 

--- a/control/available_plugin.go
+++ b/control/available_plugin.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/gomit"
 	"github.com/intelsdi-x/snap/control/plugin"

--- a/control/config.go
+++ b/control/config.go
@@ -28,7 +28,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vrischmann/jsonutil"
 
 	"github.com/intelsdi-x/snap/core"

--- a/control/control.go
+++ b/control/control.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
 	"github.com/intelsdi-x/gomit"

--- a/control/control_grpc_server_test.go
+++ b/control/control_grpc_server_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/intelsdi-x/gomit"
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/fixtures"
 	"github.com/intelsdi-x/snap/core"

--- a/control/control_security_test.go
+++ b/control/control_security_test.go
@@ -31,8 +31,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/intelsdi-x/snap/control/fixtures"

--- a/control/control_test.go
+++ b/control/control_test.go
@@ -32,8 +32,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/vrischmann/jsonutil"
 

--- a/control/metrics.go
+++ b/control/metrics.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"

--- a/control/plugin/client/grpc.go
+++ b/control/plugin/client/grpc.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/control/plugin/client/native.go
+++ b/control/plugin/client/native.go
@@ -30,7 +30,7 @@ import (
 	"time"
 	"unicode"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"

--- a/control/plugin/collector_proxy_test.go
+++ b/control/plugin/collector_proxy_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/intelsdi-x/snap/control/plugin/encoding"
 	"github.com/intelsdi-x/snap/core"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/control/plugin/execution.go
+++ b/control/plugin/execution.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var execLogger = log.WithField("_module", "plugin-exec")

--- a/control/plugin/metric_deprecated.go
+++ b/control/plugin/metric_deprecated.go
@@ -32,9 +32,9 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
+	log "github.com/sirupsen/logrus"
 )
 
 func NewPluginConfigType() ConfigType {

--- a/control/plugin/plugin.go
+++ b/control/plugin/plugin.go
@@ -24,7 +24,7 @@ import (
 	"crypto/rsa"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 )

--- a/control/plugin/plugin_deprecated.go
+++ b/control/plugin/plugin_deprecated.go
@@ -32,7 +32,7 @@ import (
 	"runtime"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/control/plugin/plugin_test.go
+++ b/control/plugin/plugin_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/control/plugin/rpc/plugin.go
+++ b/control/plugin/rpc/plugin.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/ctypes"

--- a/control/plugin/session_deprecated.go
+++ b/control/plugin/session_deprecated.go
@@ -36,7 +36,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/control/plugin/encoding"

--- a/control/plugin/session_test.go
+++ b/control/plugin/session_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/control/plugin/encoding"

--- a/control/plugin_manager.go
+++ b/control/plugin_manager.go
@@ -37,8 +37,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/appc/spec/schema"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/gomit"
 	"github.com/intelsdi-x/snap/control/plugin"

--- a/control/runner.go
+++ b/control/runner.go
@@ -26,8 +26,8 @@ import (
 	"path"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/client"

--- a/control/strategy/cache.go
+++ b/control/strategy/cache.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/pkg/chrono"
+	log "github.com/sirupsen/logrus"
 )
 
 // GlobalCacheExpiration the default time limit for which a cache entry is valid.

--- a/control/strategy/config_based.go
+++ b/control/strategy/config_based.go
@@ -20,8 +20,8 @@ limitations under the License.
 package strategy
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
+	log "github.com/sirupsen/logrus"
 )
 
 import (

--- a/control/strategy/lru.go
+++ b/control/strategy/lru.go
@@ -22,8 +22,8 @@ package strategy
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
+	log "github.com/sirupsen/logrus"
 )
 
 // lru provides a strategy that selects the least recently used available plugin.

--- a/control/strategy/pool.go
+++ b/control/strategy/pool.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"

--- a/control/strategy/sticky.go
+++ b/control/strategy/sticky.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
+	log "github.com/sirupsen/logrus"
 )
 
 import "time"

--- a/control/subscription_group.go
+++ b/control/subscription_group.go
@@ -33,7 +33,7 @@ import (
 	"github.com/intelsdi-x/snap/core/control_event"
 	"github.com/intelsdi-x/snap/core/serror"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/control/subscription_group_medium_test.go
+++ b/control/subscription_group_medium_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/plugin/helper"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/core/task.go
+++ b/core/task.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/pkg/schedule"

--- a/glide.lock
+++ b/glide.lock
@@ -35,7 +35,7 @@ imports:
 - name: github.com/intelsdi-x/gomit
   version: 286c3ad6599724faed681cd18a9ff595b00d9f3f
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: 3e667d03c92e7d5247e536e4df037f6c84692229
+  version: 69934c200c23811291535a804852ff2231bf85f0 
   subpackages:
   - v1/plugin
   - v1/plugin/rpc

--- a/glide.lock
+++ b/glide.lock
@@ -51,7 +51,7 @@ imports:
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/rs/cors
   version: 8dd4211afb5d08dbb39a533b9bb9e4b486351df6
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: be52937128b38f1d99787bb476c789e2af1147f1
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,6 @@
 package: github.com/intelsdi-x/snap
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: be52937128b38f1d99787bb476c789e2af1147f1
 - package: github.com/appc/spec
   version: ^v0.8.10

--- a/grpc/common/common.go
+++ b/grpc/common/common.go
@@ -25,11 +25,11 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/core/serror"
+	log "github.com/sirupsen/logrus"
 )
 
 // Convert a core.Metric to common.Metric protobuf message

--- a/grpc/controlproxy/rpc/control.go
+++ b/grpc/controlproxy/rpc/control.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/grpc/common"
+	log "github.com/sirupsen/logrus"
 )
 
 type Metric struct {

--- a/mgmt/rest/client/client_func_test.go
+++ b/mgmt/rest/client/client_func_test.go
@@ -31,8 +31,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/mgmt/rest"

--- a/mgmt/rest/client/client_tribe_func_test.go
+++ b/mgmt/rest/client/client_tribe_func_test.go
@@ -31,7 +31,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/intelsdi-x/snap/control"

--- a/mgmt/rest/log_handler.go
+++ b/mgmt/rest/log_handler.go
@@ -22,7 +22,7 @@ package rest
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 )
 

--- a/mgmt/rest/rest_test.go
+++ b/mgmt/rest/rest_test.go
@@ -26,10 +26,10 @@ import (
 	"net/http"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/plugin/helper"
 	"github.com/intelsdi-x/snap/scheduler"
+	log "github.com/sirupsen/logrus"
 )
 
 // common resources used for medium tests

--- a/mgmt/rest/rest_v1_test.go
+++ b/mgmt/rest/rest_v1_test.go
@@ -40,7 +40,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control"
 	"github.com/intelsdi-x/snap/core"

--- a/mgmt/rest/rest_v2_test.go
+++ b/mgmt/rest/rest_v2_test.go
@@ -35,10 +35,10 @@ import (
 	"strings"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
 	"github.com/intelsdi-x/snap/mgmt/rest/v2/mock"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/mgmt/rest/server.go
+++ b/mgmt/rest/server.go
@@ -30,9 +30,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/julienschmidt/httprouter"
 	"github.com/rs/cors"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 
 	"strings"

--- a/mgmt/rest/tribe_v1_test.go
+++ b/mgmt/rest/tribe_v1_test.go
@@ -32,7 +32,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/intelsdi-x/gomit"

--- a/mgmt/rest/v1/api.go
+++ b/mgmt/rest/v1/api.go
@@ -3,8 +3,8 @@ package v1
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/mgmt/rest/api"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/mgmt/rest/v1/rbody/body.go
+++ b/mgmt/rest/v1/rbody/body.go
@@ -27,8 +27,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core/cdata"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 )
 

--- a/mgmt/rest/v1/task.go
+++ b/mgmt/rest/v1/task.go
@@ -27,10 +27,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/mgmt/rest/v1/rbody"
 	"github.com/julienschmidt/httprouter"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/mgmt/rest/v1/tribe.go
+++ b/mgmt/rest/v1/tribe.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/mgmt/rest/v1/rbody"

--- a/mgmt/rest/v2/api.go
+++ b/mgmt/rest/v2/api.go
@@ -25,8 +25,8 @@ import (
 
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/mgmt/rest/api"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 )
 

--- a/mgmt/tribe/agreement/agreement.go
+++ b/mgmt/tribe/agreement/agreement.go
@@ -22,7 +22,7 @@ package agreement
 import (
 	"net"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/intelsdi-x/snap/core"

--- a/mgmt/tribe/delegate.go
+++ b/mgmt/tribe/delegate.go
@@ -22,7 +22,7 @@ package tribe
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type delegate struct {

--- a/mgmt/tribe/tribe.go
+++ b/mgmt/tribe/tribe.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/control_event"
@@ -39,6 +38,7 @@ import (
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 	"github.com/intelsdi-x/snap/mgmt/tribe/worker"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/memberlist"

--- a/mgmt/tribe/tribe_test.go
+++ b/mgmt/tribe/tribe_test.go
@@ -30,13 +30,13 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/mgmt/tribe/agreement"
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/mgmt/tribe/worker/worker.go
+++ b/mgmt/tribe/worker/worker.go
@@ -31,13 +31,13 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/serror"
 	"github.com/intelsdi-x/snap/mgmt/rest/client"
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/mgmt/tribe/worker/worker_test.go
+++ b/mgmt/tribe/worker/worker_test.go
@@ -26,7 +26,7 @@ package worker
 // 	"testing"
 // 	"time"
 //
-// 	log "github.com/Sirupsen/logrus"
+// 	log "github.com/sirupsen/logrus"
 // 	. "github.com/smartystreets/goconvey/convey"
 //
 // 	"github.com/intelsdi-x/snap/core"

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -28,9 +28,9 @@ import (
 	"os"
 	"path/filepath"
 
-	log "github.com/Sirupsen/logrus"
 	specaci "github.com/appc/spec/aci"
 	"github.com/appc/spec/schema"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/ctree/tree.go
+++ b/pkg/ctree/tree.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ConfigTree struct type

--- a/pkg/fileutils/file.go
+++ b/pkg/fileutils/file.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // WriteFile creates a temporary directory for loading plugins

--- a/pkg/schedule/windowed_schedule.go
+++ b/pkg/schedule/windowed_schedule.go
@@ -22,7 +22,7 @@ package schedule
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/schedule/windowed_schedule_medium_test.go
+++ b/pkg/schedule/windowed_schedule_medium_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/schedule/windowed_schedule_small_test.go
+++ b/pkg/schedule/windowed_schedule_small_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
+++ b/plugin/processor/snap-plugin-processor-passthru-grpc/passthru/passthru.go
@@ -20,7 +20,7 @@ limitations under the License.
 package passthru
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )

--- a/plugin/processor/snap-plugin-processor-passthru/passthru/passthru.go
+++ b/plugin/processor/snap-plugin-processor-passthru/passthru/passthru.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"encoding/gob"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"

--- a/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file-grpc/file/file.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
 )

--- a/plugin/publisher/snap-plugin-publisher-mock-file/file/file.go
+++ b/plugin/publisher/snap-plugin-publisher-mock-file/file/file.go
@@ -28,7 +28,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"

--- a/scheduler/job.go
+++ b/scheduler/job.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core/serror"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/queue_test.go
+++ b/scheduler/queue_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ghodss/yaml"
 

--- a/scheduler/scheduler_medium_test.go
+++ b/scheduler/scheduler_medium_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/intelsdi-x/snap/core"

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/intelsdi-x/gomit"

--- a/scheduler/task.go
+++ b/scheduler/task.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
 	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/scheduler_event"

--- a/scheduler/task_test.go
+++ b/scheduler/task_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/intelsdi-x/snap/pkg/schedule"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/watcher.go
+++ b/scheduler/watcher.go
@@ -22,7 +22,7 @@ package scheduler
 import (
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core"
 )

--- a/scheduler/watcher_test.go
+++ b/scheduler/watcher_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/intelsdi-x/snap/core"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/work_manager_test.go
+++ b/scheduler/work_manager_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/core"
 	. "github.com/intelsdi-x/snap/pkg/promise"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/worker_test.go
+++ b/scheduler/worker_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap/pkg/chrono"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/workflow.go
+++ b/scheduler/workflow.go
@@ -25,8 +25,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/gomit"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/intelsdi-x/snap/core"
 	"github.com/intelsdi-x/snap/core/cdata"

--- a/scheduler/workflow_string_test.go
+++ b/scheduler/workflow_string_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/scheduler/workflow_test.go
+++ b/scheduler/workflow_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/intelsdi-x/snap/plugin/helper"
 	"github.com/intelsdi-x/snap/scheduler/wmap"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/snapteld.go
+++ b/snapteld.go
@@ -34,7 +34,7 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"github.com/vrischmann/jsonutil"
 	"golang.org/x/crypto/ssh/terminal"
@@ -291,7 +291,7 @@ func action(ctx *cli.Context) error {
 		log.Fatal("temp dir path provided must be a directory")
 	}
 
-	// Because even though github.com/Sirupsen/logrus states that
+	// Because even though github.com/sirupsen/logrus states that
 	// 'Logs the event in colors if stdout is a tty, otherwise without colors'
 	// Seems like this does not work
 	// Please note however that the default output format without colors is somewhat different (timestamps, ...)

--- a/third_party_licenses/README.md
+++ b/third_party_licenses/README.md
@@ -26,7 +26,7 @@ Below is the list of 3rd party components grouped by licenses.
 - [cron](https://github.com/robfig/cron)
 - [govalidator](https://github.com/asaskevich/govalidator)
 - [jsonutil](https://github.com/vrischmann/jsonutil)
-- [Logrus](https://github.com/Sirupsen/logrus)
+- [Logrus](https://github.com/sirupsen/logrus)
 - [Negroni](https://github.com/urfave/negroni) 
 - [YAML](https://github.com/ghodss/yaml) (not all files, for details please see [license](yaml_license.txt))
 


### PR DESCRIPTION
Fixes https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

Summary of changes:
- update import path of sirupsen logrus

Testing done:
- `make test-all`

Related to: https://github.com/intelsdi-x/snap-plugin-lib-go/pull/97

@intelsdi-x/snap-maintainers
