### PR TITLE
Upgrading GRPC to the most recent compatible version.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -47,7 +47,7 @@ import:
   - trace
   - http2
 - package: google.golang.org/grpc
-  version: ^v1.4
+  version: ~v1.5.2
 - package: gopkg.in/yaml.v2
   version: c1cd2254a6dd314c9d73c338c12688c9325d85c6
 - package: github.com/intelsdi-x/snap-plugin-lib-go


### PR DESCRIPTION
Snap's glide dependency for gRPC currently sets version to any above release `v.1.4`. However, release `v1.6` introduced breaking change in the API removing method `NewContext` currently used in [control/plugin/client/grpc.go:527](https://github.com/intelsdi-x/snap/blob/72385fa618d69de79da5b0caf3311d4c461e7a9f/control/plugin/client/grpc.go#L527). This PR sets version to the most recent compatible one.


Summary of changes:
- Upgrading gRPC.

Testing done:
- All existing tests should pass.

@intelsdi-x/snap-maintainers
