### PR TITLE
nominate Jialei and me as snap maintainer

### DIFF
--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -18,7 +18,9 @@ Below is the list of Snap Maintainers, they are largely responsible for approvin
 |:------------------|:-----------------|
 | Andrzej Kuriata   | @andrzej-k       |
 | Emily Gu          | @candysmurf      |
+| Fengfeng Tao      | @taotod          |
 | Izabella Raulin   | @IzabellaRaulin  |
+| Jialei Wang       | @WangJialei-A    |
 | Joel Cooklin      | @jcooklin        |
 | Katarzyna Kujawa  | @katarzyna-z     |
 | Kelly Lyon        | @kjlyon          |


### PR DESCRIPTION
Because my team start to maintain snap, I nominate myself and @WangJialei-A for snap maintainers. 
Jialei is the owner of the snap intel ssd plugin and gave lots of comments to other PRs. He is familiar with snap framework very much and will cover many framework effort in the future. 

@intelsdi-x/snap-maintainers
