### PR TITLE
Handle empty configuration without panic or fatal error.

### DIFF
--- a/examples/configs/snap-config-empty.yaml
+++ b/examples/configs/snap-config-empty.yaml
@@ -1,0 +1,12 @@
+---
+control:
+  # plugins section contains plugin config settings that will be applied for
+  # plugins across tasks.
+  plugins:
+    collector:
+      pcm:
+        # this should not cause a panic
+        all:
+      psutil:
+        all:
+          path: /usr/local/bin/psutil

--- a/examples/configs/snap-config-empty.yaml
+++ b/examples/configs/snap-config-empty.yaml
@@ -10,3 +10,8 @@ control:
       psutil:
         all:
           path: /usr/local/bin/psutil
+        # this should not cause a fatal error
+        versions:
+          1:
+      # this should also not cause a fatal error
+      myplugin:

--- a/snapteld_test.go
+++ b/snapteld_test.go
@@ -133,7 +133,7 @@ func TestSnapConfig(t *testing.T) {
 
 func TestSnapConfigEmpty(t *testing.T) {
 	Convey("Test Config", t, func() {
-		Convey("with empty all: plugin config section", func() {
+		Convey("with empty plugin config sections", func() {
 			cfg := getDefaultConfig()
 			readConfig(cfg, "./examples/configs/snap-config-empty.yaml")
 			jb, _ := json.Marshal(cfg)

--- a/snapteld_test.go
+++ b/snapteld_test.go
@@ -131,6 +131,18 @@ func TestSnapConfig(t *testing.T) {
 	})
 }
 
+func TestSnapConfigEmpty(t *testing.T) {
+	Convey("Test Config", t, func() {
+		Convey("with empty all: plugin config section", func() {
+			cfg := getDefaultConfig()
+			readConfig(cfg, "./examples/configs/snap-config-empty.yaml")
+			jb, _ := json.Marshal(cfg)
+			serrs := cfgfile.ValidateSchema(CONFIG_CONSTRAINTS, string(jb))
+			So(len(serrs), ShouldEqual, 0)
+		})
+	})
+}
+
 type mockFlags map[string]string
 
 func (m mockFlags) String(key string) string {


### PR DESCRIPTION
I noticed a panic if a configuration section contains an empty block after the `all:`, and fatal errors in other cases (shown in the test case). Ideally Snap will ignore empty configuration sections and process them as if no configuration was supplied. This PR logs a warning and moves on if empty configuration sections exist, rather than a crash or fatal error.

Here is the panic, taken from a recent build from the Intel Snap releases Github page:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x2533a2]

goroutine 1 [running]:
panic(0x7182e0, 0xc42000e100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/runtime/panic.go:500 +0x1a1
encoding/json.(*encodeState).marshal.func1(0xc420191238)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:272 +0x1b9
panic(0x7182e0, 0xc42000e100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/runtime/panic.go:458 +0x243
github.com/intelsdi-x/snap/core/cdata.(*ConfigDataNode).MarshalJSON(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/travis/gopath/src/github.com/intelsdi-x/snap/core/cdata/node.go:59 +0x22
encoding/json.marshalerEncoder(0xc42029c420, 0x798d80, 0xc420320940, 0x16, 0xc420320100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:431 +0xb1
encoding/json.(*mapEncoder).encode(0xc42022c2e8, 0xc42029c420, 0x711640, 0xc4202d5c20, 0x195, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:646 +0x542
encoding/json.(*mapEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x711640, 0xc4202d5c20, 0x195, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:662 +0x64
encoding/json.(*structEncoder).encode(0xc42030fce0, 0xc42029c420, 0x746b60, 0xc4202d5c20, 0x199, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:601 +0x253
encoding/json.(*structEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x746b60, 0xc4202d5c20, 0x199, 0xc4202d0100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:615 +0x64
encoding/json.(*ptrEncoder).encode(0xc42022c2f8, 0xc42029c420, 0x6af560, 0xc4202b9958, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:742 +0xe3
encoding/json.(*ptrEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x6af560, 0xc4202b9958, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:747 +0x64
encoding/json.(*structEncoder).encode(0xc42030fbc0, 0xc42029c420, 0x78ab80, 0xc4202b9950, 0x199, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:601 +0x253
encoding/json.(*structEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x78ab80, 0xc4202b9950, 0x199, 0xc4202b0100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:615 +0x64
encoding/json.(*ptrEncoder).encode(0xc42022c310, 0xc42029c420, 0x779980, 0xc4202ac100, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:742 +0xe3
encoding/json.(*ptrEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x779980, 0xc4202ac100, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:747 +0x64
encoding/json.(*structEncoder).encode(0xc42030faa0, 0xc42029c420, 0x7d3c00, 0xc4202ac0c0, 0x199, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:601 +0x253
encoding/json.(*structEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x7d3c00, 0xc4202ac0c0, 0x199, 0xc4202a0100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:615 +0x64
encoding/json.(*ptrEncoder).encode(0xc42022c3a0, 0xc42029c420, 0x779800, 0xc4202c0b18, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:742 +0xe3
encoding/json.(*ptrEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x779800, 0xc4202c0b18, 0x196, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:747 +0x64
encoding/json.(*structEncoder).encode(0xc42030fa70, 0xc42029c420, 0x7bbca0, 0xc4202c0af0, 0x199, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:601 +0x253
encoding/json.(*structEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x7bbca0, 0xc4202c0af0, 0x199, 0xc4202c0100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:615 +0x64
encoding/json.(*ptrEncoder).encode(0xc42022c478, 0xc42029c420, 0x707e20, 0xc4202c0af0, 0x16, 0x700100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:742 +0xe3
encoding/json.(*ptrEncoder).(encoding/json.encode)-fm(0xc42029c420, 0x707e20, 0xc4202c0af0, 0x16, 0xc4202c0100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:747 +0x64
encoding/json.(*encodeState).reflectValue(0xc42029c420, 0x707e20, 0xc4202c0af0, 0x16, 0x100)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:307 +0x82
encoding/json.(*encodeState).marshal(0xc42029c420, 0x707e20, 0xc4202c0af0, 0x6d0100, 0x0, 0x0)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:280 +0xb8
encoding/json.Marshal(0x707e20, 0xc4202c0af0, 0xc420245180, 0xc4203067e0, 0x65, 0xc420304120, 0x120)
	/home/travis/.gimme/versions/go1.7.3.linux.amd64/src/encoding/json/encode.go:145 +0x8f
main.action(0xc420245180, 0x0, 0x0)
	/home/travis/gopath/src/github.com/intelsdi-x/snap/snapteld.go:252 +0x166
github.com/intelsdi-x/snap/vendor/github.com/urfave/cli.HandleAction(0x6ef820, 0x86a788, 0xc420245180, 0xc420236960, 0x0)
	/home/travis/gopath/src/github.com/intelsdi-x/snap/vendor/github.com/urfave/cli/app.go:485 +0xd4
github.com/intelsdi-x/snap/vendor/github.com/urfave/cli.(*App).Run(0xc42005ab60, 0xc42000a330, 0x3, 0x3, 0x0, 0x0)
	/home/travis/gopath/src/github.com/intelsdi-x/snap/vendor/github.com/urfave/cli/app.go:259 +0x74f
main.main()
	/home/travis/gopath/src/github.com/intelsdi-x/snap/snapteld.go:231 +0x705
```